### PR TITLE
Disable blas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,9 @@ option(ROUGHPY_BUILD_TESTS "Build C++ tests for RoughPy" ON)
 option(ROUGHPY_BUILD_PYMODULE_INPLACE "Buildg the pymodule in the project roughpy directory" OFF)
 option(ROUGHPY_LINK_NUMPY "Link with Numpy library for array handling" ON)
 option(ROUGHPY_GENERATE_DEVICE_CODE "Generate code for objects on devices" OFF)
+option(ROUGHPY_DISABLE_BLAS "Disable linking to blas/lapack" OFF)
 cmake_dependent_option(ROUGHPY_PREFER_ACCELERATE
-        "Prefer Accelerate framework on MacOS always" OFF APPLE OFF)
+    "Prefer Accelerate framework on MacOS always" OFF APPLE OFF)
 
 # If testing is enabled, find GTest to make sure the tests can be
 # successfully built.
@@ -49,44 +50,44 @@ if (SKBUILD)
 
     # This is all the variables set by GNUInstallDirs, minus LIBDIR and BINDIR
     set(_ignore_dirs
-            SBINDIR
-            LIBEXECDIR
-            SYSCONFIGDIR
-            SHAREDSTATEDIR
-            LOCALSTATEDIR
-            RUNSTATEDIR
-            INCLUDEDIR
-            OLDINCLUDEDIR
-            DATAROOTDIR
-            DATADIR
-            INFODIR
-            LOCALEDIR
-            MANDIR
-            DOCDIR
-            )
+        SBINDIR
+        LIBEXECDIR
+        SYSCONFIGDIR
+        SHAREDSTATEDIR
+        LOCALSTATEDIR
+        RUNSTATEDIR
+        INCLUDEDIR
+        OLDINCLUDEDIR
+        DATAROOTDIR
+        DATADIR
+        INFODIR
+        LOCALEDIR
+        MANDIR
+        DOCDIR
+    )
 
     if (WIN32)
         # On Windows, DLLs are put in BINDIR
         list(APPEND _ignore_dirs LIBDIR)
         set(CMAKE_INSTALL_BINDIR ${SKBUILD_PLATLIB_DIR}/roughpy CACHE STRING
-                "Overwritten install for BINDIR")
-    else()
+            "Overwritten install for BINDIR")
+    else ()
         # On not Windows, Shared Objects go in LIBDIR
         list(APPEND _ignore_dirs BINDIR)
         set(CMAKE_INSTALL_LIBDIR ${SKBUILD_PLATLIB_DIR}/roughpy CACHE STRING
-                "Overwritten install for LIBDIR")
+            "Overwritten install for LIBDIR")
 
         list(APPEND _ignore_dirs BINDIR)
-    endif()
+    endif ()
 
-    foreach(_dir ${_ignore_dirs})
+    foreach (_dir ${_ignore_dirs})
         set(CMAKE_INSTALL_${_dir} ${SKBUILD_NULL_DIR} CACHE STRING
-                "Overwritten install for ${_dir}")
-    endforeach()
+            "Overwritten install for ${_dir}")
+    endforeach ()
 
-else()
+else ()
     include(GNUInstallDirs)
-endif()
+endif ()
 
 
 # Load the helper functions
@@ -136,15 +137,14 @@ endif ()
 find_package(Python 3.8 REQUIRED COMPONENTS ${PYTHON_COMPONENTS_NEEDED})
 
 
-
 if (NOT DEFINED pybind11_ROOT)
     execute_process(COMMAND
-            "${Python_EXECUTABLE}" "-m" "pybind11" "--cmakedir"
-            COMMAND_ECHO STDOUT
-            RESULT_VARIABLE _python_pybind11_dir_found
-            OUTPUT_VARIABLE _python_pybind11_dir
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            )
+        "${Python_EXECUTABLE}" "-m" "pybind11" "--cmakedir"
+        COMMAND_ECHO STDOUT
+        RESULT_VARIABLE _python_pybind11_dir_found
+        OUTPUT_VARIABLE _python_pybind11_dir
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
     if (_python_pybind11_dir_found EQUAL 0 AND EXISTS "${_python_pybind11_dir}")
         message(STATUS "Adding Pybind11 cmake dir ${_python_pybind11_dir}")
         set(pybind11_ROOT "${_python_pybind11_dir}" CACHE INTERNAL "")
