### PR TITLE
Fix conversion to numpy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Version 0.1.0:
   - Added framework for integrating device support and redesigned scalars module to accommodate the changes.
   - Made changes to type deduction in constructors to avoid exceptions when providing lists of python ints/floats.
+  - Changed the implementation of __array__ for algebra types. A copy is always made, and the size of the array is always
+    equal to the dimension of the chosen width/depth composition.
 
 
 Version 0.0.8:

--- a/algebra/include/roughpy/algebra/algebra_base.h
+++ b/algebra/include/roughpy/algebra/algebra_base.h
@@ -191,7 +191,8 @@ public:
         return p_impl.get();
     }
 
-
+    RPY_NO_DISCARD
+    basis_type basis() const;
     RPY_NO_DISCARD
     dimn_t dimension() const;
     RPY_NO_DISCARD

--- a/algebra/include/roughpy/algebra/algebra_base_impl.h
+++ b/algebra/include/roughpy/algebra/algebra_base_impl.h
@@ -254,6 +254,15 @@ context_pointer AlgebraBase<Interface, DerivedImpl>::context() const noexcept
     return (p_impl) ? p_impl->context() : nullptr;
 }
 
+
+template <
+        typename Interface,
+        template <typename, template <typename> class> class DerivedImpl>
+typename AlgebraBase<Interface, DerivedImpl>::basis_type AlgebraBase<Interface, DerivedImpl>::basis() const
+{
+    return (p_impl) ? p_impl->basis() : basis_type();
+}
+
 template <
         typename Interface,
         template <typename, template <typename> class> class DerivedImpl>

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -71,6 +71,7 @@ add_roughpy_component(Device
         src/opencl/ocl_version.h
         src/buffer.cpp
         src/buffer_interface.cpp
+        src/core.cpp
         src/device_handle.cpp
         src/device_interface_base.cpp
         src/device_provider.cpp

--- a/device/include/roughpy/device/core.h
+++ b/device/include/roughpy/device/core.h
@@ -403,7 +403,7 @@ constexpr TypeInfo type_info() noexcept
             1U};
 }
 
-
+std::ostream& operator<<(std::ostream& os, const TypeInfo& code);
 
 
 RPY_SERIAL_SERIALIZE_FN_EXT(TypeInfo)

--- a/device/src/core.cpp
+++ b/device/src/core.cpp
@@ -1,0 +1,55 @@
+//
+// Created by sam on 11/23/23.
+//
+#include "core.h"
+
+
+std::ostream& rpy::devices::operator<<(std::ostream& os, const TypeInfo& info)
+{
+    switch (info.code) {
+        case TypeCode::Int:
+            os << "int" << info.bytes * CHAR_BIT;
+            break;
+        case TypeCode::UInt:
+            os << "uint" << info.bytes * CHAR_BIT;
+            break;
+        case TypeCode::Float:
+            os << "float" << info.bytes * CHAR_BIT;
+            break;
+        case TypeCode::OpaqueHandle:
+            os << "opaque";
+            break;
+        case TypeCode::BFloat:
+            os << "bfloat" << info.bytes*CHAR_BIT;
+            break;
+        case TypeCode::Complex:
+            os << "complex" << info.bytes*CHAR_BIT;
+        break;
+        case TypeCode::Bool:
+            os << "bool";
+            break;
+        case TypeCode::Rational:
+            os << "Rational";
+            break;
+        case TypeCode::ArbitraryPrecisionInt:
+            os << "mp_int";
+            break;
+        case TypeCode::ArbitraryPrecisionUInt:
+            os << "mp_uint";
+            break;
+        case TypeCode::ArbitraryPrecisionFloat:
+            os << "mp_float";
+            break;
+        case TypeCode::ArbitraryPrecisionComplex:
+            os << "mp_complex";
+            break;
+        case TypeCode::ArbitraryPrecisionRational:
+            os << "Rational";
+            break;
+        case TypeCode::APRationalPolynomial:
+            os << "PolyRational";
+            break;
+    }
+
+    return os;
+}

