### PR TITLE
Fix lie key iterator

### DIFF
--- a/algebra/include/roughpy/algebra/basis.h
+++ b/algebra/include/roughpy/algebra/basis.h
@@ -126,6 +126,8 @@ public:
     virtual deg_t size(deg_t degree) const noexcept = 0;
     RPY_NO_DISCARD
     virtual let_t first_letter(const key_type& key) const noexcept = 0;
+    RPY_NO_DISCARD
+    virtual let_t to_letter(const key_type& key) const noexcept = 0;
 
     RPY_NO_DISCARD
     virtual dimn_t start_of_degree(deg_t degree) const noexcept = 0;
@@ -285,6 +287,9 @@ public:
     let_t first_letter(const key_type& key) const noexcept
     {
         return instance().first_letter(key);
+    }
+    RPY_NO_DISCARD let_t to_letter(const key_type& key) const noexcept {
+        return instance().to_letter(key);
     }
     RPY_NO_DISCARD
     dimn_t start_of_degree(deg_t degree) const noexcept

--- a/algebra/include/roughpy/algebra/basis_impl.h
+++ b/algebra/include/roughpy/algebra/basis_impl.h
@@ -97,6 +97,7 @@ public:
     deg_t degree(const key_type& key) const noexcept override;
     deg_t size(deg_t degree) const noexcept override;
     let_t first_letter(const key_type& key) const noexcept override;
+    let_t to_letter(const key_type& key) const noexcept override;
     dimn_t start_of_degree(deg_t degree) const noexcept override;
     pair<optional<key_type>, optional<key_type>> parents(const key_type& key
     ) const override;
@@ -161,6 +162,11 @@ let_t WordLikeBasisImplementationMixin<T, Derived, Base>::first_letter(
 ) const noexcept
 {
     return basis_traits::first_letter(m_impl, key);
+}
+template <typename T, typename Derived, typename Base>
+let_t WordLikeBasisImplementationMixin<T, Derived, Base>::to_letter(const key_type& key) const noexcept
+{
+    return basis_traits::to_letter(m_impl, key);
 }
 template <typename T, typename Derived, typename Base>
 dimn_t

--- a/algebra/src/libalgebra_lite_internal/lie_basis_info.h
+++ b/algebra/src/libalgebra_lite_internal/lie_basis_info.h
@@ -176,6 +176,10 @@ struct BasisInfo<LieBasis, lal::hall_basis> {
         return basis->first_letter(convert_to_impl(basis, key));
     }
 
