### PR TITLE
Fix conversion warnings msvc

### DIFF
--- a/roughpy/src/args/buffer_info.cpp
+++ b/roughpy/src/args/buffer_info.cpp
@@ -27,7 +27,7 @@ Py_ssize_t BufferInfo::size() const noexcept
     return std::accumulate(
             m_view.shape,
             m_view.shape + m_view.ndim,
-            1,
+            1LL,
             std::multiplies<>()
     );
 }

--- a/roughpy/src/args/kwargs_to_path_metadata.cpp
+++ b/roughpy/src/args/kwargs_to_path_metadata.cpp
@@ -180,7 +180,7 @@ python::PyStreamMetaData python::kwargs_to_metadata(pybind11::kwargs& kwargs)
 
     if (md.schema->is_final()) {
         if (!algebra_config.width) {
-            algebra_config.width = md.schema->width();
+            algebra_config.width = static_cast<deg_t>(md.schema->width());
             RPY_DBG_ASSERT(md.width == 0);
             md.width = *algebra_config.width;
         } else if (md.schema->width() != *algebra_config.width) {
@@ -191,7 +191,7 @@ python::PyStreamMetaData python::kwargs_to_metadata(pybind11::kwargs& kwargs)
         }
     }
 
-    // Additional information that will not effect the algebra config.
+    // Additional information that will not affect the algebra config.
     if (kwargs.contains("vtype")) {
         md.vector_type
                 = kwargs_pop(kwargs, "vtype").cast<algebra::VectorType>();

--- a/roughpy/src/args/parse_data_argument.cpp
+++ b/roughpy/src/args/parse_data_argument.cpp
@@ -415,7 +415,7 @@ void ConversionManager::check_dl_size(py::capsule dlcap, deg_t depth)
     leaf.size = static_cast<dimn_t>(std::accumulate(
             leaf.shape.begin(),
             leaf.shape.end(),
-            1,
+            1LL,
             std::multiplies<>()
     ));
 }

--- a/roughpy/src/streams/lie_increment_stream.cpp
+++ b/roughpy/src/streams/lie_increment_stream.cpp
@@ -172,7 +172,9 @@ static py::object lie_increment_stream_from_increments(py::object data, py::kwar
 
     if (indices.empty()) {
         indices.reserve(num_increments);
-        for (dimn_t i = 0; i < num_increments; ++i) { indices.emplace_back(i); }
+        for (dimn_t i = 0; i < num_increments; ++i) {
+            indices.emplace_back(static_cast<param_t>(i));
+        }
         md.resolution = 0;
     } else if (indices.size() != num_increments) {
         RPY_THROW(


### PR DESCRIPTION
There were numerous type conversion warnings emitted by MSVC in recent test runs. I've fixed these implicit casts with explicit casts.