### PR TITLE
Fix Lie increment stream from int array

### DIFF
--- a/roughpy/src/args/strided_copy.cpp
+++ b/roughpy/src/args/strided_copy.cpp
@@ -1,3 +1,30 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 //
 // Created by sam on 09/08/23.
 //
@@ -9,7 +36,8 @@ void rpy::python::stride_copy(
         void* dst, const void* src, const py::ssize_t itemsize,
         const py::ssize_t ndim, const py::ssize_t* shape_in,
         const py::ssize_t* strides_in,
-        const py::ssize_t* strides_out
+        const py::ssize_t* strides_out,
+        bool transpose
 ) noexcept
 {
     RPY_DBG_ASSERT(ndim == 1 || ndim == 2);
@@ -23,12 +51,22 @@ void rpy::python::stride_copy(
                         sptr + i*strides_in[0],
                         itemsize);
         }
+    } else if (transpose) {
+         for (py::ssize_t i=0; i<shape_in[0]; ++i) {
+            for (py::ssize_t j=0; j<shape_in[1]; ++j) {
+                std::memcpy(
+                        dptr + j*strides_out[0] + i*strides_out[1],
+                        sptr + i*strides_in[0] + j*strides_in[1],
+                        itemsize
+                        );
+            }
+        }
     } else {
         for (py::ssize_t i=0; i<shape_in[0]; ++i) {
             for (py::ssize_t j=0; j<shape_in[1]; ++j) {
                 std::memcpy(
-                        dptr + i*strides_in[0] + j*strides_in[1],
                         dptr + i*strides_out[0] + j*strides_out[1],
+                        sptr + i*strides_in[0] + j*strides_in[1],
                         itemsize
                         );
             }

--- a/roughpy/src/args/strided_copy.h
+++ b/roughpy/src/args/strided_copy.h
@@ -1,3 +1,30 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 //
 // Created by sam on 09/08/23.
 //
@@ -18,7 +45,8 @@ void stride_copy(void* RPY_RESTRICT dst,
                  const py::ssize_t ndim,
                  const py::ssize_t* shape_in,
                  const py::ssize_t* strides_in,
-                 const py::ssize_t* strides_out
+                 const py::ssize_t* strides_out,
+                 bool transpose
                  ) noexcept;
 
 

--- a/roughpy/src/scalars/parse_key_scalar_stream.cpp
+++ b/roughpy/src/scalars/parse_key_scalar_stream.cpp
@@ -1,3 +1,30 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 //
 // Created by sam on 08/08/23.
 //
@@ -196,7 +223,8 @@ void buffer_to_stream(
 
         stride_copy(
                 tmp.data(), buf_info.ptr, buf_info.itemsize, buf_info.ndim,
-                buf_info.shape.data(), buf_info.strides.data(), tmp_strides
+                buf_info.shape.data(), buf_info.strides.data(), tmp_strides,
+                transposed
         );
 
         // Now that we're C-contiguous, convert_copy into the result.
@@ -248,7 +276,9 @@ void dl_to_stream(
         options.type = scalars::ScalarType::for_id(type_id);
     }
 
-    if (tensor.ndim == 0 || tensor.shape[0] == 0 || tensor.ndim > 1 && tensor.shape[1] == 0) {
+    if (tensor.ndim == 0
+        || tensor.shape[0] == 0
+        || (tensor.ndim > 1 && tensor.shape[1] == 0)) {
         return;
     }
 
@@ -298,17 +328,17 @@ void dl_to_stream(
         in_shape[0] = tensor.shape[0];
         if (tensor.ndim == 2) {
             if (transposed) {
-                out_strides[0] = tensor.shape[1]*itemsize;
                 out_shape[0] = tensor.shape[1];
                 out_shape[1] = tensor.shape[0];
             } else {
-                out_strides[0] = tensor.shape[0]*itemsize;
                 out_shape[0] = tensor.shape[0];
                 out_shape[1] = tensor.shape[1];
             }
+            out_strides[0] = out_shape[1]*itemsize;
+
             if (tensor.strides != nullptr) {
-                in_strides[0] = tensor.strides[0];
-                in_strides[1] = tensor.strides[1];
+                in_strides[0] = tensor.strides[0]*itemsize;
+                in_strides[1] = tensor.strides[1]*itemsize;
             } else {
                 in_strides[0] = tensor.shape[1]*itemsize;
                 in_strides[1] = itemsize;
@@ -319,7 +349,8 @@ void dl_to_stream(
 
         stride_copy(
                 tmp.data(), tensor.data, itemsize, tensor.ndim,
-                in_shape, in_strides, out_strides
+                in_shape, in_strides, out_strides,
+                transposed
         );
 
         // Now that we're C-contiguous, convert_copy into the result.

--- a/tests/streams/test_lie_increment_path.py
+++ b/tests/streams/test_lie_increment_path.py
@@ -4,7 +4,7 @@ import operator
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from roughpy import FreeTensor, Lie, RealInterval
 from roughpy import LieIncrementStream
@@ -151,7 +151,7 @@ def solution_signature(width, depth, tensor_size):
             for data in itertools.product(letters, repeat=d):
                 idx += 1
                 rv[idx] = factor * functools.reduce(operator.mul, data, 1) * (
-                            b - a) ** d
+                        b - a) ** d
         return rv
 
     return sig_func
@@ -247,3 +247,14 @@ def test_tick_path_sig_derivative(width, depth, tick_data, tick_indices, rng):
 
     # assert result == expected
     assert_array_almost_equal(result, expected)
+
+
+def test_lie_incr_stream_from_randints(rng):
+    array = rng.integers(0, 5, size=(4, 3))
+
+    stream = LieIncrementStream.from_increments(array, width=3, depth=2)
+
+    sig = stream.signature(RealInterval(0.0, 1.0), 2)
+
+    assert_array_equal(np.array(sig)[:5],
+                       np.hstack([[1.0], np.sum(array, axis=0)[:]]))

--- a/tests/streams/test_lie_increment_path.py
+++ b/tests/streams/test_lie_increment_path.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
+import roughpy
 from roughpy import FreeTensor, Lie, RealInterval
 from roughpy import LieIncrementStream
 
@@ -229,7 +230,7 @@ def test_tick_path_sig_derivative(width, depth, tick_data, tick_indices, rng):
     p = path(tick_data, indices=tick_indices, width=width, depth=depth)
 
     def lie():
-        return Lie(rng.uniform(0.0, 1.0, size=(width,)), width=width,
+        return Lie(rng.uniform(0.0, 5.0, size=(width,)), width=width,
                    depth=depth)
 
     perturbations = [
@@ -254,7 +255,39 @@ def test_lie_incr_stream_from_randints(rng):
 
     stream = LieIncrementStream.from_increments(array, width=3, depth=2)
 
-    sig = stream.signature(RealInterval(0.0, 1.0), 2)
+    sig = stream.signature(RealInterval(0.0, 5.0), 2)
 
-    assert_array_equal(np.array(sig)[:5],
+    assert_array_equal(np.array(sig)[:4],
+                       np.hstack([[1.0], np.sum(array, axis=0)[:]]))
+
+def test_lie_incr_stream_from_randints_no_deduction(rng):
+    array = rng.integers(0, 5, size=(4, 3))
+
+    stream = LieIncrementStream.from_increments(array, width=3, depth=2,
+                                                dtype=roughpy.DPReal)
+
+    sig = stream.signature(RealInterval(0.0, 5.0), 2)
+
+    assert_array_equal(np.array(sig)[:4],
+                       np.hstack([[1.0], np.sum(array, axis=0)[:]]))
+
+def test_lie_incr_stream_from_randints_transposed(rng):
+    array = rng.integers(0, 5, size=(4, 3))
+
+    stream = LieIncrementStream.from_increments(array.T, width=3, depth=2)
+
+    sig = stream.signature(RealInterval(0.0, 5.0), 2)
+
+    assert_array_equal(np.array(sig)[:4],
+                       np.hstack([[1.0], np.sum(array, axis=0)[:]]))
+
+def test_lie_incr_stream_from_randints_no_deduction_transposed(rng):
+    array = rng.integers(0, 5, size=(4, 3))
+
+    stream = LieIncrementStream.from_increments(array.T, width=3, depth=2,
+                                                dtype=roughpy.DPReal)
+
+    sig = stream.signature(RealInterval(0.0, 5.0), 2)
+
+    assert_array_equal(np.array(sig)[:4],
                        np.hstack([[1.0], np.sum(array, axis=0)[:]]))


### PR DESCRIPTION
Fix a bug in the creation of a `LieIncrementStream` from an array of (NumPy) integer arrays. Closes #30 .