### PR TITLE
do not transpose arrays that are wide but short for streams

### DIFF
--- a/roughpy/src/args/strided_copy.cpp
+++ b/roughpy/src/args/strided_copy.cpp
@@ -46,17 +46,21 @@ void rpy::python::stride_copy(
     const auto* sptr = static_cast<const char*>(src);
 
     if (ndim == 1) {
-        for (py::ssize_t i=0; i<shape_in[0]; ++i) {
-            std::memcpy(dptr + i*strides_out[0],
-                        sptr + i*strides_in[0],
-                        itemsize);
+        if (strides_in[0] == itemsize) {
+            std::memcpy(dptr, sptr, shape_in[0] * itemsize);
+        } else {
+            for (py::ssize_t i = 0; i < shape_in[0]; ++i) {
+                std::memcpy(dptr + i * strides_out[0],
+                            sptr + i * strides_in[0],
+                            itemsize);
+            }
         }
     } else if (transpose) {
-         for (py::ssize_t i=0; i<shape_in[0]; ++i) {
-            for (py::ssize_t j=0; j<shape_in[1]; ++j) {
+        for (py::ssize_t i = 0; i < shape_in[1]; ++i) {
+            for (py::ssize_t j = 0; j < shape_in[0]; ++j) {
                 std::memcpy(
                         dptr + j*strides_out[0] + i*strides_out[1],
-                        sptr + i*strides_in[0] + j*strides_in[1],
+                        sptr + i * strides_in[1] + j * strides_in[0],
                         itemsize
                         );
             }

--- a/roughpy/src/scalars/parse_key_scalar_stream.cpp
+++ b/roughpy/src/scalars/parse_key_scalar_stream.cpp
@@ -228,18 +228,10 @@ void buffer_to_stream(
         py::ssize_t tmp_strides[2]{};
         dimn_t tmp_shape[2]{};
         tmp_strides[buf_info.ndim - 1] = buf_info.itemsize;
-        bool transposed
-                = buf_info.ndim == 2 && buf_info.shape[0] < buf_info.shape[1];
         if (buf_info.ndim == 2) {
-            if (transposed) {
-                tmp_strides[0] = buf_info.shape[1];
-                tmp_shape[0] = buf_info.shape[1];
-                tmp_shape[1] = buf_info.shape[0];
-            } else {
-                tmp_strides[0] = buf_info.shape[0];
-                tmp_shape[0] = buf_info.shape[0];
-                tmp_shape[1] = buf_info.shape[1];
-            }
+            tmp_strides[0] = buf_info.shape[0];
+            tmp_shape[0] = buf_info.shape[0];
+            tmp_shape[1] = buf_info.shape[1];
         }
 
         stride_copy(
@@ -250,7 +242,7 @@ void buffer_to_stream(
                 buf_info.shape.data(),
                 buf_info.strides.data(),
                 tmp_strides,
-                transposed
+                false
         );
 
         // Now that we're C-contiguous, convert_copy into the result.
@@ -362,17 +354,12 @@ void dl_to_stream(
         py::ssize_t in_shape[2]{};
         dimn_t out_shape[2]{};
         out_strides[tensor.ndim - 1] = itemsize;
-        bool transposed = tensor.ndim == 2 && tensor.shape[0] < tensor.shape[1];
 
         in_shape[0] = tensor.shape[0];
         if (tensor.ndim == 2) {
-            if (transposed) {
-                out_shape[0] = tensor.shape[1];
-                out_shape[1] = tensor.shape[0];
-            } else {
-                out_shape[0] = tensor.shape[0];
-                out_shape[1] = tensor.shape[1];
-            }
+
+            out_shape[0] = tensor.shape[0];
+            out_shape[1] = tensor.shape[1];
             out_strides[0] = out_shape[1] * itemsize;
 
             if (tensor.strides != nullptr) {
@@ -394,7 +381,7 @@ void dl_to_stream(
                 in_shape,
                 in_strides,
                 out_strides,
-                transposed
+                false
         );
 
         // Now that we're C-contiguous, convert_copy into the result.

--- a/tests/streams/test_lie_increment_path.py
+++ b/tests/streams/test_lie_increment_path.py
@@ -271,26 +271,28 @@ def test_lie_incr_stream_from_randints_no_deduction(rng):
     assert_array_equal(np.array(sig)[:4],
                        np.hstack([[1.0], np.sum(array, axis=0)[:]]))
 
+
 def test_lie_incr_stream_from_randints_transposed(rng):
     array = rng.integers(0, 5, size=(4, 3))
 
-    stream = LieIncrementStream.from_increments(array.T, width=3, depth=2)
+    stream = LieIncrementStream.from_increments(array.T, width=4, depth=2)
 
-    sig = stream.signature(RealInterval(0.0, 5.0), 2)
+    sig = stream.signature(RealInterval(0.0, 5.0))
 
-    assert_array_equal(np.array(sig)[:4],
-                       np.hstack([[1.0], np.sum(array, axis=0)[:]]))
+    assert_array_equal(np.array(sig)[:5],
+                       np.hstack([[1.0], np.sum(array, axis=1)[:]]))
+
 
 def test_lie_incr_stream_from_randints_no_deduction_transposed(rng):
     array = rng.integers(0, 5, size=(4, 3))
 
-    stream = LieIncrementStream.from_increments(array.T, width=3, depth=2,
+    stream = LieIncrementStream.from_increments(array.T, width=4, depth=2,
                                                 dtype=roughpy.DPReal)
 
-    sig = stream.signature(RealInterval(0.0, 5.0), 2)
+    sig = stream.signature(RealInterval(0.0, 5.0))
 
-    assert_array_equal(np.array(sig)[:4],
-                       np.hstack([[1.0], np.sum(array, axis=0)[:]]))
+    assert_array_equal(np.array(sig)[:5],
+                       np.hstack([[1.0], np.sum(array, axis=1)[:]]))
 
 
 TYPE_DEDUCTION_WIDTH = 3


### PR DESCRIPTION
Fix a bug when constructing streams that caused stream increment arrays with larger width than number of increments to be transposed.