### PR TITLE
Add .gdbinit to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -335,6 +335,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+.gdbinit
 
 roughpy/version.py
 /my_todo.txt


### PR DESCRIPTION
This addition prevents the .gdbinit file from being tracked by Git. It ensures that any GDB configurations used during development remain local to the developer's environment.