--- a/device/src/core.cpp
+++ b/device/src/core.cpp
@@ -7,47 +7,33 @@
 std::ostream& rpy::devices::operator<<(std::ostream& os, const TypeInfo& info)
 {
     switch (info.code) {
-        case TypeCode::Int:
-            os << "int" << info.bytes * CHAR_BIT;
+        case TypeCode::Int: os << "int" << info.bytes * CHAR_BIT;
             break;
-        case TypeCode::UInt:
-            os << "uint" << info.bytes * CHAR_BIT;
+        case TypeCode::UInt: os << "uint" << info.bytes * CHAR_BIT;
             break;
-        case TypeCode::Float:
-            os << "float" << info.bytes * CHAR_BIT;
+        case TypeCode::Float: os << "float" << info.bytes * CHAR_BIT;
             break;
-        case TypeCode::OpaqueHandle:
-            os << "opaque";
+        case TypeCode::OpaqueHandle: os << "opaque";
             break;
-        case TypeCode::BFloat:
-            os << "bfloat" << info.bytes*CHAR_BIT;
+        case TypeCode::BFloat: os << "bfloat" << info.bytes * CHAR_BIT;
             break;
-        case TypeCode::Complex:
-            os << "complex" << info.bytes*CHAR_BIT;
-        break;
-        case TypeCode::Bool:
-            os << "bool";
+        case TypeCode::Complex: os << "complex" << info.bytes * CHAR_BIT;
             break;
-        case TypeCode::Rational:
-            os << "Rational";
+        case TypeCode::Bool: os << "bool";
             break;
-        case TypeCode::ArbitraryPrecisionInt:
-            os << "mp_int";
+        case TypeCode::Rational: os << "Rational";
             break;
-        case TypeCode::ArbitraryPrecisionUInt:
-            os << "mp_uint";
+        case TypeCode::ArbitraryPrecisionInt: os << "mp_int";
             break;
-        case TypeCode::ArbitraryPrecisionFloat:
-            os << "mp_float";
+        case TypeCode::ArbitraryPrecisionUInt: os << "mp_uint";
             break;
-        case TypeCode::ArbitraryPrecisionComplex:
-            os << "mp_complex";
+        case TypeCode::ArbitraryPrecisionFloat: os << "mp_float";
             break;
-        case TypeCode::ArbitraryPrecisionRational:
-            os << "Rational";
+        case TypeCode::ArbitraryPrecisionComplex: os << "mp_complex";
             break;
-        case TypeCode::APRationalPolynomial:
-            os << "PolyRational";
+        case TypeCode::ArbitraryPrecisionRational: os << "Rational";
+            break;
+        case TypeCode::APRationalPolynomial: os << "PolyRational";
             break;
     }
 

--- a/roughpy/src/algebra/free_tensor.cpp
+++ b/roughpy/src/algebra/free_tensor.cpp
@@ -103,6 +103,7 @@ static FreeTensor construct_free_tensor(py::object data, py::kwargs kwargs)
     options.type = helper.ctype;
     options.alternative_key = &alt;
 
+
     auto buffer = python::py_to_buffer(data, options);
 
     if (helper.ctype == nullptr) {

--- a/roughpy/src/algebra/free_tensor.cpp
+++ b/roughpy/src/algebra/free_tensor.cpp
@@ -103,7 +103,6 @@ static FreeTensor construct_free_tensor(py::object data, py::kwargs kwargs)
     options.type = helper.ctype;
     options.alternative_key = &alt;
 
-
     auto buffer = python::py_to_buffer(data, options);
 
     if (helper.ctype == nullptr) {

--- a/roughpy/src/algebra/setup_algebra_type.h
+++ b/roughpy/src/algebra/setup_algebra_type.h
@@ -225,29 +225,8 @@ void setup_algebra_type(py::class_<Alg, Args...>& klass)
     // setup conversion to numpy array
 #ifdef ROUGHPY_WITH_NUMPY
     klass.def("__array__", [](const Alg& self) {
-        //        py::dtype dtype = dtype_from(self.coeff_type());
-        const auto* stype = self.coeff_type();
-        py::dtype dtype = ctype_to_npy_dtype(stype);
-
-        const auto dimension = self.basis().dimension();
-        auto dense_data = self.dense_data();
-
-        if (dense_data && dense_data->size() == dimension) {
-            // Dense and full dimension, bottow
-            return py::array(
-                    dtype,
-                    {dimension},
-                    {},
-                    dense_data->pointer()
-            );
-        }
-
-        py::array result(dtype, {dimension});
-
-
-
-        return py::array(dtype);
-
+        return algebra_to_array(self);
+            // return py::array();
     });
 #endif
 

--- a/roughpy/src/algebra/setup_algebra_type.h
+++ b/roughpy/src/algebra/setup_algebra_type.h
@@ -226,19 +226,28 @@ void setup_algebra_type(py::class_<Alg, Args...>& klass)
 #ifdef ROUGHPY_WITH_NUMPY
     klass.def("__array__", [](const Alg& self) {
         //        py::dtype dtype = dtype_from(self.coeff_type());
-        py::dtype dtype = ctype_to_npy_dtype(self.coeff_type());
+        const auto* stype = self.coeff_type();
+        py::dtype dtype = ctype_to_npy_dtype(stype);
 
+        const auto dimension = self.basis().dimension();
         auto dense_data = self.dense_data();
-        if (dense_data) {
-            const auto dense_data_inner = *dense_data;
+
+        if (dense_data && dense_data->size() == dimension) {
+            // Dense and full dimension, bottow
             return py::array(
                     dtype,
-                    {dense_data_inner.size()},
+                    {dimension},
                     {},
-                    dense_data_inner.pointer()
+                    dense_data->pointer()
             );
         }
+
+        py::array result(dtype, {dimension});
+
+
+
         return py::array(dtype);
+
     });
 #endif
 

--- a/roughpy/src/algebra/setup_algebra_type.h
+++ b/roughpy/src/algebra/setup_algebra_type.h
@@ -226,7 +226,7 @@ void setup_algebra_type(py::class_<Alg, Args...>& klass)
 #ifdef ROUGHPY_WITH_NUMPY
     klass.def("__array__", [](const Alg& self) {
         return algebra_to_array(self);
-            // return py::array();
+        // return py::array();
     });
 #endif
 

--- a/roughpy/src/args/numpy.cpp
+++ b/roughpy/src/args/numpy.cpp
@@ -259,6 +259,7 @@ py::array python::dtl::dense_data_to_array(const scalars::ScalarArray& data,
             : write_type_as_py_object(raw,
                                       data.template as_slice<
                                           devices::rational_poly_scalar>());
+                break;
             case devices::TypeCode::Int:
             case devices::TypeCode::UInt:
             case devices::TypeCode::Float:

--- a/roughpy/src/args/numpy.cpp
+++ b/roughpy/src/args/numpy.cpp
@@ -235,7 +235,7 @@ py::array python::dtl::dense_data_to_array(const scalars::ScalarArray& data,
 
     py::dtype dtype(info_to_typenum(type_info));
 
-    py::array result(dtype, dimension);;
+    auto result = python::dtl::new_zero_array_for_stype(*data.type(), dimension);
 
     if (scalars::traits::is_fundamental(type_info)) {
         scalars::dtl::scalar_convert_copy(result.mutable_data(),

--- a/roughpy/src/args/numpy.cpp
+++ b/roughpy/src/args/numpy.cpp
@@ -289,7 +289,9 @@ py::array python::dtl::new_zero_array_for_stype(const scalars::ScalarType* type,
     if (typenum == NPY_OBJECT) {
         PyArray_FillObjectArray(reinterpret_cast<PyArrayObject*>(result.ptr()),
                                 Py_None);
-    } else { PyArray_FILLWBYTE(reinterpret_cast<PyArrayObject*>(result.ptr()), 0); }
+    } else {
+        PyArray_FILLWBYTE(reinterpret_cast<PyArrayObject*>(result.ptr()), 0);
+    }
 
     return result;
 }

--- a/roughpy/src/args/numpy.h
+++ b/roughpy/src/args/numpy.h
@@ -50,16 +50,23 @@ string npy_dtype_to_identifier(py::dtype dtype);
 namespace dtl {
 
 RPY_NO_DISCARD
-py::array dense_data_to_array(const scalars::ScalarArray& data, dimn_t dimension);
+py::array dense_data_to_array(const scalars::ScalarArray& data,
+                              dimn_t dimension);
 RPY_NO_DISCARD
-py::array new_zero_array_for_stype(const scalars::ScalarType* type, dimn_t dimension);
-void write_entry_to_array(py::array& array, dimn_t index, const scalars::Scalar& arg);
+py::array new_zero_array_for_stype(const scalars::ScalarType* type,
+                                   dimn_t dimension);
+void write_entry_to_array(py::array& array,
+                          dimn_t index,
+                          const scalars::Scalar& arg);
 
 
 }
 
-template <typename Interface, template <typename, template <typename> class> class DerivedImpl>
-inline py::array algebra_to_array(const algebra::AlgebraBase<Interface, DerivedImpl>& alg)
+template <typename Interface, template <typename, template <typename> class>
+          class DerivedImpl>
+RPY_NO_DISCARD
+inline py::array algebra_to_array(
+    const algebra::AlgebraBase<Interface, DerivedImpl>& alg)
 {
     const auto* stype = alg.coeff_type();
     const auto basis = alg.basis();
@@ -72,9 +79,7 @@ inline py::array algebra_to_array(const algebra::AlgebraBase<Interface, DerivedI
         auto dtype = ctype_to_npy_dtype(stype);
         return py::array(dtype, {dimension}, {}, dense_data->pointer());
     }
-    if (dense_data) {
-        return dtl::dense_data_to_array(*dense_data, dimension);
-    }
+    if (dense_data) { return dtl::dense_data_to_array(*dense_data, dimension); }
 
     auto result = dtl::new_zero_array_for_stype(stype, dimension);
 
@@ -90,4 +95,12 @@ inline py::array algebra_to_array(const algebra::AlgebraBase<Interface, DerivedI
 }// namespace rpy
 
 #endif// ROUGHPY_WITH_NUMPY
+
+namespace rpy { namespace python {
+
+void import_numpy();
+
+}}
+
+
 #endif// RPY_PY_ARGS_NUMPY_H_

--- a/roughpy/src/args/numpy.h
+++ b/roughpy/src/args/numpy.h
@@ -33,7 +33,8 @@
 #  include "roughpy_module.h"
 #  include <pybind11/numpy.h>
 
-#  include <roughpy/scalars/scalar.h>
+#  include <roughpy/scalars.h>
+#include <roughpy/algebra/algebra_base.h>
 
 #  include <string>
 
@@ -45,6 +46,45 @@ const scalars::ScalarType* npy_dtype_to_ctype(py::dtype dtype);
 py::dtype ctype_to_npy_dtype(const scalars::ScalarType* type);
 
 string npy_dtype_to_identifier(py::dtype dtype);
+
+namespace dtl {
+
+RPY_NO_DISCARD
+py::array dense_data_to_array(const scalars::ScalarArray& data, dimn_t dimension);
+RPY_NO_DISCARD
+py::array new_zero_array_for_stype(const scalars::ScalarType* type, dimn_t dimension);
+void write_entry_to_array(py::array& array, dimn_t index, const scalars::Scalar& arg);
+
+
+}
+
+template <typename Interface, template <typename, template <typename> class> class DerivedImpl>
+inline py::array algebra_to_array(const algebra::AlgebraBase<Interface, DerivedImpl>& alg)
+{
+    const auto* stype = alg.coeff_type();
+    const auto basis = alg.basis();
+    const auto dimension = basis.dimension();
+
+    auto dense_data = alg.dense_data();
+
+    if (dense_data && dense_data->size() == dimension) {
+        // Dense and full dimension, borrow
+        auto dtype = ctype_to_npy_dtype(stype);
+        return py::array(dtype, {dimension}, {}, dense_data->pointer());
+    }
+    if (dense_data) {
+        return dtl::dense_data_to_array(*dense_data, dimension);
+    }
+
+    auto result = dtl::new_zero_array_for_stype(stype, dimension);
+
+    for (auto&& item : alg) {
+        dimn_t index = basis.key_to_index(item.key());
+        dtl::write_entry_to_array(result, index, item.value());
+    }
+
+    return result;
+}
 
 }// namespace python
 }// namespace rpy

--- a/roughpy/src/args/numpy.h
+++ b/roughpy/src/args/numpy.h
@@ -96,11 +96,13 @@ inline py::array algebra_to_array(
 
 #endif// ROUGHPY_WITH_NUMPY
 
-namespace rpy { namespace python {
+namespace rpy {
+namespace python {
 
 void import_numpy();
 
-}}
+}
+}
 
 
 #endif// RPY_PY_ARGS_NUMPY_H_

--- a/roughpy/src/roughpy_module.cpp
+++ b/roughpy/src/roughpy_module.cpp
@@ -43,6 +43,8 @@
 #include "scalars/scalars.h"
 #include "streams/streams.h"
 
+#include "args/numpy.h"
+
 
 #ifndef ROUGHPY_VERSION_STRING
 #  define ROUGHPY_VERSION_STRING "1.0.0"
@@ -63,4 +65,7 @@ PYBIND11_MODULE(_roughpy, m)
     init_algebra(m);
     init_streams(m);
     //    init_recombine(m);
+
+
+    import_numpy();
 }

--- a/roughpy/src/scalars/r_py_polynomial.cpp
+++ b/roughpy/src/scalars/r_py_polynomial.cpp
@@ -369,9 +369,6 @@ static PyObject* polynomial___setstate__(PyObject* self, PyObject* args)
 }
 }
 
-PyObject* PyPolynomial_FromPolynomial(scalars::rational_poly_scalar&& poly
-) noexcept;
-
 static PyMethodDef RPyPolynomial_methods[] = {
         {      "degree",(PyCFunction) &polynomial_degree,METH_NOARGS, nullptr                                                          },
         {"__getstate__",

--- a/roughpy/src/scalars/r_py_polynomial.h
+++ b/roughpy/src/scalars/r_py_polynomial.h
@@ -58,7 +58,6 @@ PyObject* PyPolynomial_FromPolynomial(rpy::scalars::rational_poly_scalar&& poly
 ) noexcept;
 
 
-
 inline bool RPyMonomial_Check(PyObject* obj)
 {
     return Py_TYPE(obj) == &RPyMonomial_Type;

--- a/roughpy/src/scalars/r_py_polynomial.h
+++ b/roughpy/src/scalars/r_py_polynomial.h
@@ -54,6 +54,11 @@ struct RPyPolynomial {
 
 extern PyTypeObject RPyPolynomial_Type;
 
+PyObject* PyPolynomial_FromPolynomial(rpy::scalars::rational_poly_scalar&& poly
+) noexcept;
+
+
+
 inline bool RPyMonomial_Check(PyObject* obj)
 {
     return Py_TYPE(obj) == &RPyMonomial_Type;

--- a/roughpy/src/scalars/scalars.cpp
+++ b/roughpy/src/scalars/scalars.cpp
@@ -649,12 +649,11 @@ scalars::KeyScalarArray python::py_to_buffer(
                          py::reinterpret_borrow<py::sequence>(leaf)) {
                         auto val = result[idx++];
                         handle_sequence_tuple(val, key_ptr++, obj, options);
-                         }
+                    }
                 }
             }
         }
-    } else if (object.is_none()) {
-    } else {
+    } else if (object.is_none()) {} else {
         RPY_THROW(
                 std::invalid_argument,
                 "could not parse argument to a valid scalar array type"

--- a/roughpy/src/scalars/scalars.cpp
+++ b/roughpy/src/scalars/scalars.cpp
@@ -649,10 +649,11 @@ scalars::KeyScalarArray python::py_to_buffer(
                          py::reinterpret_borrow<py::sequence>(leaf)) {
                         auto val = result[idx++];
                         handle_sequence_tuple(val, key_ptr++, obj, options);
-                    }
+                         }
                 }
             }
         }
+    } else if (object.is_none()) {
     } else {
         RPY_THROW(
                 std::invalid_argument,

--- a/roughpy/src/scalars/scalars.h
+++ b/roughpy/src/scalars/scalars.h
@@ -134,6 +134,8 @@ ArgSizeInfo compute_size_and_type(
         py::handle arg
 );
 
+
+
 void init_scalars(py::module_& m);
 
 }// namespace python

--- a/scalars/include/roughpy/scalars/scalar.h
+++ b/scalars/include/roughpy/scalars/scalar.h
@@ -231,7 +231,9 @@ public:
         auto this_info = type_info();
         auto value_info = devices::type_info<remove_cv_ref_t<T>>();
         if (this_info == value_info) {
-            construct_inplace<remove_cv_ref_t<T>>(static_cast<remove_cv_ref_t<T>*>(opaque_pointer), std::forward<T>(value));
+            construct_inplace<remove_cv_ref_t<T>>(
+                static_cast<remove_cv_ref_t<T>*>(opaque_pointer),
+                std::forward<T>(value));
         } else {
             dtl::scalar_convert_copy(
                     opaque_pointer,

--- a/scalars/include/roughpy/scalars/scalar.h
+++ b/scalars/include/roughpy/scalars/scalar.h
@@ -210,7 +210,7 @@ public:
                 trivial_bytes,
                 type_info(),
                 &value,
-                devices::type_info<T>()
+                devices::type_info<remove_cv_ref_t<T>>()
         );
     }
 
@@ -229,9 +229,9 @@ public:
     {
         allocate_data();
         auto this_info = type_info();
-        auto value_info = devices::type_info<T>();
+        auto value_info = devices::type_info<remove_cv_ref_t<T>>();
         if (this_info == value_info) {
-            construct_inplace<T>(opaque_pointer, std::forward<T>(value));
+            construct_inplace<remove_cv_ref_t<T>>(static_cast<remove_cv_ref_t<T>*>(opaque_pointer), std::forward<T>(value));
         } else {
             dtl::scalar_convert_copy(
                     opaque_pointer,

--- a/scalars/include/roughpy/scalars/scalar.h
+++ b/scalars/include/roughpy/scalars/scalar.h
@@ -231,7 +231,7 @@ public:
         auto this_info = type_info();
         auto value_info = devices::type_info<remove_cv_ref_t<T>>();
         if (this_info == value_info) {
-            construct_inplace<remove_cv_ref_t<T>>(
+            construct_inplace(
                 static_cast<remove_cv_ref_t<T>*>(opaque_pointer),
                 std::forward<T>(value));
         } else {

--- a/scalars/src/scalar.cpp
+++ b/scalars/src/scalar.cpp
@@ -184,8 +184,12 @@ Scalar::Scalar(Scalar&& other) noexcept
             break;
         case dtl::ScalarContentType::OpaquePointer:
         case dtl::ScalarContentType::ConstOpaquePointer:
+            opaque_pointer = other.opaque_pointer;
+            other.opaque_pointer = nullptr;
+            break;
         case dtl::ScalarContentType::OwnedPointer:
             opaque_pointer = other.opaque_pointer;
+            other.opaque_pointer = nullptr;
             break;
         case dtl::ScalarContentType::Interface:
         case dtl::ScalarContentType::OwnedInterface:
@@ -198,7 +202,10 @@ Scalar::~Scalar()
     switch (p_type_and_content_type.get_enumeration()) {
         case dtl::ScalarContentType::OwnedPointer:
             RPY_DBG_ASSERT(p_type_and_content_type.is_pointer());
-            p_type_and_content_type->free_single(opaque_pointer);
+            if (opaque_pointer != nullptr) {
+                p_type_and_content_type->free_single(opaque_pointer);
+                opaque_pointer = nullptr;
+            }
             break;
         case dtl::ScalarContentType::Interface:
         case dtl::ScalarContentType::OwnedInterface: interface.~unique_ptr();

--- a/scalars/src/types/aprational/ap_rational_type.cpp
+++ b/scalars/src/types/aprational/ap_rational_type.cpp
@@ -30,11 +30,18 @@ ScalarArray APRationalType::allocate(dimn_t count) const
 }
 void* APRationalType::allocate_single() const
 {
-    return ScalarType::allocate_single();
+    guard_type access(m_lock);
+    auto [pos, inserted] = m_allocations.insert(new rational_scalar_type());
+    RPY_DBG_ASSERT(inserted);
+    return *pos;
 }
 void APRationalType::free_single(void* ptr) const
 {
-    ScalarType::free_single(ptr);
+    guard_type access(m_lock);
+    auto found = m_allocations.find(ptr);
+    RPY_CHECK(found != m_allocations.end());
+    delete static_cast<rational_scalar_type*>(ptr);
+    m_allocations.erase(found);
 }
 void APRationalType::convert_copy(ScalarArray& dst, const ScalarArray& src)
         const

--- a/scalars/src/types/aprational/ap_rational_type.h
+++ b/scalars/src/types/aprational/ap_rational_type.h
@@ -8,11 +8,15 @@
 #include "scalar_type.h"
 #include "scalar_types.h"
 
+#include <unordered_set>
+
 namespace rpy {
 namespace scalars {
 
 class APRationalType : public ScalarType
 {
+    mutable std::unordered_set<void*> m_allocations;
+
 public:
 
     APRationalType();

--- a/tests/algebra/test_free_tensor.py
+++ b/tests/algebra/test_free_tensor.py
@@ -467,3 +467,28 @@ def test_ft_ctor_type_deduction(data, typ):
     f = FreeTensor(data, width=TYPE_DEDUCTION_WIDTH, depth=TYPE_DEDUCTION_DEPTH)
 
     assert f.dtype == typ
+
+
+TO_ARRAY_WIDTH = 3
+TO_ARRAY_DEPTH = 3
+
+
+def to_array_tensor():
+    ctx = roughpy.get_context(width=TO_ARRAY_WIDTH, depth=TO_ARRAY_DEPTH, coeffs=roughpy.DPReal)
+
+    yield FreeTensor(ctx=ctx)
+    yield FreeTensor([0.0], ctx=ctx)
+
+    for depth in range(TO_ARRAY_WIDTH + 1):
+        yield FreeTensor(np.zeros(ctx.tensor_size(depth)), ctx=ctx)
+
+    # sparse
+    yield FreeTensor({0: 1.0, 1: 1.0}, ctx=ctx)
+
+
+@pytest.mark.parametrize("tensor", to_array_tensor())
+def test_to_array(tensor):
+    ctx = roughpy.get_context(width=TO_ARRAY_WIDTH, depth=TO_ARRAY_DEPTH, coeffs=roughpy.DPReal)
+
+    print(tensor)
+    assert_array_equal(np.array(tensor), np.zeros(ctx.tensor_size(TO_ARRAY_WIDTH)))

--- a/tests/algebra/test_free_tensor.py
+++ b/tests/algebra/test_free_tensor.py
@@ -513,3 +513,15 @@ def test_to_array_rational_coeffs():
     array_tensor = np.array(tensor)
 
     assert array_tensor.dtype == object
+
+def test_to_array_rational_poly_coeffs():
+
+    ctx = roughpy.get_context(width=TO_ARRAY_WIDTH, depth=TO_ARRAY_DEPTH, coeffs=roughpy.RationalPoly)
+
+    tensor = FreeTensor([1]*(1+TO_ARRAY_WIDTH), ctx=ctx)
+
+    array_tensor = np.array(tensor)
+
+    assert array_tensor.dtype == object
+
+

--- a/tests/algebra/test_free_tensor.py
+++ b/tests/algebra/test_free_tensor.py
@@ -502,3 +502,14 @@ def test_to_array(tensor):
                        np.zeros(ctx.tensor_size(TO_ARRAY_WIDTH)))
 
 
+
+
+def test_to_array_rational_coeffs():
+
+    ctx = roughpy.get_context(width=TO_ARRAY_WIDTH, depth=TO_ARRAY_DEPTH, coeffs=roughpy.Rational)
+
+    tensor = FreeTensor([1]*(1+TO_ARRAY_WIDTH), ctx=ctx)
+
+    array_tensor = np.array(tensor)
+
+    assert array_tensor.dtype == object

--- a/tests/algebra/test_free_tensor.py
+++ b/tests/algebra/test_free_tensor.py
@@ -484,7 +484,7 @@ def to_array_tensor():
     yield FreeTensor(ctx=ctx)
     yield FreeTensor([0.0], ctx=ctx)
 
-    for depth in range(TO_ARRAY_WIDTH + 1):
+    for depth in range(TO_ARRAY_WIDTH+1):
         yield FreeTensor(np.zeros(ctx.tensor_size(depth)), ctx=ctx)
 
     # sparse
@@ -496,6 +496,9 @@ def test_to_array(tensor):
     ctx = roughpy.get_context(width=TO_ARRAY_WIDTH, depth=TO_ARRAY_DEPTH,
                               coeffs=roughpy.DPReal)
 
-    print(tensor)
-    assert_array_equal(np.array(tensor),
+    array_tensor = np.array(tensor)
+    assert array_tensor.flags.owndata
+    assert_array_equal(array_tensor,
                        np.zeros(ctx.tensor_size(TO_ARRAY_WIDTH)))
+
+

--- a/tests/algebra/test_free_tensor.py
+++ b/tests/algebra/test_free_tensor.py
@@ -45,8 +45,7 @@ def test_create_single_float_no_ctype():
     result = FreeTensor(1.0, width=2, depth=2)
 
     np_result = np.array(result)
-    assert np_result.shape == (1,)
-    assert_array_equal(np_result, np.array([1.]))
+    assert_array_equal(np_result, np.array([1., 0, 0, 0, 0, 0, 0]))
     assert result.width == 2
     assert result.max_degree == 2
 
@@ -55,8 +54,8 @@ def test_create_single_int_no_ctype():
     result = FreeTensor(1, width=2, depth=2)
 
     np_result = np.array(result)
-    assert np_result.shape == (1,)
-    assert_array_equal(np_result, np.array([1.]))
+    assert np_result.flags.owndata
+    assert_array_equal(np_result, np.array([1., 0, 0, 0, 0, 0, 0]))
     assert result.width == 2
     assert result.max_degree == 2
 
@@ -65,9 +64,8 @@ def test_create_list_floats_no_ctype():
     result = FreeTensor([0., 1., 2., 3.], width=3, depth=2)
 
     np_result = np.array(result)
-    assert np_result.shape == (4,)
     assert np_result.dtype == np.float64
-    assert_array_equal(np_result, np.array([0., 1., 2., 3.]))
+    assert_array_equal(np_result, np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
     assert result.width == 3
     assert result.max_degree == 2
 
@@ -76,9 +74,9 @@ def test_create_list_ints_no_ctype():
     result = FreeTensor([0, 1, 2, 3], width=3, depth=2)
 
     np_result = np.array(result)
-    assert np_result.shape == (4,)
+    assert np_result.flags.owndata
     assert np_result.dtype == np.float64
-    assert_array_equal(np_result, np.array([0., 1., 2., 3.]))
+    assert_array_equal(np_result, np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
     assert result.width == 3
     assert result.max_degree == 2
 
@@ -111,7 +109,7 @@ def test_create_dlpack():
 
     assert result.width == 3
     assert result.max_degree == 2
-    assert_array_equal(result, np.array([0., 1., 2., 3.]))
+    assert_array_equal(result, np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
 
 
 def test_create_buffer_doubles():
@@ -121,7 +119,7 @@ def test_create_buffer_doubles():
 
     assert result.width == 3
     assert result.max_degree == 2
-    assert_array_equal(result, np.array([0., 1., 2., 3.]))
+    assert_array_equal(result, np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
 
 
 def test_create_buffer_floats():
@@ -131,7 +129,7 @@ def test_create_buffer_floats():
 
     assert result.width == 3
     assert result.max_degree == 2
-    assert_array_equal(result, np.array([0., 1., 2., 3.], dtype=np.float32))
+    assert_array_equal(result, np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.float32))
 
 
 def test_create_intv_pair():
@@ -236,7 +234,7 @@ def test_create_FreeTensor_specified_width_incomplete_degree_range(rng, width):
 
 def test_FreeTensor_array_roundtrip(width, rdata, rtensor):
     assert rtensor.width == width
-    assert_array_equal(rdata, np.array(rtensor))
+    assert_array_equal(rdata, np.array(rtensor)[:rdata.shape[0]])
 
 
 def test_FreeTensor_repr(rng, width, depth, tensor_size):

--- a/tests/algebra/test_free_tensor.py
+++ b/tests/algebra/test_free_tensor.py
@@ -65,7 +65,8 @@ def test_create_list_floats_no_ctype():
 
     np_result = np.array(result)
     assert np_result.dtype == np.float64
-    assert_array_equal(np_result, np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+    assert_array_equal(np_result,
+                       np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
     assert result.width == 3
     assert result.max_degree == 2
 
@@ -76,7 +77,8 @@ def test_create_list_ints_no_ctype():
     np_result = np.array(result)
     assert np_result.flags.owndata
     assert np_result.dtype == np.float64
-    assert_array_equal(np_result, np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+    assert_array_equal(np_result,
+                       np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
     assert result.width == 3
     assert result.max_degree == 2
 
@@ -109,7 +111,8 @@ def test_create_dlpack():
 
     assert result.width == 3
     assert result.max_degree == 2
-    assert_array_equal(result, np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+    assert_array_equal(result,
+                       np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
 
 
 def test_create_buffer_doubles():
@@ -119,7 +122,8 @@ def test_create_buffer_doubles():
 
     assert result.width == 3
     assert result.max_degree == 2
-    assert_array_equal(result, np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+    assert_array_equal(result,
+                       np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0]))
 
 
 def test_create_buffer_floats():
@@ -129,7 +133,9 @@ def test_create_buffer_floats():
 
     assert result.width == 3
     assert result.max_degree == 2
-    assert_array_equal(result, np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.float32))
+    assert_array_equal(result,
+                       np.array([0., 1., 2., 3., 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                dtype=np.float32))
 
 
 def test_create_intv_pair():
@@ -179,7 +185,7 @@ def test_create_list_intv_pairs_dense():
     assert result.width == 2
     assert result.max_degree == 2
     assert result.storage_type == roughpy.VectorType.DenseVector
-    assert_array_equal(result, np.array([0., 1., 2.]))
+    assert_array_equal(result, np.array([0., 1., 2., 0, 0, 0, 0]))
 
 
 def test_create_dict_args():
@@ -353,7 +359,7 @@ def test_FreeTensor_mul_single_letter(width):
     expected = FreeTensor(np.array(
         [1.0, 1.0] + [0.0] * (width - 1) + [0.5] + [0.0] * (width ** 2 - 1) + [
             1.0 / 6.0] + [0.0] * (width ** 3 - 1)),
-                          width=width, depth=depth)
+        width=width, depth=depth)
 
     assert t.exp() == expected
 
@@ -438,8 +444,8 @@ def test_antipode(width, depth, data1, coeff_type, vec_type):
 
 
 def test_free_tensor_pickle_roundtrip():
-
-    t = FreeTensor(np.array([1.0, 2.0, 3.0, 4.0]), width=3, depth=2, dtype=DPReal)
+    t = FreeTensor(np.array([1.0, 2.0, 3.0, 4.0]), width=3, depth=2,
+                   dtype=DPReal)
 
     t2 = pickle.loads(pickle.dumps(t))
 
@@ -472,7 +478,8 @@ TO_ARRAY_DEPTH = 3
 
 
 def to_array_tensor():
-    ctx = roughpy.get_context(width=TO_ARRAY_WIDTH, depth=TO_ARRAY_DEPTH, coeffs=roughpy.DPReal)
+    ctx = roughpy.get_context(width=TO_ARRAY_WIDTH, depth=TO_ARRAY_DEPTH,
+                              coeffs=roughpy.DPReal)
 
     yield FreeTensor(ctx=ctx)
     yield FreeTensor([0.0], ctx=ctx)
@@ -486,7 +493,9 @@ def to_array_tensor():
 
 @pytest.mark.parametrize("tensor", to_array_tensor())
 def test_to_array(tensor):
-    ctx = roughpy.get_context(width=TO_ARRAY_WIDTH, depth=TO_ARRAY_DEPTH, coeffs=roughpy.DPReal)
+    ctx = roughpy.get_context(width=TO_ARRAY_WIDTH, depth=TO_ARRAY_DEPTH,
+                              coeffs=roughpy.DPReal)
 
     print(tensor)
-    assert_array_equal(np.array(tensor), np.zeros(ctx.tensor_size(TO_ARRAY_WIDTH)))
+    assert_array_equal(np.array(tensor),
+                       np.zeros(ctx.tensor_size(TO_ARRAY_WIDTH)))


### PR DESCRIPTION
Changed the behaviour of the __array__ method for algebra types. A copy is always returned of the correct size.