@@ -164,14 +164,13 @@ check_include_file_cxx(filesystem RPY_HAS_STD_FILESYSTEM)
 check_include_file_cxx(optional RPY_HAS_STD_OPTIONAL)
 
 
-
 set(Boost_NO_WARN_NEW_VERSIONS ON)
 set(RYP_BOOST_VERSION 1.81)
 find_package(Boost ${RPY_BOOST_VERSION} REQUIRED COMPONENTS url system)
 
 if (NOT RPY_HAS_STD_FILESYSTEM)
     find_package(Boost ${RPY_BOOST_VERSION} REQUIRED COMPONENTS filesystem)
-endif()
+endif ()
 
 
 find_package(Eigen3 CONFIG REQUIRED)
@@ -181,82 +180,84 @@ find_package(SndFile CONFIG REQUIRED)
 find_package(tomlplusplus CONFIG REQUIRED)
 
 message(STATUS "Target architecture ${RPY_ARCH}")
-if (RPY_ARCH MATCHES "[xX](86(_64)?|64)|[aA][mM][dD]64" AND NOT
+if (NOT ROUGHPY_DISABLE_BLAS)
+    if (RPY_ARCH MATCHES "[xX](86(_64)?|64)|[aA][mM][dD]64" AND NOT
         ROUGHPY_PREFER_ACCELERATE)
 
-    # If we're looking for MKL then we might have installed it via pip.
-    # To make sure we can find this, let's use Python's importlib metadata to
-    # locate the directory containing MKLConfig.cmake and add the relevant
-    # directory to the prefix path.
-    execute_process(COMMAND ${Python_EXECUTABLE}
+        # If we're looking for MKL then we might have installed it via pip.
+        # To make sure we can find this, let's use Python's importlib metadata to
+        # locate the directory containing MKLConfig.cmake and add the relevant
+        # directory to the prefix path.
+        execute_process(COMMAND ${Python_EXECUTABLE}
             "${CMAKE_CURRENT_LIST_DIR}/tools/python-get-binary-obj-path.py"
             "--directory" "mkl-devel" "cmake/mkl/MKLConfig.cmake"
             RESULT_VARIABLE _python_mkl_dir_found
             OUTPUT_VARIABLE _python_mkl_dir
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET
-            )
-    if (NOT _python_mkl_dir_found AND EXISTS "${_python_mkl_dir}")
-        cmake_path(GET _python_mkl_dir PARENT_PATH _python_mkl_dir)
-        message(STATUS "Adding MKL dir from pip-installed mkl: ${_python_mkl_dir}")
-        list(APPEND CMAKE_PREFIX_PATH "${_python_mkl_dir}")
-        if (NOT MKL_ROOT)
-            set(MKL_ROOT "${_python_mkl_dir}")
+        )
+        if (NOT _python_mkl_dir_found AND EXISTS "${_python_mkl_dir}")
+            cmake_path(GET _python_mkl_dir PARENT_PATH _python_mkl_dir)
+            message(STATUS "Adding MKL dir from pip-installed mkl: ${_python_mkl_dir}")
+            list(APPEND CMAKE_PREFIX_PATH "${_python_mkl_dir}")
+            if (NOT MKL_ROOT)
+                set(MKL_ROOT "${_python_mkl_dir}")
+            endif ()
+            set(MKL_DIR "${_python_mkl_dir}")
         endif ()
-        set(MKL_DIR "${_python_mkl_dir}")
-    endif ()
 
-    # Set the variables that determine the actual MKL library that we need to
-    # link. At the moment, we force 32-bit addressing on both 32- and 64-bit
-    # platforms, statically linked, and using the Intel OMP library (except on
-    # Windows).
-    if (RPY_ARCH STREQUAL "x86")
-        set(MKL_ARCH ia32)
-    else ()
-        set(MKL_ARCH intel64)
-        set(MKL_INTERFACE lp64)
-    endif ()
-
-    set(MKL_LINK static)
-    if (WIN32)
-        # Currently there is no way to get this working with threading
-        # on Windows using this distribution of MKL
-        set(MKL_THREADING sequential)
-    else ()
-        set(MKL_THREADING intel_thread)
-    endif ()
-
-    find_package(MKL CONFIG)
-    if (TARGET MKL::MKL)
-        set(RPY_USE_MKL ON CACHE INTERNAL "BLAS/LAPACK provided by mkl")
-        add_library(BLAS::BLAS ALIAS MKL::MKL)
-        add_library(LAPACK::LAPACK ALIAS MKL::MKL)
-
-        if (DEFINED MKL_OMP_LIB AND MKL_OMP_LIB)
-#            if (APPLE)
-#                foreach (LANG IN ITEMS C CXX)
-#                    set(OpenMP_${LANG}_LIB_NAMES "${MKL_OMP_LIB}" CACHE STRING "libomp location for OpenMP")
-#                endforeach ()
-#            endif ()
-#            set(OpenMP_${MKL_OMP_LIB}_LIBRARY "${MKL_THREAD_LIB}")
+        # Set the variables that determine the actual MKL library that we need to
+        # link. At the moment, we force 32-bit addressing on both 32- and 64-bit
+        # platforms, statically linked, and using the Intel OMP library (except on
+        # Windows).
+        if (RPY_ARCH STREQUAL "x86")
+            set(MKL_ARCH ia32)
+        else ()
+            set(MKL_ARCH intel64)
+            set(MKL_INTERFACE lp64)
         endif ()
-    else ()
-        set(RPY_USE_MKL OFF CACHE INTERNAL "BLAS/LAPACK not provided by mkl")
+
+        set(MKL_LINK static)
+        if (WIN32)
+            # Currently there is no way to get this working with threading
+            # on Windows using this distribution of MKL
+            set(MKL_THREADING sequential)
+        else ()
+            set(MKL_THREADING intel_thread)
+        endif ()
+
+        find_package(MKL CONFIG)
+        if (TARGET MKL::MKL)
+            set(RPY_USE_MKL ON CACHE INTERNAL "BLAS/LAPACK provided by mkl")
+            add_library(BLAS::BLAS ALIAS MKL::MKL)
+            add_library(LAPACK::LAPACK ALIAS MKL::MKL)
+
+            if (DEFINED MKL_OMP_LIB AND MKL_OMP_LIB)
+                #            if (APPLE)
+                #                foreach (LANG IN ITEMS C CXX)
+                #                    set(OpenMP_${LANG}_LIB_NAMES "${MKL_OMP_LIB}" CACHE STRING "libomp location for OpenMP")
+                #                endforeach ()
+                #            endif ()
+                #            set(OpenMP_${MKL_OMP_LIB}_LIBRARY "${MKL_THREAD_LIB}")
+            endif ()
+        else ()
+            set(RPY_USE_MKL OFF CACHE INTERNAL "BLAS/LAPACK not provided by mkl")
+            set(BLA_SIZEOF_INTEGER 4)
+            set(BLA_STATIC ON)
+        endif ()
+    elseif (APPLE)
+        set(RPY_USE_ACCELERATE ON CACHE INTERNAL "BLAS/LAPACK provided by Accelerate")
+        set(BLA_VENDOR Apple)
         set(BLA_SIZEOF_INTEGER 4)
         set(BLA_STATIC ON)
     endif ()
-elseif (APPLE)
-    set(RPY_USE_ACCELERATE ON CACHE INTERNAL "BLAS/LAPACK provided by Accelerate")
-    set(BLA_VENDOR Apple)
-    set(BLA_SIZEOF_INTEGER 4)
-    set(BLA_STATIC ON)
-endif ()
 
-if (NOT TARGET BLAS::BLAS)
-    find_package(BLAS REQUIRED)
-endif ()
-if (NOT TARGET LAPACK::LAPACK)
-    find_package(LAPACK REQUIRED)
+    if (NOT TARGET BLAS::BLAS)
+        find_package(BLAS REQUIRED)
+    endif ()
+    if (NOT TARGET LAPACK::LAPACK)
+        find_package(LAPACK REQUIRED)
+    endif ()
 endif ()
 
 #if (APPLE AND NOT DEFINED MKL_OMP_LIB)
@@ -320,27 +321,27 @@ endif ()
 #set(CMAKE_INSTALL_BINDIR "roughpy" CACHE STRING "install binary dir")
 
 install(TARGETS
-        RoughPy_PyModule
-        EXPORT RoughPy_EXPORTS
-        RUNTIME DESTINATION roughpy
-        LIBRARY
-        DESTINATION roughpy
-        NAMELINK_SKIP
-        ARCHIVE DESTINATION ${SKBUILD_NULL_DIR}
-        COMPONENT Development
-        EXCLUDE_FROM_ALL
-        INCLUDES DESTINATION ${SKBUILD_NULL_DIR}
-        COMPONENT Development
-        EXCLUDE_FROM_ALL
-        )
+    RoughPy_PyModule
+    EXPORT RoughPy_EXPORTS
+    RUNTIME DESTINATION roughpy
+    LIBRARY
+    DESTINATION roughpy
+    NAMELINK_SKIP
+    ARCHIVE DESTINATION ${SKBUILD_NULL_DIR}
+    COMPONENT Development
+    EXCLUDE_FROM_ALL
+    INCLUDES DESTINATION ${SKBUILD_NULL_DIR}
+    COMPONENT Development
+    EXCLUDE_FROM_ALL
+)
 
 install(FILES roughpy/py.typed DESTINATION roughpy)
 install(DIRECTORY roughpy
-        DESTINATION .
-        FILES_MATCHING
-        PATTERN "*.py"
-        PATTERN "*.pyi"
-        PATTERN "src/*" EXCLUDE)
+    DESTINATION .
+    FILES_MATCHING
+    PATTERN "*.py"
+    PATTERN "*.pyi"
+    PATTERN "src/*" EXCLUDE)
 
 set(_runtime_deps "")
 foreach (_rpy_lib IN LISTS ROUGHPY_LIBS)

