### PR TITLE
Fix degree argument on basis size

### DIFF
--- a/roughpy/src/algebra/basis.cpp
+++ b/roughpy/src/algebra/basis.cpp
@@ -85,9 +85,9 @@ static py::class_<T> wordlike_basis_setup(py::module_& m, const char* name)
         if (degree < 0) {
             degree = basis.depth();
         } else if (degree > basis.depth()) {
-            PyErr_WarnEx(nullptr,
+            PyErr_SetString(PyExc_ValueError,
                          "the requested degree exceeds the "
-                         "maximum degree for this basis", 1);
+                         "maximum degree for this basis");
             throw py::error_already_set();
         }
 

--- a/roughpy/src/algebra/basis.cpp
+++ b/roughpy/src/algebra/basis.cpp
@@ -81,7 +81,16 @@ static py::class_<T> wordlike_basis_setup(py::module_& m, const char* name)
             [](const T& self, const K& key) { return self.parents(0); },
             "key"_a
     );
-    basis.def("size", [](const T& basis, deg_t degree) {
+    basis.def("size", [](const T& basis, deg_t degree = -1) {
+        if (degree < 0) {
+            degree = basis.depth();
+        } else if (degree > basis.depth()) {
+            PyErr_WarnEx(nullptr,
+                         "the requested degree exceeds the "
+                         "maximum degree for this basis", 1);
+            throw py::error_already_set();
+        }
+
         return basis.size(degree);
     });
 

--- a/roughpy/src/algebra/context.cpp
+++ b/roughpy/src/algebra/context.cpp
@@ -44,36 +44,78 @@ using rpy::python::RPyContext;
 extern "C" {
 
 static const char* lie_size_DOC = R"rpydoc()rpydoc";
-static PyObject* RPyContext_lie_size(PyObject* self, PyObject* degree)
+static PyObject* RPyContext_lie_size(PyObject * self,
+                                     PyObject * args,
+                                     PyObject * kwargs)
 {
-    auto deg = static_cast<deg_t>(PyLong_AsLong(degree));
-    return PyLong_FromSize_t(ctx_cast(self)->lie_size(deg));
+    static const char* kwords[] = {"degree", nullptr};
+    const auto& myself = ctx_cast(self);
+    const deg_t max_degree = myself->depth();
+    deg_t depth = max_degree;
+
+    if (PyArg_ParseTupleAndKeywords(args,
+                                    kwargs,
+                                    "|i",
+                                    const_cast<char**>(kwords),
+                                    &depth) == 0) {
+        return nullptr;
+    }
+
+    if (depth < 0) {
+        depth = max_degree;
+    } else if (depth > max_degree) {
+        PyErr_SetString(PyExc_ValueError, "the requested degree exceeds the"
+                                          " maximum degree for this basis");
+        return nullptr;
+    }
+    return PyLong_FromSize_t(myself->lie_size(depth));
 }
 static const char* tensor_size_DOC = R"rpydoc()rpydoc";
-static PyObject* RPyContext_tensor_size(PyObject* self, PyObject* degree)
+static PyObject* RPyContext_tensor_size(PyObject * self,
+                                        PyObject * args,
+                                        PyObject * kwargs)
 {
-    auto deg = static_cast<deg_t>(PyLong_AsLong(degree));
-    return PyLong_FromSize_t(ctx_cast(self)->tensor_size(deg));
+    static const char* kwords[] = {"degree", nullptr};
+    const auto& myself = ctx_cast(self);
+    const deg_t max_degree = myself->depth();
+    deg_t depth = max_degree;
+
+    if (PyArg_ParseTupleAndKeywords(args,
+                                    kwargs,
+                                    "|i",
+                                    const_cast<char**>(kwords),
+                                    &depth) == 0) {
+        return nullptr;
+    }
+
+    if (depth < 0) {
+        depth = max_degree;
+    } else if (depth > max_degree) {
+        PyErr_SetString(PyExc_ValueError, "the requested degree exceeds the"
+                                          " maximum degree for this basis");
+        return nullptr;
+    }
+    return PyLong_FromSize_t(myself->tensor_size(depth));
 }
 static const char* cbh_DOC = R"rpydoc()rpydoc";
 static PyObject*
-RPyContext_cbh(PyObject* self, PyObject* args, PyObject* kwargs)
+RPyContext_cbh(PyObject * self, PyObject * args, PyObject * kwargs)
 {
     static const char* kwords[] = {"lies", "vec_type", nullptr};
     const auto& ctx = ctx_cast(self);
 
-    PyObject* py_lies = nullptr;
-    PyObject* vtype = nullptr;
+    PyObject * py_lies = nullptr;
+    PyObject * vtype = nullptr;
 
     if (!PyArg_ParseTupleAndKeywords(
-                args,
-                kwargs,
-                "O|O!",
-                const_cast<char**>(kwords),
-                &py_lies,
-                py::type::of<VectorType>().ptr(),
-                &vtype
-        )) {
+        args,
+        kwargs,
+        "O|O!",
+        const_cast<char**>(kwords),
+        &py_lies,
+        py::type::of<VectorType>().ptr(),
+        &vtype
+    )) {
         return nullptr;
     }
 
@@ -91,7 +133,7 @@ RPyContext_cbh(PyObject* self, PyObject* args, PyObject* kwargs)
             return python::cast_to_object(ctx->zero_lie(VectorType::Sparse));
         }
         return python::cast_to_object(
-                ctx->zero_lie(py::handle(vtype).cast<VectorType>())
+            ctx->zero_lie(py::handle(vtype).cast<VectorType>())
         );
     }
 
@@ -102,7 +144,9 @@ RPyContext_cbh(PyObject* self, PyObject* args, PyObject* kwargs)
 }
 static const char* compute_signature_DOC = R"rpydoc()rpydoc";
 static PyObject*