+    static let_t to_letter(storage_t basis, const our_key_type& key) {
+        return basis->to_letter(convert_to_impl(basis, key));
+    }
+
     /// Get the key type that represents letter
     static our_key_type key_of_letter(storage_t basis, let_t letter)
     {

--- a/algebra/src/libalgebra_lite_internal/tensor_basis_info.h
+++ b/algebra/src/libalgebra_lite_internal/tensor_basis_info.h
@@ -171,6 +171,10 @@ struct BasisInfo<TensorBasis, lal::tensor_basis> {
         return basis->first_letter(convert_to_impl(basis, key));
     }
 
+    static let_t to_letter(storage_t basis, const our_key_type& key) {
+        return basis->to_letter(convert_to_impl(basis, key));
+    }
+
     /// Get the key type that represents letter
     static our_key_type key_of_letter(storage_t basis, let_t letter)
     {

--- a/roughpy/src/algebra/lie_key.cpp
+++ b/roughpy/src/algebra/lie_key.cpp
@@ -194,7 +194,7 @@ parse_key(const algebra::LieBasis& lbasis, key_type key)
 {
     using namespace rpy::python;
     if (lbasis.letter(key)) {
-        return {PyLieLetter::from_letter(lbasis.first_letter(key))};
+        return {PyLieLetter::from_letter(lbasis.to_letter(key))};
     }
 
     auto keys = lbasis.parents(key);
@@ -205,8 +205,8 @@ parse_key(const algebra::LieBasis& lbasis, key_type key)
     const bool right_letter = lbasis.letter(right_key);
 
     if (left_letter && right_letter) {
-        return {PyLieLetter::from_letter(lbasis.first_letter(left_key)),
-                PyLieLetter::from_letter(lbasis.first_letter(right_key))};
+        return {PyLieLetter::from_letter(lbasis.to_letter(left_key)),
+                PyLieLetter::from_letter(lbasis.to_letter(right_key))};
     }
 
     typename PyLieKey::container_type result;
@@ -215,7 +215,7 @@ parse_key(const algebra::LieBasis& lbasis, key_type key)
         auto right_result = parse_key(lbasis, right_key);
 
         result.reserve(2 + right_result.size());
-        result.push_back(PyLieLetter::from_letter(lbasis.first_letter(left_key))
+        result.push_back(PyLieLetter::from_letter(lbasis.to_letter(left_key))
         );
         result.push_back(PyLieLetter::from_offset(1));
 
@@ -225,7 +225,7 @@ parse_key(const algebra::LieBasis& lbasis, key_type key)
 
         result.reserve(2 + left_result.size());
         result.push_back(PyLieLetter::from_offset(2));
-        result.push_back(PyLieLetter::from_letter(lbasis.first_letter(right_key)
+        result.push_back(PyLieLetter::from_letter(lbasis.to_letter(right_key)
         ));
 
         result.insert(result.cend(), left_result.begin(), left_result.end());

--- a/roughpy/src/algebra/lie_key_iterator.cpp
+++ b/roughpy/src/algebra/lie_key_iterator.cpp
@@ -43,7 +43,7 @@ static const char* LKEY_ITERATOR_DOC
 python::PyLieKeyIterator::PyLieKeyIterator(
         algebra::LieBasis basis, key_type current, key_type end
 )
-    : m_current(current), m_end(end), m_basis(move(basis))
+    : m_current(current), m_end(end), m_basis(std::move(basis))
 {
     auto dim = m_basis.dimension();
     if (m_end > m_basis.dimension()) {
@@ -54,8 +54,6 @@ python::PyLieKeyIterator::PyLieKeyIterator(
 static python::PyLieKey
 to_py_lie_key(key_type k, const algebra::LieBasis& lbasis)
 {
-    auto width = lbasis.width();
-
     if (lbasis.letter(k)) { return python::PyLieKey(lbasis, k); }
 
     auto lparent = *lbasis.lparent(k);
@@ -75,10 +73,10 @@ to_py_lie_key(key_type k, const algebra::LieBasis& lbasis)
 
 python::PyLieKey python::PyLieKeyIterator::next()
 {
-    if (m_current > m_end) { throw py::stop_iteration(); }
+     if (m_current > m_end) { throw py::stop_iteration(); }
     auto current = m_current;
     ++m_current;
-    return to_py_lie_key(current, m_basis);
+    return python::PyLieKey(m_basis, current);
 }
 
 void python::init_lie_key_iterator(py::module_& m)

--- a/tests/algebra/test_lie_basis.py
+++ b/tests/algebra/test_lie_basis.py
@@ -4,9 +4,13 @@ import roughpy as rp
 
 def test_lie_basis_iteration():
 
-    ctx = rp.get_context(2, 2, rp.DPReal)
+    ctx = rp.get_context(2, 3, rp.DPReal)
     basis = ctx.lie_basis
 
     keys = list(basis)
 
-    assert len(keys) == 3
+    # assert len(keys) == 3
+    assert [str(k) for k in keys] == ["1", "2", "[1,2]", "[1,[1,2]]", "[2,[1,2]]"]
+    # assert str(keys[0]) == '1'
+    # assert str(keys[1]) == '2'
+    # assert str(keys[3]) == "[1,2]"


### PR DESCRIPTION
Fixed a bug in the Lie key iterator that caused keys to be represented incorrectly. Closes #40 .