--- a/roughpy/CMakeLists.txt
+++ b/roughpy/CMakeLists.txt
@@ -31,9 +31,11 @@ if (ROUGHPY_BUILD_PYMODULE_INPLACE)
 endif ()
 
 
+set_target_properties(RoughPy_PyModule PROPERTIES
+    INSTALL_RPATH $ORIGIN)
 if (LINUX)
     set_target_properties(RoughPy_PyModule PROPERTIES
-            INSTALL_RPATH "$ORIGIN")
+            INSTALL_RPATH $ORIGIN)
 elseif (APPLE)
     set_target_properties(RoughPy_PyModule PROPERTIES
             INSTALL_RPATH "@loader_path;@loader_path/../../..")

--- a/scalars/CMakeLists.txt
+++ b/scalars/CMakeLists.txt
@@ -96,8 +96,8 @@ add_roughpy_component(Scalars
             Boost::boost
             Eigen3::Eigen
             Libalgebra_lite::Libalgebra_lite
-            BLAS::BLAS
-            LAPACK::LAPACK
+            BLAS::BLAS IF NOT ROUGHPY_DISABLE_BLAS
+            LAPACK::LAPACK IF NOT ROUGHPY_DISABLE_BLAS
         PRIVATE
             PCGRandom::pcg_random
     CONFIGURE

--- a/scalars/scalar_blas_defs.h.in
+++ b/scalars/scalar_blas_defs.h.in
@@ -1,7 +1,9 @@
 #ifndef ROUGHPY_SCALARS_SCALAR_BLAS_DEFS
 #define ROUGHPY_SCALARS_SCALAR_BLAS_DEFS
 
+#cmakedefine ROUGHPY_DISABLE_BLAS
 
+#ifndef ROUGHPY_DISABLE_BLAS
 #cmakedefine RPY_USE_MKL
 #cmakedefine RPY_USE_ACCELERATE
 #cmakedefine RPY_LAPACK_ILP64
@@ -88,5 +90,5 @@ using integer = lapack_int;
 }
 }
 