-RPyContext_compute_signature(PyObject* self, PyObject* args, PyObject* kwargs)
+RPyContext_compute_signature(PyObject * self,
+                             PyObject * args,
+                             PyObject * kwargs)
 {
     static const char* kwords[] = {"data", "vtype", nullptr};
     const auto& ctx = ctx_cast(self);
@@ -111,14 +155,14 @@ RPyContext_compute_signature(PyObject* self, PyObject* args, PyObject* kwargs)
     py::handle py_vtype;
 
     if (!PyArg_ParseTupleAndKeywords(
-                args,
-                kwargs,
-                "O|O!",
-                const_cast<char**>(kwords),
-                py_data.ptr(),
-                py::type::of<VectorType>().ptr(),
-                py_vtype.ptr()
-        )) {
+        args,
+        kwargs,
+        "O|O!",
+        const_cast<char**>(kwords),
+        py_data.ptr(),
+        py::type::of<VectorType>().ptr(),
+        py_vtype.ptr()
+    )) {
         return nullptr;
     }
 
@@ -170,9 +214,9 @@ RPyContext_compute_signature(PyObject* self, PyObject* args, PyObject* kwargs)
         request.data_stream.reserve_size(n_increments);
         for (dimn_t i = 0; i < n_increments; ++i) {
             request.data_stream.push_back(scalars::ScalarArray{
-                    ctype,
-                    p_buffer + i * width * itemsize,
-                    width});
+                ctype,
+                p_buffer + i * width * itemsize,
+                width});
         }
     } else {
         request.data_stream.reserve_size(options.shape.size());
@@ -182,9 +226,9 @@ RPyContext_compute_signature(PyObject* self, PyObject* args, PyObject* kwargs)
         auto n_increments = options.shape.size();
         for (dimn_t i = 0; i < n_increments; ++i) {
             request.data_stream.push_back(scalars::ScalarArray{
-                    ctype,
-                    p_buffer,
-                    static_cast<dimn_t>(options.shape[i])});
+                ctype,
+                p_buffer,
+                static_cast<dimn_t>(options.shape[i])});
             request.key_stream.push_back(p_keys);
             p_buffer += options.shape[i] * itemsize;
             p_keys += options.shape[i];
@@ -194,7 +238,7 @@ RPyContext_compute_signature(PyObject* self, PyObject* args, PyObject* kwargs)
     return python::cast_to_object(ctx->signature(request));
 }
 static const char* to_logsignature_DOC = R"rpydoc()rpydoc";
-static PyObject* RPyContext_to_logsignature(PyObject* self, PyObject* arg)
+static PyObject* RPyContext_to_logsignature(PyObject * self, PyObject * arg)
 {
 
     py::handle py_sig(arg);
@@ -210,7 +254,7 @@ static PyObject* RPyContext_to_logsignature(PyObject* self, PyObject* arg)
     return python::cast_to_object(ctx->tensor_to_lie(sig.log()));
 }
 static const char* lie_to_tensor_DOC = R"rpydoc()rpydoc";
