### PR TITLE
Remove debug configuration and tidy up actions file.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: "daily"
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -96,9 +96,9 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Build and test
-        uses: pypa/cibuildwheel@v2.16.0
+        uses: pypa/cibuildwheel@v2.21.3
         env:
-          MACOSX_DEPLOYMENT_TARGET: 11.0.0
+          MACOSX_DEPLOYMENT_TARGET: 12.0.0
           VCPKG_INSTALL_OPTIONS: "--debug"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
             auditwheel show {wheel} &&
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install release deps
         run: python -m pip install twine

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -89,7 +89,7 @@ jobs:
           submodules: true
 
       - name: Setup gha caching for vcpkg
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -98,9 +98,7 @@ jobs:
       - name: Build and test
         uses: pypa/cibuildwheel@v2.21.3
         env:
-          MACOSX_DEPLOYMENT_TARGET: 12.0.0
           GITHUB_TOK: "${{ secrets.GITHUB_TOKEN }}"
-          CIBW_ENVIRONMENT_PASS_LINUX: GITHUB_TOK VCPKG_BINARY_SOURCES ACTIONS_CACHE_URL ACTIONS_RUNTIME_TOKEN
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -58,7 +58,7 @@ jobs:
           twine check dist/*
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: ./dist/*
@@ -99,16 +99,10 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.3
         env:
           MACOSX_DEPLOYMENT_TARGET: 12.0.0
-          VCPKG_INSTALL_OPTIONS: "--debug"
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
-            auditwheel show {wheel} &&
-            auditwheel repair -w {dest_dir} {wheel}
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: > 
-            delocate-wheel --require-archs {delocate_archs} --ignore-missing-dependencies -w {dest_dir} -v {wheel}
           GITHUB_TOK: "${{ secrets.GITHUB_TOKEN }}"
           CIBW_ENVIRONMENT_PASS_LINUX: GITHUB_TOK VCPKG_BINARY_SOURCES ACTIONS_CACHE_URL ACTIONS_RUNTIME_TOKEN
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -121,7 +115,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -129,13 +123,13 @@ jobs:
         run: python -m pip install twine
 
       - name: Retrieve sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sdist
           path: dist
 
       - name: Retrieve wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheels
           path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,15 @@
 name: tests
 
 on:
-  push:
-    branches: [ "main" ]
-    paths-ignore:
-      - "examples/**"
-      - "doc/**"
-      - "README.md"
-      - "*.txt"
-      - "CHANGELOG"
-      - "tools/*.py"
+#  push:
+#    branches: [ "main" ]
+#    paths-ignore:
+#      - "examples/**"
+#      - "doc/**"
+#      - "README.md"
+#      - "*.txt"
+#      - "CHANGELOG"
+#      - "tools/*.py"
   pull_request:
     branches: [ "main" ]
     paths-ignore:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         python-version: 3.13
 
     - name: Setup gha caching for vcpkg
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Operating System :: Unix",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,10 +105,9 @@ skip = [
     "*-musl*",
     "pp*",
     "*linux_i686",
-    "*arm64",
     "*universal2",
-    "cp3{6,7}-*",
-    "cp3{8,9}-macos*"
+    "cp3{6,7,8}-*",
+    "cp3{9}-macos*"
 ]
 build-verbosity=1
 
@@ -123,6 +122,15 @@ environment= "CMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake VCPK
 before-build = "pip install delvewheel"
 repair-wheel-command = "delvewheel repair -w {dest_dir} --ignore-in-wheel {wheel}"
 
-
 [tool.cibuildwheel.linux]
 repair-wheel-command = "auditwheel show {wheel} && auditwheel repair -w {dest_dir} {wheel}"
+environment-pass = [
+    "GITHUB_TOK",
+    "VCPKG_BINARY_SOURCES",
+    "ACTIONS_CACHE_URL",
+    "ACTIONS_RUNTIME_TOKEN"
+]
+
+[tool.cibuildwheel.macos]
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} --ignore-missing-dependencies -w {dest_dir} -v {wheel}"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ filterwarnings = ["ignore::DeprecationWarning"]
 
 
 [tool.scikit-build]
+cmake.version = ">=3.26"
+ninja.version = ">=1.11"
 wheel.packages = []
 cmake.verbose = true
 logging.level = "INFO"


### PR DESCRIPTION
Moved some of the configuration environment variables out of the build_wheels build and into the pyproject.toml. Hopefully the improvements to the build system will allow us to build more flexibly.