-
+#endif // ROUGHPY_DISABLE_BLAS
 #endif // ROUGHPY_SCALARS_SCALAR_BLAS_DEFS

--- a/scalars/src/linear_algebra/blas.h
+++ b/scalars/src/linear_algebra/blas.h
@@ -34,6 +34,7 @@
 
 #include "scalar_blas_defs.h"
 
+#ifndef ROUGHPY_DISABLE_BLAS
 #define RPY_BLAS_FUNC_(NAME) RPY_JOIN(cblas_, NAME)
 #define RPY_BLAS_FUNC(NAME) RPY_BLAS_FUNC_(RPY_JOIN(RPY_BLA_SPRX, NAME))
 
@@ -133,5 +134,5 @@ struct blas_funcs {
 }// namespace blas
 }// namespace scalars
 }// namespace rpy
-
+#endif
 #endif// ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_BLAS_H_

--- a/scalars/src/linear_algebra/blas_complex_double.cpp
+++ b/scalars/src/linear_algebra/blas_complex_double.cpp
@@ -30,6 +30,8 @@
 
 #include "blas.h"
 
+
+#ifndef ROUGHPY_DISABLE_BLAS
 #define RPY_BLA_SPRX z
 #define RPY_BLA_RPRX d
 
@@ -143,4 +145,5 @@ void blas_funcs<double_complex, double>::gemm(
 }// namespace scalars
 }// namespace rpy
 