-static PyObject* RPyContext_lie_to_tensor(PyObject* self, PyObject* arg)
+static PyObject* RPyContext_lie_to_tensor(PyObject * self, PyObject * arg)
 {
     py::handle py_lie(arg);
     if (!py::isinstance<algebra::Lie>(py_lie)) {
@@ -223,7 +267,7 @@ static PyObject* RPyContext_lie_to_tensor(PyObject* self, PyObject* arg)
     );
 }
 static const char* tensor_to_lie_DOC = R"rpydoc()rpydoc";
-static PyObject* RPyContext_tensor_to_lie(PyObject* self, PyObject* arg)
+static PyObject* RPyContext_tensor_to_lie(PyObject * self, PyObject * arg)
 {
     py::handle py_ft(arg);
     if (!py::isinstance<algebra::FreeTensor>(py_ft)) {
@@ -233,35 +277,35 @@ static PyObject* RPyContext_tensor_to_lie(PyObject* self, PyObject* arg)
 
     const auto& ctx = ctx_cast(self);
     return python::cast_to_object(
-            ctx->tensor_to_lie(py_ft.cast<const FreeTensor&>())
+        ctx->tensor_to_lie(py_ft.cast<const FreeTensor&>())
     );
 }
 
-static PyObject* RPyContext_enter(PyObject* self) { return self; }
+static PyObject* RPyContext_enter(PyObject * self) { return self; }
 
-static PyObject* RPyContext_exit(PyObject* self, PyObject* RPY_UNUSED_VAR)
+static PyObject* RPyContext_exit(PyObject * self, PyObject * RPY_UNUSED_VAR)
 {
     Py_RETURN_NONE;
 }
 
 static const char* zero_lie_DOC
-        = R"rpydoc(Get a new Lie with value zero)rpydoc";
+    = R"rpydoc(Get a new Lie with value zero)rpydoc";
 static PyObject*
-RPyContext_zero_lie(PyObject* self, PyObject* args, PyObject* kwargs)
+RPyContext_zero_lie(PyObject * self, PyObject * args, PyObject * kwargs)
 {
     static const char* kwords[] = {"vtype", nullptr};
     PyTypeObject* vtype_type
-            = reinterpret_cast<PyTypeObject*>(py::type::of<VectorType>().ptr());
+        = reinterpret_cast<PyTypeObject*>(py::type::of<VectorType>().ptr());
 
-    PyObject* py_vtype = nullptr;
+    PyObject * py_vtype = nullptr;
     if (PyArg_ParseTupleAndKeywords(
-                args,
-                kwargs,
-                "|O!",
-                const_cast<char**>(kwords),
-                vtype_type,
-                &py_vtype
-        )
+        args,
+        kwargs,
+        "|O!",
+        const_cast<char**>(kwords),
+        vtype_type,
+        &py_vtype
+    )
         == 0) {
         return nullptr;
     }
@@ -278,38 +322,38 @@ RPyContext_zero_lie(PyObject* self, PyObject* args, PyObject* kwargs)
     }
 
 static PyMethodDef RPyContext_members[] = {
-        ADD_METHOD(lie_size, METH_O),
-        ADD_METHOD(tensor_size, METH_O),
-        ADD_METHOD(cbh, METH_VARARGS | METH_KEYWORDS),
-        ADD_METHOD(compute_signature, METH_VARARGS | METH_KEYWORDS),
-        ADD_METHOD(to_logsignature, METH_O),
-        ADD_METHOD(lie_to_tensor, METH_O),
-        ADD_METHOD(tensor_to_lie, METH_O),
-        ADD_METHOD(zero_lie, METH_VARARGS | METH_KEYWORDS),
-        {"__enter__", (PyCFunction) &RPyContext_enter,  METH_NOARGS, nullptr},
-        { "__exit__",  (PyCFunction) &RPyContext_exit, METH_VARARGS, nullptr},
-        {    nullptr,                         nullptr,            0, nullptr}
+    ADD_METHOD(lie_size, METH_VARARGS | METH_KEYWORDS),
+    ADD_METHOD(tensor_size, METH_VARARGS | METH_KEYWORDS),
+    ADD_METHOD(cbh, METH_VARARGS | METH_KEYWORDS),
+    ADD_METHOD(compute_signature, METH_VARARGS | METH_KEYWORDS),
+    ADD_METHOD(to_logsignature, METH_O),
+    ADD_METHOD(lie_to_tensor, METH_O),
+    ADD_METHOD(tensor_to_lie, METH_O),
+    ADD_METHOD(zero_lie, METH_VARARGS | METH_KEYWORDS),
+    {"__enter__", (PyCFunction) &RPyContext_enter, METH_NOARGS, nullptr},
+    {"__exit__", (PyCFunction) &RPyContext_exit, METH_VARARGS, nullptr},
+    {nullptr, nullptr, 0, nullptr}
 };
 
 #undef ADD_METHOD
 
