### PR TITLE
Add support for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -96,9 +96,9 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Build and test
-        uses: pypa/cibuildwheel@v2.16.0
+        uses: pypa/cibuildwheel@v2.21.3
         env:
-          MACOSX_DEPLOYMENT_TARGET: 11.0.0
+          MACOSX_DEPLOYMENT_TARGET: 12.0.0
           VCPKG_INSTALL_OPTIONS: "--debug"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
             auditwheel show {wheel} &&
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install release deps
         run: python -m pip install twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Operating System :: Unix",


### PR DESCRIPTION
Updated pyproject.toml to include classifiers for Python 3.12 and 3.13. Modified GitHub workflow to use Python 3.13 and updated cibuildwheel action and macOS deployment target to the latest versions.

closes #105 