### PR TITLE
Fix fault constructing larger than expected array

### DIFF
--- a/algebra/src/lite_context.h
+++ b/algebra/src/lite_context.h
@@ -429,7 +429,7 @@ OutType LiteContext<Coefficients>::construct_impl(
 
     Slice<const scalar_type> raw_data;
 
-    const auto size = data.data.size();
+    const auto size = std::min(data.data.size(), basis->size(-1));
     std::vector<scalar_type> tmp;
     const auto* this_type = ctype();
     if (data.data.type() != this_type) {

--- a/tests/streams/test_lie_increment_path.py
+++ b/tests/streams/test_lie_increment_path.py
@@ -7,6 +7,7 @@ import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 import roughpy
+import roughpy as rp
 from roughpy import FreeTensor, Lie, RealInterval
 from roughpy import LieIncrementStream
 
@@ -90,6 +91,40 @@ def test_path_creation_odd_data(data):
 #     p.restrict(RealInterval(0.0, 0.5))
 #
 #     assert p.domain() == RealInterval(0.0, 0.5)
+
+
+def test_from_array_inferred_width_3_2_increments():
+    data = np.array([[3, 7, 0], [0, 0, 1]])
+    stream = LieIncrementStream.from_increments(data, depth=2,
+                                                coeffs=rp.Rational)
+    sig = stream.signature(depth=1)
+
+    assert sig.width == 3
+    assert sig.max_degree == 1
+    assert sig == rp.FreeTensor(np.array([1, 3, 7, 1]), width=3, depth=1,
+                                coeffs=rp.Rational)
+
+
+def test_from_array_width_3_2_increments():
+    data = np.array([[3, 7, 0], [0, 0, 1]])
+    stream = LieIncrementStream.from_increments(data, width=3, depth=2,
+                                                coeffs=rp.Rational)
+    sig = stream.signature(depth=1)
+
+    assert sig.width == 3
+    assert sig.max_degree == 1
+    assert sig == rp.FreeTensor(np.array([1, 3, 7, 1]), width=3, depth=1,
+                                coeffs=rp.Rational)
+
+
+def test_from_array_wider_than_depth_2_dim():
+    stream = rp.LieIncrementStream.from_increments(
+        np.array([[3, 7, 0, 4], [0, 0, 1, 5]]), width=2, depth=2,
+        coeffs=rp.Rational)
+    sig = stream.signature(depth=1)
+
+    assert sig == rp.FreeTensor(np.array([1, 3, 7]), width=2, depth=1,
+                                coeffs=rp.Rational)
 
 
 def test_tick_path_signature_calc_accuracy():


### PR DESCRIPTION
Fixed a bug caused by passing a wider than expected array to stream construction. Closes #70.