-static PyObject* RPyContext_width_getter(PyObject* self)
+static PyObject* RPyContext_width_getter(PyObject * self)
 {
     return PyLong_FromLong(ctx_cast(self)->width());
 }
-static PyObject* RPyContext_depth_getter(PyObject* self)
+static PyObject* RPyContext_depth_getter(PyObject * self)
 {
     return PyLong_FromLong(ctx_cast(self)->depth());
 }
-static PyObject* RPyContext_ctype_getter(PyObject* self)
+static PyObject* RPyContext_ctype_getter(PyObject * self)
 {
     return python::to_ctype_type(ctx_cast(self)->ctype()).release().ptr();
 }
-static PyObject* RPyContext_lie_basis_getter(PyObject* self)
+static PyObject* RPyContext_lie_basis_getter(PyObject * self)
 {
     return python::cast_to_object(ctx_cast(self)->get_lie_basis());
 }
-static PyObject* RPyContext_tensor_basis_getter(PyObject* self)
+static PyObject* RPyContext_tensor_basis_getter(PyObject * self)
 {
     return python::cast_to_object(ctx_cast(self)->get_tensor_basis());
 }
@@ -320,17 +364,17 @@ static PyObject* RPyContext_tensor_basis_getter(PyObject* self)
     }
 
 static PyGetSetDef RPyContext_getset[] = {
-        ADD_GETSET(width),
-        ADD_GETSET(depth),
-        ADD_GETSET(ctype),
-        ADD_GETSET(lie_basis),
-        ADD_GETSET(tensor_basis),
-        {nullptr, nullptr, nullptr, nullptr, nullptr}
+    ADD_GETSET(width),
+    ADD_GETSET(depth),
+    ADD_GETSET(ctype),
+    ADD_GETSET(lie_basis),
+    ADD_GETSET(tensor_basis),
+    {nullptr, nullptr, nullptr, nullptr, nullptr}
 };
 
 #undef ADD_GETSET
 
-static PyObject* RPyContext_repr(PyObject* self)
+static PyObject* RPyContext_repr(PyObject * self)
 {
     const auto& ctx = ctx_cast(self);
     std::stringstream ss;
@@ -338,18 +382,18 @@ static PyObject* RPyContext_repr(PyObject* self)
        << ", ctype=" << ctx->ctype()->name() << ')';
     return PyUnicode_FromString(ss.str().c_str());
 }
-static PyObject* RPyContext_str(PyObject* self)
+static PyObject* RPyContext_str(PyObject * self)
 {
     return RPyContext_repr(self);
 }
 
 RPY_UNUSED static PyObject*
-RPyContext_new(PyObject* self, PyObject* args, PyObject* kwargs)
+RPyContext_new(PyObject * self, PyObject * args, PyObject * kwargs)
 {
     RPY_UNREACHABLE_RETURN(nullptr);
 }
 