+#endif // ROUGHPY_DISABLE_BLAS
 #endif// ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_BLAS_COMPLEX_DOUBLE_CPP_

--- a/scalars/src/linear_algebra/blas_complex_float.cpp
+++ b/scalars/src/linear_algebra/blas_complex_float.cpp
@@ -33,6 +33,9 @@
 #define ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_BLAS_COMPLEX_FLOAT_CPP_
 
 #include "blas.h"
+
+#ifndef ROUGHPY_DISABLE_BLAS
+
 #define RPY_BLA_SPRX c
 #define RPY_BLA_RPRX s
 
@@ -147,4 +150,5 @@ void blas_funcs<float_complex, float>::gemm(
 }// namespace scalars
 }// namespace rpy
 
+#endif
 #endif// ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_BLAS_COMPLEX_FLOAT_CPP_

--- a/scalars/src/linear_algebra/blas_double.cpp
+++ b/scalars/src/linear_algebra/blas_double.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 the RoughPy Developers. All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
 //
 // 1. Redistributions of source code must retain the above copyright notice,
 // this list of conditions and the following disclaimer.
@@ -18,12 +18,13 @@
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 // ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 //
 // Created by user on 02/08/23.
@@ -33,14 +34,18 @@
 #define ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_BLAS_DOUBLE_CPP_
 
 #include "blas.h"
-#define RPY_BLA_SPRX d
 
