### PR TITLE
Revert to libalgebra-lite submodule rather than using vcpkg

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/libalgebra_lite"]
+	path = external/libalgebra_lite
+	url = https://github.com/datasig-ac-uk/libalgebra-lite

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,8 @@ if (ROUGHPY_BUILD_TESTS)
 
     enable_testing()
 
-    # If we are building roughpy tests and gtest is available then we also
-    # to build the libalgebra_lite tests.
-    set(LIBALGEBRA_LITE_BUILD_TESTS ON CACHE INTERNAL "")
 endif ()
+
 
 # If we're building with SKBUILD, we need to define install locations for
 # all the components using their special directory variables. Otherwise,
@@ -252,9 +250,7 @@ if (NOT ROUGHPY_DISABLE_BLAS)
         find_package(MKL CONFIG)
         if (TARGET MKL::MKL)
             set(RPY_USE_MKL ON CACHE INTERNAL "BLAS/LAPACK provided by mkl")
-            add_library(BLAS::BLAS ALIAS MKL::MKL
-                    algebra/src/libalgebra_lite_internal/rational_coefficients.cpp
-                    algebra/src/libalgebra_lite_internal/rational_coefficients.h)
+            add_library(BLAS::BLAS ALIAS MKL::MKL)
             add_library(LAPACK::LAPACK ALIAS MKL::MKL)
 
             if (DEFINED MKL_OMP_LIB AND MKL_OMP_LIB)
@@ -313,7 +309,7 @@ endif ()
 find_package(pybind11 REQUIRED)
 find_package(cereal REQUIRED)
 find_package(PCGRandom REQUIRED)
-find_package(Libalgebra_lite REQUIRED)
+#find_package(Libalgebra_lite REQUIRED)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GMP REQUIRED IMPORTED_TARGET gmp)
@@ -331,7 +327,11 @@ elseif (NOT WIN32)
     set(CMAKE_INSTALL_RPATH "$ORIGIN" CACHE INTERNAL "")
 endif ()
 
-#add_subdirectory(external/libalgebra_lite)
+
+
+set(LIBALGEBRA_LITE_BUILD_TESTS OFF CACHE INTERNAL "")
+set(LIBALGEBRA_LITE_RATIONAL_CEFFS OFF CACHE INTERNAL "")
+add_subdirectory(external/libalgebra_lite)
 
 
 add_subdirectory(core)
@@ -340,6 +340,7 @@ add_subdirectory(scalars)
 add_subdirectory(intervals)
 add_subdirectory(algebra)
 add_subdirectory(streams)
+
 if (ROUGHPY_BUILD_PYLIB)
     add_subdirectory(roughpy)
 endif ()

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -5,16 +5,6 @@
     "baseline": "4f9d25a7f299db656c376af402637819ee2caba0",
     "repository": "https://github.com/microsoft/vcpkg"
   },
-  "registries": [
-    {
-      "kind": "filesystem",
-      "path": "./tools/registry",
-      "baseline": "default",
-      "packages": [
-        "libalgebra-lite"
-      ]
-    }
-  ],
   "overlay-triplets": [
     "./tools/triplets"
   ],

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -64,9 +64,6 @@
     "name" : "opencl",
     "version>=" : "v2023.02.06#2"
   }, {
-    "name" : "libalgebra-lite",
-    "version>=" : "1.0.0"
-  }, {
     "name" : "boost-stacktrace",
     "version>=" : "1.83.0"
   } ],


### PR DESCRIPTION
Long term we'll be moving away from using libalgebra-lite as an external module and incorporating the functionality into RoughPy directly so it doesn't make sense to make it a regular dependency.