### PR TITLE
Fix unknown keyword arguments not flagged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ build-backend = "scikit_build_core.build"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+filterwarnings = ["ignore::DeprecationWarning"]
 
 
 [tool.scikit-build]

--- a/roughpy/CMakeLists.txt
+++ b/roughpy/CMakeLists.txt
@@ -97,6 +97,8 @@ target_sources(RoughPy_PyModule PRIVATE
         src/args/kwargs_to_vector_construction.h
         src/args/numpy.cpp
         src/args/numpy.h
+        src/args/parse_algebra_configuration.cpp
+        src/args/parse_algebra_configuration.h
         src/args/parse_schema.cpp
         src/args/parse_schema.h
         src/args/strided_copy.cpp

--- a/roughpy/CMakeLists.txt
+++ b/roughpy/CMakeLists.txt
@@ -87,6 +87,7 @@ target_sources(RoughPy_PyModule PRIVATE
         src/algebra/tensor_key.h
         src/algebra/tensor_key_iterator.cpp
         src/algebra/tensor_key_iterator.h
+        src/args/check_for_excess_args.cpp
         src/args/convert_timestamp.cpp
         src/args/convert_timestamp.h
         src/args/dlpack_helpers.cpp

--- a/roughpy/src/algebra/context.cpp
+++ b/roughpy/src/algebra/context.cpp
@@ -44,78 +44,88 @@ using rpy::python::RPyContext;
 extern "C" {
 
 static const char* lie_size_DOC = R"rpydoc()rpydoc";
-static PyObject* RPyContext_lie_size(PyObject * self,
-                                     PyObject * args,
-                                     PyObject * kwargs)
+static PyObject*
+RPyContext_lie_size(PyObject* self, PyObject* args, PyObject* kwargs)
 {
     static const char* kwords[] = {"degree", nullptr};
     const auto& myself = ctx_cast(self);
     const deg_t max_degree = myself->depth();
     deg_t depth = max_degree;
 
-    if (PyArg_ParseTupleAndKeywords(args,
-                                    kwargs,
-                                    "|i",
-                                    const_cast<char**>(kwords),
-                                    &depth) == 0) {
+    if (PyArg_ParseTupleAndKeywords(
+                args,
+                kwargs,
+                "|i",
+                const_cast<char**>(kwords),
+                &depth
+        )
+        == 0) {
         return nullptr;
     }
 
     if (depth < 0) {
         depth = max_degree;
     } else if (depth > max_degree) {
-        PyErr_SetString(PyExc_ValueError, "the requested degree exceeds the"
-                                          " maximum degree for this basis");
+        PyErr_SetString(
+                PyExc_ValueError,
+                "the requested degree exceeds the"
+                " maximum degree for this basis"
+        );
         return nullptr;
     }
     return PyLong_FromSize_t(myself->lie_size(depth));
 }
 static const char* tensor_size_DOC = R"rpydoc()rpydoc";
-static PyObject* RPyContext_tensor_size(PyObject * self,
-                                        PyObject * args,
-                                        PyObject * kwargs)
+static PyObject*
+RPyContext_tensor_size(PyObject* self, PyObject* args, PyObject* kwargs)
 {
     static const char* kwords[] = {"degree", nullptr};
     const auto& myself = ctx_cast(self);
     const deg_t max_degree = myself->depth();
     deg_t depth = max_degree;
 
-    if (PyArg_ParseTupleAndKeywords(args,
-                                    kwargs,
-                                    "|i",
-                                    const_cast<char**>(kwords),
-                                    &depth) == 0) {
+    if (PyArg_ParseTupleAndKeywords(
+                args,
+                kwargs,
+                "|i",
+                const_cast<char**>(kwords),
+                &depth
+        )
+        == 0) {
         return nullptr;
     }
 
     if (depth < 0) {
         depth = max_degree;
     } else if (depth > max_degree) {
-        PyErr_SetString(PyExc_ValueError, "the requested degree exceeds the"
-                                          " maximum degree for this basis");
+        PyErr_SetString(
+                PyExc_ValueError,
+                "the requested degree exceeds the"
+                " maximum degree for this basis"
+        );
         return nullptr;
     }
     return PyLong_FromSize_t(myself->tensor_size(depth));
 }
 static const char* cbh_DOC = R"rpydoc()rpydoc";
 static PyObject*
-RPyContext_cbh(PyObject * self, PyObject * args, PyObject * kwargs)
+RPyContext_cbh(PyObject* self, PyObject* args, PyObject* kwargs)
 {
     static const char* kwords[] = {"lies", "vec_type", nullptr};
     const auto& ctx = ctx_cast(self);
 
-    PyObject * py_lies = nullptr;
-    PyObject * vtype = nullptr;
+    PyObject* py_lies = nullptr;
+    PyObject* vtype = nullptr;
 
     if (!PyArg_ParseTupleAndKeywords(
-        args,
-        kwargs,
-        "O|O!",
-        const_cast<char**>(kwords),
-        &py_lies,
-        py::type::of<VectorType>().ptr(),
-        &vtype
-    )) {
+                args,
+                kwargs,
+                "O|O!",
+                const_cast<char**>(kwords),
+                &py_lies,
+                py::type::of<VectorType>().ptr(),
+                &vtype
+        )) {
         return nullptr;
     }
 
@@ -133,7 +143,7 @@ RPyContext_cbh(PyObject * self, PyObject * args, PyObject * kwargs)
             return python::cast_to_object(ctx->zero_lie(VectorType::Sparse));
         }
         return python::cast_to_object(
-            ctx->zero_lie(py::handle(vtype).cast<VectorType>())
+                ctx->zero_lie(py::handle(vtype).cast<VectorType>())
         );
     }
 
@@ -144,9 +154,7 @@ RPyContext_cbh(PyObject * self, PyObject * args, PyObject * kwargs)
 }
 static const char* compute_signature_DOC = R"rpydoc()rpydoc";
 static PyObject*
-RPyContext_compute_signature(PyObject * self,
-                             PyObject * args,
-                             PyObject * kwargs)
+RPyContext_compute_signature(PyObject* self, PyObject* args, PyObject* kwargs)
 {
     static const char* kwords[] = {"data", "vtype", nullptr};
     const auto& ctx = ctx_cast(self);
@@ -155,14 +163,14 @@ RPyContext_compute_signature(PyObject * self,
     py::handle py_vtype;
 
     if (!PyArg_ParseTupleAndKeywords(
-        args,
-        kwargs,
-        "O|O!",
-        const_cast<char**>(kwords),
-        py_data.ptr(),
-        py::type::of<VectorType>().ptr(),
-        py_vtype.ptr()
-    )) {
+                args,
+                kwargs,
+                "O|O!",
+                const_cast<char**>(kwords),
+                py_data.ptr(),
+                py::type::of<VectorType>().ptr(),
+                py_vtype.ptr()
+        )) {
         return nullptr;
     }
 
@@ -214,9 +222,10 @@ RPyContext_compute_signature(PyObject * self,
         request.data_stream.reserve_size(n_increments);
         for (dimn_t i = 0; i < n_increments; ++i) {
             request.data_stream.push_back(scalars::ScalarArray{
-                ctype,
-                p_buffer + i * width * itemsize,
-                width});
+                    ctype,
+                    p_buffer + i * width * itemsize,
+                    width
+            });
         }
     } else {
         request.data_stream.reserve_size(options.shape.size());
@@ -226,9 +235,10 @@ RPyContext_compute_signature(PyObject * self,
         auto n_increments = options.shape.size();
         for (dimn_t i = 0; i < n_increments; ++i) {
             request.data_stream.push_back(scalars::ScalarArray{
-                ctype,
-                p_buffer,
-                static_cast<dimn_t>(options.shape[i])});
+                    ctype,
+                    p_buffer,
+                    static_cast<dimn_t>(options.shape[i])
+            });
             request.key_stream.push_back(p_keys);
             p_buffer += options.shape[i] * itemsize;
             p_keys += options.shape[i];
@@ -238,7 +248,7 @@ RPyContext_compute_signature(PyObject * self,
     return python::cast_to_object(ctx->signature(request));
 }
 static const char* to_logsignature_DOC = R"rpydoc()rpydoc";
-static PyObject* RPyContext_to_logsignature(PyObject * self, PyObject * arg)
+static PyObject* RPyContext_to_logsignature(PyObject* self, PyObject* arg)
 {
 
     py::handle py_sig(arg);
@@ -254,7 +264,7 @@ static PyObject* RPyContext_to_logsignature(PyObject * self, PyObject * arg)
     return python::cast_to_object(ctx->tensor_to_lie(sig.log()));
 }
 static const char* lie_to_tensor_DOC = R"rpydoc()rpydoc";
-static PyObject* RPyContext_lie_to_tensor(PyObject * self, PyObject * arg)
+static PyObject* RPyContext_lie_to_tensor(PyObject* self, PyObject* arg)
 {
     py::handle py_lie(arg);
     if (!py::isinstance<algebra::Lie>(py_lie)) {
@@ -267,7 +277,7 @@ static PyObject* RPyContext_lie_to_tensor(PyObject * self, PyObject * arg)
     );
 }
 static const char* tensor_to_lie_DOC = R"rpydoc()rpydoc";
-static PyObject* RPyContext_tensor_to_lie(PyObject * self, PyObject * arg)
+static PyObject* RPyContext_tensor_to_lie(PyObject* self, PyObject* arg)
 {
     py::handle py_ft(arg);
     if (!py::isinstance<algebra::FreeTensor>(py_ft)) {
@@ -277,35 +287,35 @@ static PyObject* RPyContext_tensor_to_lie(PyObject * self, PyObject * arg)
 
     const auto& ctx = ctx_cast(self);
     return python::cast_to_object(
-        ctx->tensor_to_lie(py_ft.cast<const FreeTensor&>())
+            ctx->tensor_to_lie(py_ft.cast<const FreeTensor&>())
     );
 }
 
-static PyObject* RPyContext_enter(PyObject * self) { return self; }
+static PyObject* RPyContext_enter(PyObject* self) { return self; }
 
-static PyObject* RPyContext_exit(PyObject * self, PyObject * RPY_UNUSED_VAR)
+static PyObject* RPyContext_exit(PyObject* self, PyObject* RPY_UNUSED_VAR)
 {
     Py_RETURN_NONE;
 }
 
 static const char* zero_lie_DOC
-    = R"rpydoc(Get a new Lie with value zero)rpydoc";
+        = R"rpydoc(Get a new Lie with value zero)rpydoc";
 static PyObject*
-RPyContext_zero_lie(PyObject * self, PyObject * args, PyObject * kwargs)
+RPyContext_zero_lie(PyObject* self, PyObject* args, PyObject* kwargs)
 {
     static const char* kwords[] = {"vtype", nullptr};
     PyTypeObject* vtype_type
-        = reinterpret_cast<PyTypeObject*>(py::type::of<VectorType>().ptr());
+            = reinterpret_cast<PyTypeObject*>(py::type::of<VectorType>().ptr());
 
-    PyObject * py_vtype = nullptr;
+    PyObject* py_vtype = nullptr;
     if (PyArg_ParseTupleAndKeywords(
-        args,
-        kwargs,
-        "|O!",
-        const_cast<char**>(kwords),
-        vtype_type,
-        &py_vtype
-    )
+                args,
+                kwargs,
+                "|O!",
+                const_cast<char**>(kwords),
+                vtype_type,
+                &py_vtype
+        )
         == 0) {
         return nullptr;
     }
@@ -318,63 +328,64 @@ RPyContext_zero_lie(PyObject * self, PyObject * args, PyObject * kwargs)
 
 #define ADD_METHOD(NAME, FLAGS)                                                \
     {                                                                          \
-        #NAME, (PyCFunction) &RPyContext_##NAME, (FLAGS), NAME##_DOC           \
+        #NAME, (PyCFunction) & RPyContext_##NAME, (FLAGS), NAME##_DOC          \
     }
 
 static PyMethodDef RPyContext_members[] = {
-    ADD_METHOD(lie_size, METH_VARARGS | METH_KEYWORDS),
-    ADD_METHOD(tensor_size, METH_VARARGS | METH_KEYWORDS),
-    ADD_METHOD(cbh, METH_VARARGS | METH_KEYWORDS),
-    ADD_METHOD(compute_signature, METH_VARARGS | METH_KEYWORDS),
-    ADD_METHOD(to_logsignature, METH_O),
-    ADD_METHOD(lie_to_tensor, METH_O),
-    ADD_METHOD(tensor_to_lie, METH_O),
-    ADD_METHOD(zero_lie, METH_VARARGS | METH_KEYWORDS),
-    {"__enter__", (PyCFunction) &RPyContext_enter, METH_NOARGS, nullptr},
-    {"__exit__", (PyCFunction) &RPyContext_exit, METH_VARARGS, nullptr},
-    {nullptr, nullptr, 0, nullptr}
+        ADD_METHOD(lie_size, METH_VARARGS | METH_KEYWORDS),
+        ADD_METHOD(tensor_size, METH_VARARGS | METH_KEYWORDS),
+        ADD_METHOD(cbh, METH_VARARGS | METH_KEYWORDS),
+        ADD_METHOD(compute_signature, METH_VARARGS | METH_KEYWORDS),
+        ADD_METHOD(to_logsignature, METH_O),
+        ADD_METHOD(lie_to_tensor, METH_O),
+        ADD_METHOD(tensor_to_lie, METH_O),
+        ADD_METHOD(zero_lie, METH_VARARGS | METH_KEYWORDS),
+        {"__enter__", (PyCFunction) &RPyContext_enter,  METH_NOARGS, nullptr},
+        { "__exit__",  (PyCFunction) &RPyContext_exit, METH_VARARGS, nullptr},
+        {    nullptr,                         nullptr,            0, nullptr}
 };
 
 #undef ADD_METHOD
 
-static PyObject* RPyContext_width_getter(PyObject * self)
+static PyObject* RPyContext_width_getter(PyObject* self)
 {
     return PyLong_FromLong(ctx_cast(self)->width());
 }
-static PyObject* RPyContext_depth_getter(PyObject * self)
+static PyObject* RPyContext_depth_getter(PyObject* self)
 {
     return PyLong_FromLong(ctx_cast(self)->depth());
 }
-static PyObject* RPyContext_ctype_getter(PyObject * self)
+static PyObject* RPyContext_ctype_getter(PyObject* self)
 {
     return python::to_ctype_type(ctx_cast(self)->ctype()).release().ptr();
 }
-static PyObject* RPyContext_lie_basis_getter(PyObject * self)
+static PyObject* RPyContext_lie_basis_getter(PyObject* self)
 {
     return python::cast_to_object(ctx_cast(self)->get_lie_basis());
 }
-static PyObject* RPyContext_tensor_basis_getter(PyObject * self)
+static PyObject* RPyContext_tensor_basis_getter(PyObject* self)
 {
     return python::cast_to_object(ctx_cast(self)->get_tensor_basis());
 }
 
 #define ADD_GETSET(NAME)                                                       \
     {                                                                          \
-        #NAME, (getter) &RPyContext_##NAME##_getter, nullptr, nullptr, nullptr \
+        #NAME, (getter) & RPyContext_##NAME##_getter, nullptr, nullptr,        \
+                nullptr                                                        \
     }
 
 static PyGetSetDef RPyContext_getset[] = {
-    ADD_GETSET(width),
-    ADD_GETSET(depth),
-    ADD_GETSET(ctype),
-    ADD_GETSET(lie_basis),
-    ADD_GETSET(tensor_basis),
-    {nullptr, nullptr, nullptr, nullptr, nullptr}
+        ADD_GETSET(width),
+        ADD_GETSET(depth),
+        ADD_GETSET(ctype),
+        ADD_GETSET(lie_basis),
+        ADD_GETSET(tensor_basis),
+        {nullptr, nullptr, nullptr, nullptr, nullptr}
 };
 
 #undef ADD_GETSET
 
-static PyObject* RPyContext_repr(PyObject * self)
+static PyObject* RPyContext_repr(PyObject* self)
 {
     const auto& ctx = ctx_cast(self);
     std::stringstream ss;
@@ -382,87 +393,76 @@ static PyObject* RPyContext_repr(PyObject * self)
        << ", ctype=" << ctx->ctype()->name() << ')';
     return PyUnicode_FromString(ss.str().c_str());
 }
-static PyObject* RPyContext_str(PyObject * self)
+static PyObject* RPyContext_str(PyObject* self)
 {
     return RPyContext_repr(self);
 }
 
 RPY_UNUSED static PyObject*
-RPyContext_new(PyObject * self, PyObject * args, PyObject * kwargs)
+RPyContext_new(PyObject* self, PyObject* args, PyObject* kwargs)
 {
     RPY_UNREACHABLE_RETURN(nullptr);
 }
 
-static PyObject*
-    RPyContext_richcompare(PyObject * o1, PyObject * o2, int
-opid ) {
+static PyObject* RPyContext_richcompare(PyObject* o1, PyObject* o2, int opid)
+{
 
-switch ( opid ) {
-case Py_EQ :
-if ( ctx_cast(o1) == ctx_cast(o2)) {
-Py_RETURN_TRUE ;
-}
-Py_RETURN_FALSE;
-case Py_NE:
-if (
-ctx_cast(o1)
-==
-ctx_cast(o2)
-) {
-Py_RETURN_FALSE;
-}
-Py_RETURN_TRUE;
-case Py_LT:
-case Py_LE:
-case Py_GT:
-case Py_GE:
-break;
-}
+    switch (opid) {
+        case Py_EQ:
+            if (ctx_cast(o1) == ctx_cast(o2)) { Py_RETURN_TRUE; }
+            Py_RETURN_FALSE;
+        case Py_NE:
+            if (ctx_cast(o1) == ctx_cast(o2)) { Py_RETURN_FALSE; }
+            Py_RETURN_TRUE;
+        case Py_LT:
+        case Py_LE:
+        case Py_GT:
+        case Py_GE: break;
+    }
 
-return nullptr;
+    return nullptr;
 }
-
 
 static const char* CONTEXT_DOC = R"rpydoc()rpydoc";
 PyTypeObject rpy::python::RPyContext_Type = {
-    PyVarObject_HEAD_INIT(nullptr, 0)         //
-    "_roughpy.Context",                       /* tp_name */
-    sizeof(python::RPyContext),               /* tp_basicsize */
-    0,                                        /* tp_itemsize */
-    nullptr,                                  /* tp_dealloc */
-    0,                                        /* tp_vectorcall_offset */
-    (getattrfunc) nullptr,                    /* tp_getattr */
-    (setattrfunc) nullptr,                    /* tp_setattr */
-    nullptr,                                  /* tp_as_async */
-    (reprfunc) RPyContext_repr,               /* tp_repr */
-    nullptr,                                  /* tp_as_number */
-    nullptr,                                  /* tp_as_sequence */
-    nullptr,                                  /* tp_as_mapping */
-    nullptr,                                  /* tp_hash */
-    nullptr,                                  /* tp_call */
-    (reprfunc) RPyContext_str,                /* tp_str */
-    nullptr,                                  /* tp_getattro */
-    (setattrofunc) nullptr,                   /* tp_setattro */
-    (PyBufferProcs*) nullptr,                 /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-    CONTEXT_DOC,                              /* tp_doc */
-    nullptr,                                  /* tp_traverse */
-    nullptr,                                  /* tp_clear */
-    RPyContext_richcompare,                   /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    (getiterfunc) nullptr,                    /* tp_iter */
-    nullptr,                                  /* tp_iternext */
-    RPyContext_members,                       /* tp_methods */
-    nullptr,                                  /* tp_members */
-    RPyContext_getset,                        /* tp_getset */
-    nullptr,                                  /* tp_base */
-    nullptr,                                  /* tp_dict */
-    nullptr,                                  /* tp_descr_get */
-    nullptr,                                  /* tp_descr_set */
-    0,                                        /* tp_dictoffset */
-    (initproc) nullptr,                       /* tp_init */
-    nullptr,                                  /* tp_alloc */
-    PyType_GenericNew,                        /* tp_new */
+        PyVarObject_HEAD_INIT(nullptr, 0)         //
+        "_roughpy.Context",                       /* tp_name */
+        sizeof(python::RPyContext),               /* tp_basicsize */
+        0,                                        /* tp_itemsize */
+        nullptr,                                  /* tp_dealloc */
+        0,                                        /* tp_vectorcall_offset */
+        (getattrfunc) nullptr,                    /* tp_getattr */
+        (setattrfunc) nullptr,                    /* tp_setattr */
+        nullptr,                                  /* tp_as_async */
+        (reprfunc) RPyContext_repr,               /* tp_repr */
+        nullptr,                                  /* tp_as_number */
+        nullptr,                                  /* tp_as_sequence */
+        nullptr,                                  /* tp_as_mapping */
+        nullptr,                                  /* tp_hash */
+        nullptr,                                  /* tp_call */
+        (reprfunc) RPyContext_str,                /* tp_str */
+        nullptr,                                  /* tp_getattro */
+        (setattrofunc) nullptr,                   /* tp_setattro */
+        (PyBufferProcs*) nullptr,                 /* tp_as_buffer */
+        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
+        CONTEXT_DOC,                              /* tp_doc */
+        nullptr,                                  /* tp_traverse */
+        nullptr,                                  /* tp_clear */
+        RPyContext_richcompare,                   /* tp_richcompare */
+        0,                                        /* tp_weaklistoffset */
+        (getiterfunc) nullptr,                    /* tp_iter */
+        nullptr,                                  /* tp_iternext */
+        RPyContext_members,                       /* tp_methods */
+        nullptr,                                  /* tp_members */
+        RPyContext_getset,                        /* tp_getset */
+        nullptr,                                  /* tp_base */
+        nullptr,                                  /* tp_dict */
+        nullptr,                                  /* tp_descr_get */
+        nullptr,                                  /* tp_descr_set */
+        0,                                        /* tp_dictoffset */
+        (initproc) nullptr,                       /* tp_init */
+        nullptr,                                  /* tp_alloc */
+        PyType_GenericNew,                        /* tp_new */
 };
 }
 
@@ -502,22 +502,22 @@ PyTypeObject rpy::python::RPyContext_Type = {
 PyObject* python::RPyContext_FromContext(algebra::context_pointer ctx)
 {
     auto* new_ctx = reinterpret_cast<RPyContext*>(
-        RPyContext_Type.tp_alloc(&RPyContext_Type, 0)
+            RPyContext_Type.tp_alloc(&RPyContext_Type, 0)
     );
     new_ctx->p_ctx = std::move(ctx);
     return reinterpret_cast<PyObject*>(new_ctx);
 }
 
 static py::handle py_get_context(
-    deg_t width,
-    deg_t depth,
-    const py::object& ctype,
-    const py::kwargs& kwargs
+        deg_t width,
+        deg_t depth,
+        const py::object& ctype,
+        const py::kwargs& kwargs
 )
 {
     // TODO: Make this accept extra arguments.
     return python::RPyContext_FromContext(
-        get_context(width, depth, python::to_stype_ptr(ctype), {})
+            get_context(width, depth, python::to_stype_ptr(ctype), {})
     );
 }
 

--- a/roughpy/src/args/check_for_excess_args.cpp
+++ b/roughpy/src/args/check_for_excess_args.cpp
@@ -1,0 +1,28 @@
+//
+// Created by sam on 2/22/24.
+//
+
+#include "roughpy_module.h"
+
+#include <sstream>
+
+using namespace rpy;
+
+void rpy::python::check_for_excess_arguments(const py::kwargs& kwargs)
+{
+
+    if (!kwargs.empty()) {
+        std::stringstream ss;
+        ss << "unrecognised keyword arguments provided:\n";
+        bool first = true;
+        for (auto item : kwargs) {
+            if (!first) {
+                ss << ", ";
+                first = false;
+            }
+            ss << item.first;
+        }
+
+        RPY_THROW(py::key_error, ss.str().c_str());
+    }
+}

--- a/roughpy/src/args/kwargs_to_path_metadata.cpp
+++ b/roughpy/src/args/kwargs_to_path_metadata.cpp
@@ -26,7 +26,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "kwargs_to_path_metadata.h"
-
+#include "parse_algebra_configuration.h"
 
 #include "algebra/context.h"
 #include "scalars/scalar_type.h"
@@ -39,41 +39,53 @@
 
 using namespace rpy;
 
-python::PyStreamMetaData
-python::kwargs_to_metadata(const pybind11::kwargs& kwargs)
+python::PyStreamMetaData python::kwargs_to_metadata(pybind11::kwargs& kwargs)
 {
 
     PyStreamMetaData md{
-            0,                              // width
-            0,                              // depth
-            {},                             // support
-            nullptr,                        // context
-            nullptr,                        // scalar type
-            {},                             // vector type
-            {},                              // default resolution
-            intervals::IntervalType::Clopen,// interval type
-            nullptr,                        // schema
-            false                           // include_param_as_data
+            0,                                   // width
+            0,                                   // depth
+            {},                                  // support
+            nullptr,                             // context
+            nullptr,                             // scalar type
+            {},                                  // vector type
+            {},                                  // default resolution
+            intervals::IntervalType::Clopen,     // interval type
+            nullptr,                             // schema
+            rpy::streams::ChannelType::Increment,// default channel type
+            false                                // include_param_as_data
     };
 
     streams::ChannelType ch_type;
 
     if (kwargs.contains("schema")) {
-        auto schema = kwargs["schema"];
+        auto schema = kwargs_pop(kwargs, "schema");
         if (py::isinstance<streams::StreamSchema>(schema)) {
             md.schema = schema.cast<std::shared_ptr<streams::StreamSchema>>();
         } else {
             md.schema = parse_schema(schema);
         }
-        if (!md.schema->is_final()) { md.schema->finalize(); }
-    } else if (kwargs.contains("channel_types")) {
-        auto channels = kwargs["channel_types"];
+        if (!md.schema->is_final()) { md.schema->finalize(0); }
+    }
+
+    if (kwargs.contains("channel_types")) {
+        if (md.schema && md.schema->is_final()) {
+            PyErr_WarnEx(
+                    PyExc_RuntimeWarning,
+                    "specifying both a finalized schema and "
+                    "\"channel_types\" ignores "
+                    "the \"channel_types\" argument",
+                    1
+            );
+        }
+        auto channels = kwargs_pop(kwargs, "channel_types");
 
         // homogeneous channel types
         if (py::isinstance<streams::ChannelType>(channels)) {
-            ch_type = channels.cast<streams::ChannelType>();
+            md.default_channel_type = channels.cast<streams::ChannelType>();
         } else if (py::isinstance<py::str>(channels)) {
-            ch_type = string_to_channel_type(channels.cast<string>());
+            md.default_channel_type
+                    = string_to_channel_type(channels.cast<string>());
 
             // labelled heterogeneous channel types
         } else if (py::isinstance<py::dict>(channels)) {
@@ -126,77 +138,17 @@ python::kwargs_to_metadata(const pybind11::kwargs& kwargs)
 
         // Unset channel to, assume homogeneous increments
     } else {
-        ch_type = streams::ChannelType::Increment;
+        md.default_channel_type = streams::ChannelType::Increment;
     }
 
-    if (kwargs.contains("ctx")) {
-        auto ctx = kwargs["ctx"];
-        if (!py::isinstance(
-                    ctx, reinterpret_cast<PyObject*>(&RPyContext_Type)
-            )) {
-            RPY_THROW(py::type_error, "expected a Context object");
-        }
-        md.ctx = python::ctx_cast(ctx.ptr());
-        md.width = md.ctx->width();
-        md.scalar_type = md.ctx->ctype();
-
-        if (!md.schema) {
-            md.schema = std::make_shared<streams::StreamSchema>();
-            for (deg_t i = 0; i < md.width; ++i) {
-                switch (ch_type) {
-                    case streams::ChannelType::Increment:
-                        md.schema->insert_increment("");
-                        break;
-                    case streams::ChannelType::Value:
-                        md.schema->insert_value("");
-                        break;
-                    case streams::ChannelType::Categorical:
-                        md.schema->insert_categorical("");
-                        break;
-                    case streams::ChannelType::Lie:
-                        md.schema->insert_lie("");
-                        break;
-                }
-            }
-        }
-
-        auto schema_width = static_cast<deg_t>(md.schema->width());
-        if (schema_width != md.width) {
-            md.width = schema_width;
-            md.ctx = md.ctx->get_alike(
-                    md.width, md.ctx->depth(), md.scalar_type
-            );
-        }
-    } else {
-        if (md.schema) {
-            md.width = static_cast<deg_t>(md.schema->width());
-        } else if (kwargs.contains("width")) {
-            md.width = kwargs["width"].cast<rpy::deg_t>();
-        }
-
-        if (kwargs.contains("depth")) {
-            md.depth = kwargs["depth"].cast<rpy::deg_t>();
-        }
-        if (kwargs.contains("dtype")) {
-            auto dtype = kwargs["dtype"];
-#ifdef ROUGHPY_WITH_NUMPY
-            if (py::isinstance<py::dtype>(dtype)) {
-                md.scalar_type = npy_dtype_to_ctype(dtype);
-            } else {
-                md.scalar_type = py_arg_to_ctype(dtype);
-            }
-#else
-            md.scalar_type = py_arg_to_ctype(dtype);
-#endif
-        }
+    if (!md.schema) {
+        // No schema was given, but a width was given so construct an empty
+        // Schema.
+        md.schema = std::make_shared<streams::StreamSchema>();
     }
 
     if (kwargs.contains("include_time")
-        && kwargs["include_time"].cast<bool>()) {
-
-        if (!md.schema) {
-            md.schema = std::make_shared<streams::StreamSchema>();
-        }
+        && kwargs_pop(kwargs, "include_time").cast<bool>()) {
 
         if (md.schema->is_final()) {
             RPY_THROW(
@@ -210,16 +162,46 @@ python::kwargs_to_metadata(const pybind11::kwargs& kwargs)
         md.include_param_as_data = true;
     }
 
+    // Now parse the algebra config
+    auto algebra_config = parse_algebra_configuration(kwargs);
+
+    if (algebra_config.ctx) {
+        md.ctx = std::move(algebra_config.ctx);
+        md.width = md.ctx->width();
+        md.scalar_type = md.ctx->ctype();
+    } else {
+        if (algebra_config.width) { md.width = *algebra_config.width; }
+        if (algebra_config.depth) { md.depth = *algebra_config.depth; }
+        if (algebra_config.scalar_type != nullptr) {
+            md.scalar_type = algebra_config.scalar_type;
+        }
+    }
+
+    if (md.schema->is_final()) {
+        if (!algebra_config.width) {
+            algebra_config.width = md.schema->width();
+            RPY_DBG_ASSERT(md.width == 0);
+            md.width = *algebra_config.width;
+        } else if (md.schema->width() != *algebra_config.width) {
+            RPY_THROW(
+                    py::value_error,
+                    "specified width does not match the schema width"
+            );
+        }
+    }
+
+    // Additional information that will not effect the algebra config.
     if (kwargs.contains("vtype")) {
-        md.vector_type = kwargs["vtype"].cast<algebra::VectorType>();
+        md.vector_type
+                = kwargs_pop(kwargs, "vtype").cast<algebra::VectorType>();
     }
 
     if (kwargs.contains("resolution")) {
-        md.resolution = kwargs["resolution"].cast<resolution_t>();
+        md.resolution = kwargs_pop(kwargs, "resolution").cast<resolution_t>();
     }
 
     if (kwargs.contains("support")) {
-        auto support = kwargs["support"];
+        auto support = kwargs_pop(kwargs, "support");
         if (!py::isinstance<intervals::Interval>(support)) {
             md.support = intervals::RealInterval(
                     support.cast<const intervals::Interval&>()

--- a/roughpy/src/args/kwargs_to_path_metadata.h
+++ b/roughpy/src/args/kwargs_to_path_metadata.h
@@ -46,11 +46,11 @@ struct PyStreamMetaData {
     optional<resolution_t> resolution;
     intervals::IntervalType interval_type;
     std::shared_ptr<streams::StreamSchema> schema;
+    streams::ChannelType default_channel_type;
     bool include_param_as_data;
 };
 
-PyStreamMetaData kwargs_to_metadata(const py::kwargs& kwargs);
-
+PyStreamMetaData kwargs_to_metadata(py::kwargs& kwargs);
 
 resolution_t param_to_resolution(param_t accuracy) noexcept;
 

--- a/roughpy/src/args/kwargs_to_vector_construction.cpp
+++ b/roughpy/src/args/kwargs_to_vector_construction.cpp
@@ -84,5 +84,8 @@ python::kwargs_to_construction_data(pybind11::kwargs& kwargs)
         );
     }
 
+    // we should now have consumed all the the kwargs. Run the check
+    python::check_for_excess_arguments(kwargs);
+
     return helper;
 }

--- a/roughpy/src/args/kwargs_to_vector_construction.cpp
+++ b/roughpy/src/args/kwargs_to_vector_construction.cpp
@@ -80,7 +80,9 @@ python::kwargs_to_construction_data(pybind11::kwargs& kwargs)
 
     if (helper.width != 0 && helper.depth != 0 && helper.ctype != nullptr) {
         helper.ctx = algebra::get_context(
-                helper.width, helper.depth, helper.ctype
+                helper.width,
+                helper.depth,
+                helper.ctype
         );
     }
 

--- a/roughpy/src/args/kwargs_to_vector_construction.h
+++ b/roughpy/src/args/kwargs_to_vector_construction.h
@@ -54,8 +54,7 @@ struct PyVectorConstructionHelper {
     /// Data type provided
 };
 
-PyVectorConstructionHelper kwargs_to_construction_data(const py::kwargs& kwargs
-);
+PyVectorConstructionHelper kwargs_to_construction_data(py::kwargs& kwargs);
 
 }// namespace python
 }// namespace rpy

--- a/roughpy/src/args/parse_algebra_configuration.cpp
+++ b/roughpy/src/args/parse_algebra_configuration.cpp
@@ -1,0 +1,109 @@
+//
+// Created by sam on 2/19/24.
+//
+
+#include "parse_algebra_configuration.h"
+
+#include <roughpy/algebra/context.h>
+
+using namespace rpy;
+using namespace rpy::python;
+
+
+AlgebraConfiguration python::parse_algebra_configuration(py::kwargs& kwargs)
+{
+    AlgebraConfiguration result;
+    bool warned = false;
+
+    static constexpr const char* ctx_kwords[] = {
+        "ctx",
+        "context"
+    };
+    const char* ctx_name = nullptr;
+
+    for (const auto* name : ctx_kwords) {
+        if (kwargs.contains(name)) {
+            ctx_name = name;
+            auto ctx = kwargs_pop(kwargs, name);
+            result.ctx = ctx_cast(ctx.ptr());
+            break;
+        }
+    }
+
+    static constexpr const char* width_kword = "width";
+
+    if (kwargs.contains(width_kword)) {
+        result.width = kwargs_pop(kwargs, width_kword).cast<deg_t>();
+        if (result.ctx) {
+            PyErr_WarnFormat(PyExc_RuntimeWarning,
+                             1,
+                             "providing both \"%s\" and \"width\" "
+                             "ignores the \"width\" parameter. "
+                             "Note that the \"width\" parameter is deprecated,"
+                             "and you should use the \"ctx\" argument instead.",
+                             ctx_name);
+            warned = true;
+        }
+        if (!warned) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "using the \"width\" keyword argument is deprecated, "
+                         "instead you should use a context and the \"ctx\""
+                         " keyword argument to specify the "
+                         "algebra configuration",
+                         1);
+            warned = true;
+        }
+    }
+
+    static constexpr const char* depth_keyword = "depth";
+    if (kwargs.contains(depth_keyword)) {
+        result.depth = kwargs_pop(kwargs, depth_keyword).cast<deg_t>();
+        if (!warned && result.ctx) {
+            PyErr_WarnFormat(PyExc_RuntimeWarning,
+                             1,
+                             "providing both \"%s\" and \"depth\" "
+                             "ignores the \"depth\" parameter. "
+                             "Note that the \"depth\" parameter is deprecated,"
+                             "and you should use the \"ctx\" argument instead.",
+                             ctx_name);
+            warned = true;
+        }
+        if (!warned) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "using the \"depth\" keyword argument is deprecated, "
+                         "instead you should use a context and the \"ctx\""
+                         " keyword argument to specify the "
+                         "algebra configuration",
+                         1);
+            warned = true;
+        }
+    }
+
+    static constexpr const char* coeff_kwords[] = {"dtype", "ctype", "coeffs"};
+    for (const auto* name : coeff_kwords) {
+        if (kwargs.contains(name)) {
+            const auto obj = kwargs_pop(kwargs, name);
+            if (!warned && result.ctx) {
+                PyErr_WarnFormat(PyExc_RuntimeWarning,
+                                 1,
+                                 "providing both \"%s\" and \"%s\" "
+                                 "ignores the \"%s\" parameter. "
+                                 "Note that the \"%s\" parameter is deprecated,"
+                                 "and you should use the \"ctx\" argument instead.",
+                                 ctx_name, name, name, name
+                );
+                warned = true;
+            }
+            if (!warned) {
+                PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+                                 "using the \"%s\" keyword argument is deprecated, "
+                                 "instead you should use a context and the \"ctx\""
+                                 " keyword argument to specify the "
+                                 "algebra configuration",
+                                 name);
+                warned = true;
+            }
+        }
+    }
+
+}

--- a/roughpy/src/args/parse_algebra_configuration.h
+++ b/roughpy/src/args/parse_algebra_configuration.h
@@ -7,10 +7,9 @@
 
 
 #include "roughpy_module.h"
-#include "algebra/context.h"
-#include "scalars/scalar_type.h"
 
 #include <roughpy/core/types.h>
+#include <roughpy/scalars/scalars_fwd.h>
 #include <roughpy/algebra/context_fwd.h>
 
 namespace rpy {
@@ -20,9 +19,10 @@ struct AlgebraConfiguration {
     algebra::context_pointer ctx;
     optional <deg_t> width;
     optional <deg_t> depth;
-    PyScalarMetaType* scalar_type;
+    const scalars::ScalarType* scalar_type;
 };
 
+RPY_NO_EXPORT
 AlgebraConfiguration parse_algebra_configuration(py::kwargs& kwargs);
 
 }

--- a/roughpy/src/args/parse_algebra_configuration.h
+++ b/roughpy/src/args/parse_algebra_configuration.h
@@ -1,0 +1,31 @@
+//
+// Created by sam on 2/19/24.
+//
+
+#ifndef ROUGHPY_PARSE_ALGEBRA_CONFIGURATION_H
+#define ROUGHPY_PARSE_ALGEBRA_CONFIGURATION_H
+
+
+#include "roughpy_module.h"
+#include "algebra/context.h"
+#include "scalars/scalar_type.h"
+
+#include <roughpy/core/types.h>
+#include <roughpy/algebra/context_fwd.h>
+
+namespace rpy {
+namespace python {
+
+struct AlgebraConfiguration {
+    algebra::context_pointer ctx;
+    optional <deg_t> width;
+    optional <deg_t> depth;
+    PyScalarMetaType* scalar_type;
+};
+
+AlgebraConfiguration parse_algebra_configuration(py::kwargs& kwargs);
+
+}
+}
+
+#endif //ROUGHPY_PARSE_ALGEBRA_CONFIGURATION_H

--- a/roughpy/src/roughpy_module.h
+++ b/roughpy/src/roughpy_module.h
@@ -68,8 +68,7 @@ inline PyObject* cast_to_object(T&& arg) noexcept
     return py::cast(std::forward<T>(arg)).release().ptr();
 }
 
-
-py::object kwargs_pop(py::kwargs& kwargs, const char* name)
+inline py::object kwargs_pop(py::kwargs& kwargs, const char* name)
 {
     auto arg = py::reinterpret_borrow<py::object>(kwargs[name]);
     PyDict_DelItemString(kwargs.ptr(), name);

--- a/roughpy/src/roughpy_module.h
+++ b/roughpy/src/roughpy_module.h
@@ -68,6 +68,15 @@ inline PyObject* cast_to_object(T&& arg) noexcept
     return py::cast(std::forward<T>(arg)).release().ptr();
 }
 
+
+py::object kwargs_pop(py::kwargs& kwargs, const char* name)
+{
+    auto arg = py::reinterpret_borrow<py::object>(kwargs[name]);
+    PyDict_DelItemString(kwargs.ptr(), name);
+    return arg;
+}
+
+
 }// namespace python
 }// namespace rpy
 