-static constexpr double convert_scalar(const double& arg) noexcept {
-     return arg;
+#ifndef ROUGHPY_DISABLE_BLAS
+#  define RPY_BLA_SPRX d
+
+static constexpr double convert_scalar(const double& arg) noexcept
+{
+    return arg;
 }
 
-namespace rpy { namespace scalars { namespace blas {
-
+namespace rpy {
+namespace scalars {
+namespace blas {
 
 template <>
 void blas_funcs<double, double>::axpy(
@@ -66,7 +71,8 @@ typename blas_funcs<double, double>::scalar blas_funcs<double, double>::dot(
     );
 }
 template <>
-typename blas_funcs<double, double>::abs_scalar blas_funcs<double, double>::asum(
+typename blas_funcs<double, double>::abs_scalar
+blas_funcs<double, double>::asum(
         const integer n, const scalar* x, const integer incx
 ) noexcept
 {
@@ -75,7 +81,8 @@ typename blas_funcs<double, double>::abs_scalar blas_funcs<double, double>::asum
     );
 }
 template <>
-typename blas_funcs<double, double>::abs_scalar blas_funcs<double, double>::nrm2(
+typename blas_funcs<double, double>::abs_scalar
+blas_funcs<double, double>::nrm2(
         const integer n, const scalar* x, const integer incx
 ) noexcept
 {
@@ -126,8 +133,9 @@ void blas_funcs<double, double>::gemm(
     );
 }
 
+}// namespace blas
+}// namespace scalars
+}// namespace rpy
 
-}}}
-
-
+#endif
 #endif// ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_BLAS_DOUBLE_CPP_

--- a/scalars/src/linear_algebra/blas_float.cpp
+++ b/scalars/src/linear_algebra/blas_float.cpp
@@ -34,6 +34,8 @@
 
 #include "blas.h"
 
+#ifndef ROUGHPY_DISABLE_BLAS
+
 #define RPY_BLA_SPRX s
 
 
@@ -136,4 +138,5 @@ void blas_funcs<float, float>::gemm(
 }// namespace rpy
 
 #undef RPY_BLA_SPRX
+#endif
 #endif// ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_BLAS_FLOAT_CPP_

--- a/scalars/src/linear_algebra/lapack.h
+++ b/scalars/src/linear_algebra/lapack.h
@@ -35,6 +35,7 @@
 #include "scalar_blas_defs.h"
 #include "blas.h"
 
+#ifndef ROUGHPY_DISABLE_BLAS
 #define RPY_LPK_FUNC_(NAME) RPY_JOIN(LAPACKE_, NAME)
 #define RPY_LPK_FUNC(NAME) \
     RPY_LPK_FUNC_(RPY_JOIN(RPY_LPK_SPRX, RPY_JOIN(NAME, _work)))
@@ -247,5 +248,5 @@ struct lapack_funcs : lapack_func_workspace<S, R> {
 }// namespace lapack
 }// namespace scalars
 }// namespace rpy
-
+#endif
 #endif// ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_LAPACK_H_

--- a/scalars/src/linear_algebra/lapack_complex_double.cpp
+++ b/scalars/src/linear_algebra/lapack_complex_double.cpp
@@ -34,6 +34,9 @@
 
 #include "lapack.h"
 
+
+#ifndef ROUGHPY_DISABLE_BLAS
+
 #define RPY_LPK_SPRX z
 
 
@@ -339,4 +342,5 @@ void lapack_funcs<double_complex, double>::gelsd(
 }// namespace scalars
 }// namespace rpy
 
+#endif
 #endif// ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_LAPACK_COMPLEX_DOUBLE_CPP_

--- a/scalars/src/linear_algebra/lapack_complex_float.cpp
+++ b/scalars/src/linear_algebra/lapack_complex_float.cpp
@@ -34,6 +34,8 @@
 
 #include "lapack.h"
 
+#ifndef ROUGHPY_DISABLE_BLAS
+
 #define RPY_LPK_SPRX c
 
 static constexpr rpy::blas::complex32
@@ -337,4 +339,5 @@ void lapack_funcs<scalars::float_complex, float>::gelsd(
 }// namespace scalars
 }// namespace rpy
 
+#endif
 #endif// ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_LAPACK_COMPLEX_FLOAT_CPP_

--- a/scalars/src/linear_algebra/lapack_double.cpp
+++ b/scalars/src/linear_algebra/lapack_double.cpp
@@ -29,6 +29,8 @@
 #define ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_LAPACK_DOUBLE_CPP_
 
 #include "lapack.h"
+
+#ifndef ROUGHPY_DISABLE_BLAS
 #define RPY_LPK_SPRX d
 
 static constexpr double convert_scalar(const double& arg) noexcept
@@ -333,4 +335,5 @@ void lapack_funcs<double, double>::gelsd(
 }// namespace scalars
 }// namespace rpy
 
