### PR TITLE
Add manual workflow trigger in build_wheels.yml

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,7 @@
 name: Build Wheels
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'


### PR DESCRIPTION
Enabled the workflow_dispatch event to allow manual triggering of the build wheels workflow. This provides more flexibility for testing and deployment without requiring a new tag push.