### PR TITLE
Fix partition intermediates unchecked

### DIFF
--- a/roughpy/src/intervals/partition.cpp
+++ b/roughpy/src/intervals/partition.cpp
@@ -35,6 +35,8 @@
 #include <pybind11/stl.h>
 #include <pybind11/operators.h>
 
+#include <algorithm>
+
 using namespace rpy;
 using namespace intervals;
 using namespace pybind11::literals;
@@ -47,11 +49,17 @@ namespace {
 Partition partition_py_ctor(const RealInterval& interval,
                             const py::iterable& py_intermediates)
 {
+    const auto inf = interval.inf();
+    const auto sup = interval.sup();
     std::vector<param_t> intermediates;
     for (auto&& mid : py_intermediates) {
-        intermediates.push_back(mid.cast<param_t>());
+        auto param = mid.cast<param_t>();
+        if (interval.contains_point(param) && param != inf && param != sup) {
+            intermediates.push_back(param);
+        }
     }
 
+    std::sort(intermediates.begin(), intermediates.end());
     return Partition(interval, std::move(intermediates));
 }
 

--- a/tests/intervals/test_partitions.py
+++ b/tests/intervals/test_partitions.py
@@ -1,9 +1,17 @@
 
 import pickle
 
-import pytest
+import numpy as np
 
+import roughpy as rp
 from roughpy import Partition, RealInterval
+
+
+def test_partition_trim_intermediates():
+    interval = rp.RealInterval(0.0, 1.0)
+    partition = rp.Partition(interval, intermediates=np.arange(10))
+
+    assert partition.intermediates() == []
 
 def test_partition_pickle_roundtrip():
 


### PR DESCRIPTION
Fix Partition intermediate points not being filtered to contain only those within the base interval and not being sorted.

Closes #80 