-static PyObject *
+static PyObject*
     RPyContext_richcompare(PyObject * o1, PyObject * o2, int
 opid ) {
 
@@ -381,44 +425,44 @@ return nullptr;
 
 static const char* CONTEXT_DOC = R"rpydoc()rpydoc";
 PyTypeObject rpy::python::RPyContext_Type = {
-        PyVarObject_HEAD_INIT(nullptr, 0)         //
-        "_roughpy.Context",                       /* tp_name */
-        sizeof(python::RPyContext),               /* tp_basicsize */
-        0,                                        /* tp_itemsize */
-        nullptr,                                  /* tp_dealloc */
-        0,                                        /* tp_vectorcall_offset */
-        (getattrfunc) nullptr,                    /* tp_getattr */
-        (setattrfunc) nullptr,                    /* tp_setattr */
-        nullptr,                                  /* tp_as_async */
-        (reprfunc) RPyContext_repr,               /* tp_repr */
-        nullptr,                                  /* tp_as_number */
-        nullptr,                                  /* tp_as_sequence */
-        nullptr,                                  /* tp_as_mapping */
-        nullptr,                                  /* tp_hash */
-        nullptr,                                  /* tp_call */
-        (reprfunc) RPyContext_str,                /* tp_str */
-        nullptr,                                  /* tp_getattro */
-        (setattrofunc) nullptr,                   /* tp_setattro */
-        (PyBufferProcs*) nullptr,                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-        CONTEXT_DOC,                              /* tp_doc */
-        nullptr,                                  /* tp_traverse */
-        nullptr,                                  /* tp_clear */
-        RPyContext_richcompare,                   /* tp_richcompare */
-        0,                                        /* tp_weaklistoffset */
-        (getiterfunc) nullptr,                    /* tp_iter */
-        nullptr,                                  /* tp_iternext */
-        RPyContext_members,                       /* tp_methods */
-        nullptr,                                  /* tp_members */
-        RPyContext_getset,                        /* tp_getset */
-        nullptr,                                  /* tp_base */
-        nullptr,                                  /* tp_dict */
-        nullptr,                                  /* tp_descr_get */
-        nullptr,                                  /* tp_descr_set */
-        0,                                        /* tp_dictoffset */
-        (initproc) nullptr,                       /* tp_init */
-        nullptr,                                  /* tp_alloc */
-        PyType_GenericNew,                        /* tp_new */
+    PyVarObject_HEAD_INIT(nullptr, 0)         //
+    "_roughpy.Context",                       /* tp_name */
+    sizeof(python::RPyContext),               /* tp_basicsize */
+    0,                                        /* tp_itemsize */
+    nullptr,                                  /* tp_dealloc */
+    0,                                        /* tp_vectorcall_offset */
+    (getattrfunc) nullptr,                    /* tp_getattr */
+    (setattrfunc) nullptr,                    /* tp_setattr */
+    nullptr,                                  /* tp_as_async */
+    (reprfunc) RPyContext_repr,               /* tp_repr */
+    nullptr,                                  /* tp_as_number */
+    nullptr,                                  /* tp_as_sequence */
+    nullptr,                                  /* tp_as_mapping */
+    nullptr,                                  /* tp_hash */
+    nullptr,                                  /* tp_call */
+    (reprfunc) RPyContext_str,                /* tp_str */
+    nullptr,                                  /* tp_getattro */
+    (setattrofunc) nullptr,                   /* tp_setattro */
+    (PyBufferProcs*) nullptr,                 /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
+    CONTEXT_DOC,                              /* tp_doc */
+    nullptr,                                  /* tp_traverse */
+    nullptr,                                  /* tp_clear */
+    RPyContext_richcompare,                   /* tp_richcompare */
+    0,                                        /* tp_weaklistoffset */
+    (getiterfunc) nullptr,                    /* tp_iter */
+    nullptr,                                  /* tp_iternext */
+    RPyContext_members,                       /* tp_methods */
+    nullptr,                                  /* tp_members */
+    RPyContext_getset,                        /* tp_getset */
+    nullptr,                                  /* tp_base */
+    nullptr,                                  /* tp_dict */
+    nullptr,                                  /* tp_descr_get */
+    nullptr,                                  /* tp_descr_set */
+    0,                                        /* tp_dictoffset */
+    (initproc) nullptr,                       /* tp_init */
+    nullptr,                                  /* tp_alloc */
+    PyType_GenericNew,                        /* tp_new */
 };
 }
 
@@ -458,22 +502,22 @@ PyTypeObject rpy::python::RPyContext_Type = {
 PyObject* python::RPyContext_FromContext(algebra::context_pointer ctx)
 {
     auto* new_ctx = reinterpret_cast<RPyContext*>(
-            RPyContext_Type.tp_alloc(&RPyContext_Type, 0)
+        RPyContext_Type.tp_alloc(&RPyContext_Type, 0)
     );
     new_ctx->p_ctx = std::move(ctx);
     return reinterpret_cast<PyObject*>(new_ctx);
 }
 
 static py::handle py_get_context(
-        deg_t width,
-        deg_t depth,
-        const py::object& ctype,
-        const py::kwargs& kwargs
+    deg_t width,
+    deg_t depth,
+    const py::object& ctype,
+    const py::kwargs& kwargs
 )
 {
     // TODO: Make this accept extra arguments.
     return python::RPyContext_FromContext(
-            get_context(width, depth, python::to_stype_ptr(ctype), {})
+        get_context(width, depth, python::to_stype_ptr(ctype), {})
     );
 }
 


### PR DESCRIPTION
Fixed a couple of problems resulting from the (lack of) default arguments for the basis.size method and context.(tensor|lie)_size method.

Both methods now have a default argument which queries the size at the maximum degree of the algebra. If the user requests an degree larger than the depth, an exception is thrown. If the requested degree is negative, the maximum degree is requested.

Closes #75 and closes #76 