+#endif
 #endif// ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_LAPACK_DOUBLE_CPP_

--- a/scalars/src/linear_algebra/lapack_float.cpp
+++ b/scalars/src/linear_algebra/lapack_float.cpp
@@ -34,6 +34,7 @@
 
 #include "lapack.h"
 
+#ifndef ROUGHPY_DISABLE_BLAS
 #define RPY_LPK_SPRX s
 
 static constexpr float convert_scalar(const float& arg) noexcept { return arg; }
@@ -461,5 +462,5 @@ void lapack_funcs<float, float>::gelsd(
 }}}
 
 
-
+#endif
 #endif// ROUGHPY_SCALARS_SRC_LINEAR_ALGEBRA_LAPACK_FLOAT_CPP_

--- a/scalars/src/scalar_blas_impl.h
+++ b/scalars/src/scalar_blas_impl.h
@@ -42,6 +42,7 @@
 
 #include "scalar_blas_defs.h"
 
+#ifndef ROUGHPY_DISABLE_BLAS
 namespace rpy {
 namespace scalars {
 
@@ -232,4 +233,5 @@ SingularValueDecomposition ScalarBlasImpl<S>::svd(const ScalarMatrix& matrix)
 }// namespace scalars
 }// namespace rpy
 
+#endif
 #endif// ROUGHPY_SCALAR_BLAS_IMPL_H

--- a/scalars/src/scalar_implementations/double/double_lin_alg.cpp
+++ b/scalars/src/scalar_implementations/double/double_lin_alg.cpp
@@ -30,6 +30,8 @@
 //
 
 #include "double_lin_alg.h"
+#ifndef ROUGHPY_DISABLE_BLAS
+
 
 namespace rpy {
 namespace scalars {
@@ -39,3 +41,4 @@ template class StandardLinearAlgebra<double, double>;
 
 }// namespace scalars
 }// namespace rpy
+#endif

--- a/scalars/src/scalar_implementations/double/double_lin_alg.h
+++ b/scalars/src/scalar_implementations/double/double_lin_alg.h
@@ -33,6 +33,8 @@
 #define ROUGHPY_SCALARS_SRC_DOUBLE_LIN_ALG_H_
 
 #include "../../standard_linalg.h"
+#ifndef ROUGHPY_DISABLE_BLAS
+
 
 namespace rpy {
 namespace scalars {
@@ -42,4 +44,5 @@ extern template class StandardLinearAlgebra<double, double>;
 }// namespace scalars
 }// namespace rpy
 
+#endif
 #endif// ROUGHPY_SCALARS_SRC_DOUBLE_LIN_ALG_H_

--- a/scalars/src/scalar_implementations/double/double_type.cpp
+++ b/scalars/src/scalar_implementations/double/double_type.cpp
@@ -36,7 +36,9 @@ using namespace rpy::scalars;
 
 DoubleType::DoubleType() : StandardScalarType<double>("f64", "DPReal") {}
 
+#ifndef ROUGHPY_DISABLE_BLAS
 std::unique_ptr<BlasInterface> DoubleType::get_blas() const
 {
     return std::make_unique<StandardLinearAlgebra<double, double>>(this);
 }
+#endif

--- a/scalars/src/scalar_implementations/double/double_type.h
+++ b/scalars/src/scalar_implementations/double/double_type.h
@@ -33,6 +33,7 @@
 #define ROUGHPY_SCALARS_SRC_DOUBLE_TYPE_H
 
 #include "../../standard_scalar_type.h"
+#include "scalar_blas_defs.h"
 
 namespace rpy {
 namespace scalars {
@@ -42,7 +43,9 @@ class DoubleType : public StandardScalarType<double>
 public:
     DoubleType();
 
+#ifndef ROUGHPY_DISABLE_BLAS
     std::unique_ptr<BlasInterface> get_blas() const override;
+#endif
 };
 
 }// namespace scalars