--- a/roughpy/src/roughpy_module.h
+++ b/roughpy/src/roughpy_module.h
@@ -75,6 +75,7 @@ inline py::object kwargs_pop(py::kwargs& kwargs, const char* name)
     return arg;
 }
 
+void check_for_excess_arguments(const py::kwargs& kwargs);
 
 }// namespace python
 }// namespace rpy

--- a/roughpy/src/streams/brownian_stream.cpp
+++ b/roughpy/src/streams/brownian_stream.cpp
@@ -45,8 +45,7 @@ using namespace pybind11::literals;
 static const char* BROWNIAN_PATH_DOC = R"rpydoc(A Brownian motion stream.
 )rpydoc";
 
-static py::object
-Brownian_from_generator(const py::args& args, const py::kwargs& kwargs)
+static py::object Brownian_from_generator(py::args args, py::kwargs kwargs)
 {
 
     auto pmd = python::kwargs_to_metadata(kwargs);

--- a/roughpy/src/streams/brownian_stream.cpp
+++ b/roughpy/src/streams/brownian_stream.cpp
@@ -71,6 +71,8 @@ static py::object Brownian_from_generator(py::args args, py::kwargs kwargs)
 
     // TODO: Fix this up properly.
 
+    python::check_for_excess_arguments(kwargs);
+
     streams::StreamMetadata md{
             pmd.width,
             pmd.support ? *pmd.support

--- a/roughpy/src/streams/externally_sourced_stream.cpp
+++ b/roughpy/src/streams/externally_sourced_stream.cpp
@@ -41,6 +41,7 @@
 #include "scalars/scalar_type.h"
 #include "scalars/scalars.h"
 #include "stream.h"
+#include "streams/schema_finalization.h"
 
 #include <boost/url/parse.hpp>
 
@@ -59,7 +60,7 @@ static const char* EXTERNALLY_SOURCED_STREAM_DOC
 )rpydoc";
 
 static py::object
-external_stream_constructor(string uri_string, const py::kwargs& kwargs)
+external_stream_constructor(string uri_string, py::kwargs kwargs)
 {
     auto pmd = python::kwargs_to_metadata(kwargs);
 
@@ -115,7 +116,8 @@ external_stream_constructor(string uri_string, const py::kwargs& kwargs)
     if (pmd.resolution != 0) { factory.set_resolution(*pmd.resolution); }
     if (pmd.support) { factory.set_support(*pmd.support); }
     if (pmd.vector_type) { factory.set_vtype(*pmd.vector_type); }
-    if (pmd.schema) { factory.set_schema(pmd.schema); }
+
+    factory.set_schema(pmd.schema);
 
     PyObject* py_stream = python::RPyStream_FromStream(factory.construct());
 

--- a/roughpy/src/streams/function_stream.cpp
+++ b/roughpy/src/streams/function_stream.cpp
@@ -42,15 +42,18 @@ static const char* FUNC_STREAM_DOC
 )rpydoc";
 
 python::FunctionStream::FunctionStream(
-        py::object fn, python::FunctionStream::FunctionValueType val_type,
+        py::object fn,
+        python::FunctionStream::FunctionValueType val_type,
         streams::StreamMetadata md
 )
-    : DynamicallyConstructedStream(std::move(md)), m_fn(std::move(fn)),
+    : DynamicallyConstructedStream(std::move(md)),
+      m_fn(std::move(fn)),
       m_val_type(val_type)
 {}
 
 algebra::Lie python::FunctionStream::log_signature_impl(
-        const intervals::Interval& interval, const algebra::Context& ctx
+        const intervals::Interval& interval,
+        const algebra::Context& ctx
 ) const
 {
     py::gil_scoped_acquire gil;
@@ -87,22 +90,22 @@ static py::object from_function(py::object fn, py::kwargs kwargs)
     if (pmd.ctx == nullptr && pmd.width != 0 && pmd.depth != 0
         && pmd.scalar_type != nullptr) {
         pmd.ctx = algebra::get_context(
-                pmd.width, pmd.depth, pmd.scalar_type, {}
+                pmd.width,
+                pmd.depth,
+                pmd.scalar_type,
+                {}
         );
     }
 
     // TODO: Fix this up properly.
 
-    intervals::RealInterval effective_support =
-            intervals::RealInterval::unbounded();
-    if (pmd.support) {
-        effective_support = *pmd.support;
-    }
+    intervals::RealInterval effective_support
+            = intervals::RealInterval::unbounded();
+    if (pmd.support) { effective_support = *pmd.support; }
 
-    if (!pmd.resolution) {
-        pmd.resolution = 0;
-    }
+    if (!pmd.resolution) { pmd.resolution = 0; }
 
+    python::check_for_excess_arguments(kwargs);
 
     streams::StreamMetadata md{
             pmd.width,
@@ -110,11 +113,14 @@ static py::object from_function(py::object fn, py::kwargs kwargs)
             pmd.ctx,
             pmd.scalar_type,
             pmd.vector_type ? *pmd.vector_type : algebra::VectorType::Dense,
-            *pmd.resolution};
+            *pmd.resolution
+    };
 
     PyObject* stream = python::RPyStream_FromStream(
             streams::Stream(python::FunctionStream(
-                    std::move(fn), python::FunctionStream::Value, std::move(md)
+                    std::move(fn),
+                    python::FunctionStream::Value,
+                    std::move(md)
             ))
     );
     return py::reinterpret_steal<py::object>(stream);

--- a/roughpy/src/streams/lie_increment_stream.cpp
+++ b/roughpy/src/streams/lie_increment_stream.cpp
@@ -109,7 +109,7 @@ static py::object lie_increment_stream_from_increments(py::object data, py::kwar
             = intervals::RealInterval::right_unbounded(0.0, md.interval_type);
 
     if (kwargs.contains("indices")) {
-        auto indices_arg = kwargs["indices"];
+        auto indices_arg = kwargs_pop(kwargs, "indices");
 
         if (py::isinstance<py::buffer>(indices_arg)) {
             auto info
@@ -203,6 +203,10 @@ static py::object lie_increment_stream_from_increments(py::object data, py::kwar
                 md.interval_type
         );
     }
+
+    // Everything is finished except building the stream. Check for extra kword
+    // args
+    python::check_for_excess_arguments(kwargs);
 
     python::finalize_schema(md);
 

--- a/roughpy/src/streams/lie_increment_stream.cpp
+++ b/roughpy/src/streams/lie_increment_stream.cpp
@@ -37,6 +37,7 @@
 #include "scalars/parse_key_scalar_stream.h"
 #include "scalars/scalar_type.h"
 #include "scalars/scalars.h"
+#include "schema_finalization.h"
 #include "stream.h"
 
 #include <limits>
@@ -64,10 +65,7 @@ void buffer_to_indices(
     (*scalars::scalar_type_of<param_t>())->convert_copy(dst, src);
 }
 
-static py::object lie_increment_stream_from_increments(
-        const py::object& data,
-        const py::kwargs& kwargs
-)
+static py::object lie_increment_stream_from_increments(py::object data, py::kwargs kwargs)
 {
     auto md = kwargs_to_metadata(kwargs);
 
@@ -181,9 +179,6 @@ static py::object lie_increment_stream_from_increments(
 
 
 
-    if (!md.schema) {
-        md.schema = std::make_shared<streams::StreamSchema>(md.width);
-    }
 
     if (!md.resolution) {
         RPY_DBG_ASSERT(!indices.empty());
@@ -209,6 +204,7 @@ static py::object lie_increment_stream_from_increments(
         );
     }
 
+    python::finalize_schema(md);
 
     auto result = streams::Stream(streams::LieIncrementStream(
             ks_stream.data_stream,

--- a/roughpy/src/streams/piecewise_abelian_stream.cpp
+++ b/roughpy/src/streams/piecewise_abelian_stream.cpp
@@ -73,6 +73,8 @@ static py::object construct_piecewise_lie_stream(
         pmd.resolution = 0;
     }
 
+    python::check_for_excess_arguments(kwargs);
+
     pmd.support = intervals::RealInterval(a, b);
 
     streams::Stream result(streams::PiecewiseAbelianStream(

--- a/roughpy/src/streams/piecewise_abelian_stream.cpp
+++ b/roughpy/src/streams/piecewise_abelian_stream.cpp
@@ -47,7 +47,7 @@ static const char* PW_LIE_STREAM_DOC
 
 static py::object construct_piecewise_lie_stream(
         std::vector<std::pair<intervals::RealInterval, algebra::Lie>> lies,
-        const py::kwargs& kwargs
+        py::kwargs kwargs
 )
 {
 

--- a/roughpy/src/streams/schema_finalization.cpp
+++ b/roughpy/src/streams/schema_finalization.cpp
@@ -51,12 +51,28 @@ last_minute_setup(streams::StreamSchema& schema, PyStreamMetaData& pmd)
 
     if (schema.is_final()) { return; }
 
+    // Now is the time to make sure the schema width is correct
+    RPY_DBG_ASSERT(pmd.width != 0);
+    for (auto i = static_cast<deg_t>(schema.width()); i < pmd.width; ++i) {
+        switch (pmd.default_channel_type) {
+            case rpy::streams::ChannelType::Increment:
+                schema.insert_increment("");
+                break;
+            case rpy::streams::ChannelType::Value:
+                schema.insert_value("");
+                break;
+            case rpy::streams::ChannelType::Categorical:
+                schema.insert_categorical("");
+                break;
+            case rpy::streams::ChannelType::Lie: schema.insert_lie(""); break;
+        }
+    }
+
     if (pmd.include_param_as_data) {
         schema.parametrization()->add_as_channel();
     }
 
-
-    schema.finalize();
+    schema.finalize(0);
 }
 
 void python::finalize_schema(PyStreamMetaData& pmd)

--- a/roughpy/src/streams/tick_stream.cpp
+++ b/roughpy/src/streams/tick_stream.cpp
@@ -56,7 +56,7 @@ static const char* TICK_STREAM_DOC = R"rpydoc(Tick stream
 //                                 const py::handle &data,
 //                                 const py::kwargs &kwargs);
 
-static py::object construct(const py::object& data, const py::kwargs& kwargs)
+static py::object construct(const py::object& data, py::kwargs kwargs)
 {
 
     auto pmd = python::kwargs_to_metadata(kwargs);

--- a/streams/include/roughpy/streams/schema.h
+++ b/streams/include/roughpy/streams/schema.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 the RoughPy Developers. All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
 //
 // 1. Redistributions of source code must retain the above copyright notice,
 // this list of conditions and the following disclaimer.
@@ -18,12 +18,13 @@
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 // ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 //
 // Created by user on 24/05/23.
@@ -141,7 +142,6 @@ public:
 
     const scalars::ScalarType* get_most_appropriate_scalar_type() const;
 
-
 public:
     RPY_NO_DISCARD iterator find(const string& label);
 
@@ -177,8 +177,8 @@ public:
 
     RPY_NO_DISCARD dimn_t label_to_stream_dim(const string& label) const;
 
-    StreamChannel& insert(string label, std::unique_ptr<StreamChannel>&& channel_data);
-
+    StreamChannel&
+    insert(string label, std::unique_ptr<StreamChannel>&& channel_data);
 
     StreamChannel& insert_increment(string label);
     StreamChannel& insert_value(string label);
@@ -186,7 +186,7 @@ public:
     StreamChannel& insert_lie(string label);
 
     RPY_NO_DISCARD bool is_final() const noexcept { return m_is_final; }
-    void finalize() noexcept { m_is_final = true; }
+    void finalize(deg_t n_channels = -1);
 
     RPY_NO_DISCARD intervals::RealInterval
     adjust_interval(const intervals::Interval& arg) const;

--- a/streams/src/external_data_sources/sound_file_data_source.cpp
+++ b/streams/src/external_data_sources/sound_file_data_source.cpp
@@ -352,6 +352,8 @@ Stream SoundFileDataSourceFactory::construct_stream(void* payload) const
 
     if (!pl->schema) {
         pl->schema = std::make_shared<StreamSchema>(meta.width);
+    } else if (!pl->schema->is_final()) {
+        pl->schema->finalize(meta.width);
     }
 
     // Let the library handle normalisation

--- a/streams/src/schema.cpp
+++ b/streams/src/schema.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 the RoughPy Developers. All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
 //
 // 1. Redistributions of source code must retain the above copyright notice,
 // this list of conditions and the following disclaimer.
@@ -18,27 +18,27 @@
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 // ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 //
 // Created by user on 24/05/23.
 //
 
+#include <algorithm>
+#include <cereal/types/vector.hpp>
 #include <roughpy/core/macros.h>
 #include <roughpy/streams/schema.h>
-#include <cereal/types/vector.hpp>
-#include <algorithm>
 
 using namespace rpy;
 using namespace rpy::streams;
 
-StreamSchema::StreamSchema() : p_parameterization(new Parameterization)
-{}
+StreamSchema::StreamSchema() : p_parameterization(new Parameterization) {}
 
 StreamSchema::StreamSchema(dimn_t width)
     : p_parameterization(new Parameterization)
@@ -48,7 +48,8 @@ StreamSchema::StreamSchema(dimn_t width)
 }
 
 bool StreamSchema::compare_labels(
-        string_view item_label, string_view ref_label
+        string_view item_label,
+        string_view ref_label
 ) noexcept
 {
 
@@ -122,14 +123,14 @@ typename StreamSchema::iterator StreamSchema::find(const string& label)
     return it_end;
 }
 
-dimn_t StreamSchema::width() const {
+dimn_t StreamSchema::width() const
+{
     auto channels_width = width_without_param();
-    if (p_parameterization->needs_adding()) {
-        channels_width += 1;
-    }
+    if (p_parameterization->needs_adding()) { channels_width += 1; }
     return channels_width;
 }
-dimn_t StreamSchema::width_without_param() const {
+dimn_t StreamSchema::width_without_param() const
+{
     return width_to_iterator(end());
 }
 
@@ -146,7 +147,8 @@ dimn_t StreamSchema::channel_to_stream_dim(dimn_t channel_no) const
     return width_to_iterator(nth(channel_no));
 }
 dimn_t StreamSchema::channel_variant_to_stream_dim(
-        dimn_t channel_no, dimn_t variant_no
+        dimn_t channel_no,
+        dimn_t variant_no
 ) const
 {
     RPY_CHECK(channel_no < size());
@@ -167,7 +169,8 @@ std::pair<dimn_t, dimn_t> StreamSchema::stream_dim_to_channel(dimn_t stream_dim
 }
 
 string StreamSchema::label_from_channel_it(
-        const_iterator channel_it, dimn_t variant_id
+        const_iterator channel_it,
+        dimn_t variant_id
 )
 {
     return channel_it->first + channel_it->second->label_suffix(variant_id);
@@ -185,7 +188,8 @@ string_view StreamSchema::label_of_channel_id(dimn_t channel_id) const
     return nth(channel_id)->first;
 }
 string StreamSchema::label_of_channel_variant(
-        dimn_t channel_id, dimn_t channel_variant
+        dimn_t channel_id,
+        dimn_t channel_variant
 ) const
 {
     RPY_CHECK(channel_id < size());
@@ -215,14 +219,16 @@ dimn_t StreamSchema::label_to_stream_dim(const string& label) const
     }
 
     const string_view variant_label(
-            &*variant_begin, static_cast<dimn_t>(label.end() - variant_begin)
+            &*variant_begin,
+            static_cast<dimn_t>(label.end() - variant_begin)
     );
     result += channel->second->variant_id_of_label(variant_label);
     return result;
 }
 
 StreamChannel& StreamSchema::insert(
-        string label, std::unique_ptr<StreamChannel>&& channel_data
+        string label,
+        std::unique_ptr<StreamChannel>&& channel_data
 )
 {
     RPY_CHECK(!m_is_final);
@@ -243,7 +249,6 @@ StreamSchema::adjust_interval(const intervals::Interval& arg) const
 {
     return p_parameterization->convert_parameter_interval(arg);
 }
-
 
 StreamChannel& StreamSchema::insert_increment(string label)
 {
@@ -270,12 +275,26 @@ StreamSchema::label_to_lie_key(const string& label) const
 }
 typename StreamSchema::lie_key StreamSchema::time_channel_to_lie_key() const
 {
-    if (!p_parameterization->needs_adding()) {
-        return lie_key();
-    }
+    if (!p_parameterization->needs_adding()) { return lie_key(); }
     RPY_CHECK(p_parameterization);
 
     return static_cast<lie_key>(width_to_iterator(end())) + 1;
+}
+
+void StreamSchema::finalize(deg_t n_channels)
+{
+
+    if (n_channels > 0 && n_channels < width()) {
+        RPY_THROW(
+                std::runtime_error,
+                "specified number of channels does not match actual number of "
+                "channels"
+        );
+    }
+
+    for (auto i = width(); i < n_channels; ++i) { insert_increment(""); }
+
+    m_is_final = true;
 }
 
 #define RPY_EXPORT_MACRO ROUGHPY_STREAMS_EXPORT

--- a/tests/streams/test_lie_increment_path.py
+++ b/tests/streams/test_lie_increment_path.py
@@ -101,8 +101,9 @@ def test_from_array_inferred_width_3_2_increments():
 
     assert sig.width == 3
     assert sig.max_degree == 1
-    assert sig == rp.FreeTensor(np.array([1, 3, 7, 1]), width=3, depth=1,
-                                dtype=rp.Rational)
+    expected = rp.FreeTensor(np.array([1, 3, 7, 1]), width=3, depth=1,
+                             dtype=rp.Rational)
+    assert sig == expected, f"{sig} != {expected}"
 
 
 def test_from_array_width_3_2_increments():
@@ -113,8 +114,9 @@ def test_from_array_width_3_2_increments():
 
     assert sig.width == 3
     assert sig.max_degree == 1
-    assert sig == rp.FreeTensor(np.array([1, 3, 7, 1]), width=3, depth=1,
-                                dtype=rp.Rational)
+    expected = rp.FreeTensor(np.array([1, 3, 7, 1]), width=3, depth=1,
+                             dtype=rp.Rational)
+    assert sig == expected, f"{sig} != {expected}"
 
 
 def test_from_array_wider_than_depth_2_dim():

--- a/tests/streams/test_lie_increment_path.py
+++ b/tests/streams/test_lie_increment_path.py
@@ -102,19 +102,19 @@ def test_from_array_inferred_width_3_2_increments():
     assert sig.width == 3
     assert sig.max_degree == 1
     assert sig == rp.FreeTensor(np.array([1, 3, 7, 1]), width=3, depth=1,
-                                coeffs=rp.Rational)
+                                dtype=rp.Rational)
 
 
 def test_from_array_width_3_2_increments():
     data = np.array([[3, 7, 0], [0, 0, 1]])
     stream = LieIncrementStream.from_increments(data, width=3, depth=2,
-                                                coeffs=rp.Rational)
+                                                dtype=rp.Rational)
     sig = stream.signature(depth=1)
 
     assert sig.width == 3
     assert sig.max_degree == 1
     assert sig == rp.FreeTensor(np.array([1, 3, 7, 1]), width=3, depth=1,
-                                coeffs=rp.Rational)
+                                dtype=rp.Rational)
 
 
 def test_from_array_wider_than_depth_2_dim():
@@ -124,7 +124,7 @@ def test_from_array_wider_than_depth_2_dim():
     sig = stream.signature(depth=1)
 
     assert sig == rp.FreeTensor(np.array([1, 3, 7]), width=2, depth=1,
-                                coeffs=rp.Rational)
+                                dtype=rp.Rational)
 
 
 def test_tick_path_signature_calc_accuracy():


### PR DESCRIPTION
Overhauled the handling of keyword arguments in constructors for streams and algebra types.

All of these constructors now make use of the new `parse_algebra_configuration` function to get the context or width-depth-scalar_type combination. Moreover, the `width`, `depth`, and `dtype` arguments are now deprecated, and a warning is produced to tell the user to use `ctx` instead.

In addition, a mechanism has been put in place to check that all the keyword arguments have been consumed, and raising an exception if not,

Closes #77 