### PR TITLE
Update readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-<center>
-  <img src="https://raw.githubusercontent.com/datasig-ac-uk/RoughPy/main/branding/logo/logo_square_white.jpg">
-</center><br>
+<div style="text-align: center;">
+  <img src="https://raw.githubusercontent.com/datasig-ac-uk/RoughPy/main/branding/logo/logo_square_white.jpg" title="RoughPy Logo">
+</div><br>
 
 # RoughPy
 RoughPy is a package for working with streaming data as rough paths, and working with algebraic objects such as free tensors, shuffle tensors, and elements of the free Lie algebra.
 
 This library is currently in an alpha stage, and as such many features are still incomplete or not fully implemented. Please bear this in mind when looking at the source code.
 
+Please refer to the [documentation](https://roughpy.org) and to
+the [examples folder](examples/) for details on how to use RoughPy. If you want
+to implement more complex functions built on top of RoughPy, you may also want
+to check out the  [roughpy/tensor_functions.py]() file to see how the "Log"
+function is implemented for free tensor objects.
 
 ## Installation
 RoughPy can be installed from PyPI using `pip` on Windows, Linux, and MacOS (Intel based Mac only, sorry not Apple Silicon support yet). Simply run
@@ -29,12 +34,6 @@ export CMAKE_TOOLCHAIN_FILE=$(pwd)/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
 ```
 With this environment variable set, most of the dependencies will be installed automatically during the build process.
 
-On MacOS with Apple Silicon you will need to install libomp (for example using Homebrew `brew install libomp`).
-This is not necessary on Intel based MacOS where the Intel iomp5 can be used instead. 
-The build system will use `brew --prefix libomp` to try to locate this library.
-(The actual `brew` executable can be customised by setting the `ROUGHPY_BREW_EXECUTABLE` CMake variable 
-or environment variable.)
-
 You should now be able to pip install either using the PyPI source distribution (using the `--no-binary :roughpy:` 
 flag), or directly from GitHub (recommended):
 ```bash
@@ -56,44 +55,7 @@ For this reason, a query over any interval is replaced by a query is replaced by
 In particular, if both the left-hand and right-hand ends of the interval are contained in the clopen granular interval, we round the interval to the empty interval. 
 Specifying a resolution of 32 or 64 equates to using integer arithmetic.
 
-## Usage
-Following the NumPy (and related) convention, we import RoughPy under the alias `rp` as follows:
-```python
-import roughpy as rp
-```
-The main object(s) that you will interact with are `Stream` objects or the family of factory classes such as `LieIncrementStream`. For example, we can create a `LieIncrementStream` using the following commands:
-```python
-import numpy as np
-stream = rp.LieIncrementStream.from_increments(np.array([[0, 1, 2], [3, 4, 5]], dtype=np.float64), depth=2)
-```
-This will create a stream whose (hidden) underlying data are the two increments `[0., 1., 2.]` and `[3., 4., 5.]`, and whose algebra elements are truncated at maximum depth 2.
-To compute the log signature over an interval we use the `log_signature` method on the stream, for example
-```python
-interval = rp.RealInterval(0., 1.)
-lsig = stream.log_signature(interval)
-```
-Printing this new object `lsig` should give the following result
-```
-{ 1(2) 2(3) }
-```
-which is the first increment from the underlying data. (By default, the increments are assumed to occur at parameter values equal to their row index in the provided data.)
 
-Similarly, the signature can be computed using the `signature` method on the stream object:
-```python
-sig = stream.signature(interval)
-```
-Notice that the `lsig` and `sig` objects have types `Lie` and `FreeTensor`, respectively. They behave exactly as you would expect elements of these algebras to behave. Moreover, they will (usually) be convertible directly to a NumPy array (or TensorFlow, PyTorch, JAX tensor type in the future) of the underlying data, so you can interact with them as if they were simple arrays.
-
-We can also construct streams by providing the raw data of Lie increments with higher order terms by specifying the width using the same constructor above.
-For example, if we take width 2 and depth 2 then the elements of a Lie element will have keys (1, 2, [1,2]).
-So if we provide the following data, we construct a stream whose underlying Lie increments are width 2, depth 2 
-```
-stream = rp.LieIncrementStream.from_increments(np.array([[1, 2, 0.5], [0.2, -0.1, 0.2]], dtype=np.float64), width=2, depth=2)
-print(stream.log_signature(rp.RealInterval(0, 0.5), 2)) # returns the first increment
-# { 1(1), 2(2), 0.5([1,2]) }
->>> print(stream.log_signature(rp.RealInterval(0, 1.5), 2)) # Campbell-Baker-Hausdorff product of both increments
-{ 1.2(1) 1.9(2) 0.45([1,2]) }
-```
 
 
 ## Support


### PR DESCRIPTION
Added an explicit link to the documentation and examples folder, removed the old usage section - pending rewrite - and added a link to the tensor functions module as an example of how to build on top of the RoughPy API.