--- a/scalars/src/scalar_implementations/float/float_blas.cpp
+++ b/scalars/src/scalar_implementations/float/float_blas.cpp
@@ -30,7 +30,7 @@
 //
 
 #include "float_blas.h"
-
+#ifndef ROUGHPY_DISABLE_BLAS
 
 using namespace rpy;
 using namespace rpy::scalars;
@@ -604,3 +604,5 @@ template class StandardLinearAlgebra<float, float>;
 //
 //    check_and_report_errors(info);
 //}
+
+#endif

--- a/scalars/src/scalar_implementations/float/float_blas.h
+++ b/scalars/src/scalar_implementations/float/float_blas.h
@@ -34,12 +34,15 @@
 
 #include "../../standard_linalg.h"
 
+#ifndef ROUGHPY_DISABLE_BLAS
 namespace rpy {
 namespace scalars {
+
 
 extern template class StandardLinearAlgebra<float, float>;
 
 }// namespace scalars
 }// namespace rpy
 
+#endif
 #endif// ROUGHPY_SCALARS_SRC_FLOAT_BLAS_H

--- a/scalars/src/scalar_implementations/float/float_type.cpp
+++ b/scalars/src/scalar_implementations/float/float_type.cpp
@@ -35,7 +35,10 @@
 using namespace rpy::scalars;
 
 FloatType::FloatType() : StandardScalarType<float>("f32", "SPReal") {}
+
+#ifndef ROUGHPY_DISABLE_BLAS
 std::unique_ptr<BlasInterface> FloatType::get_blas() const
 {
     return std::make_unique<StandardLinearAlgebra<float, float>>(this);
 }
+#endif

--- a/scalars/src/scalar_implementations/float/float_type.h
+++ b/scalars/src/scalar_implementations/float/float_type.h
@@ -33,6 +33,7 @@
 #define ROUGHPY_SCALARS_SRC_FLOAT_TYPE_H
 
 #include "../../standard_scalar_type.h"
+#include "scalar_blas_defs.h"
 
 namespace rpy {
 namespace scalars {
@@ -42,7 +43,9 @@ class FloatType : public StandardScalarType<float>
 public:
     FloatType();
 
+#ifndef ROUGHPY_DISABLE_BLAS
     std::unique_ptr<BlasInterface> get_blas() const override;
+#endif
 };
 
 }// namespace scalars

--- a/scalars/src/standard_linalg.h
+++ b/scalars/src/standard_linalg.h
@@ -25,6 +25,9 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#ifndef ROUGHPY_SCALARS_STANDARD_LINALG_H_
+#define ROUGHPY_SCALARS_STANDARD_LINALG_H_
+
 #include <roughpy/scalars/scalars_fwd.h>
 
 #include <roughpy/scalars/owned_scalar_array.h>
@@ -37,7 +40,7 @@
 #include "linear_algebra/blas.h"
 #include "linear_algebra/lapack.h"
 
-
+#ifndef ROUGHPY_DISABLE_BLAS
 
 namespace rpy {
 namespace scalars {
@@ -631,3 +634,6 @@ StandardLinearAlgebra<S, R>::gelsd(ScalarMatrix& A, ScalarMatrix& b)
 }// namespace scalars
 
 }// namespace rpy
+
+#endif
+#endif // ROUGHPY_SCALARS_STANDARD_LINALG_H_

--- a/scalars/src/test_float_blas.cpp
+++ b/scalars/src/test_float_blas.cpp
@@ -35,6 +35,7 @@
 
 #include <vector>
 
+#ifndef ROUGHPY_DISABLE_BLAS
 using namespace rpy;
 using namespace rpy::scalars;
 
@@ -80,3 +81,8 @@ TEST_F(FloatBlasTests, TestRowMajorByRowMajorFull)
     EXPECT_EQ(ptr[2], -8.0F);
     EXPECT_EQ(ptr[3], 13.0F);
 }
+
+
+
+
+#endif


### PR DESCRIPTION
Added cmake option to disable generation of BLAS bindings,  and provided a temporary workaround to a bug in vcpkg that causes some cmake variables to be unset.