### PR TITLE
Make BufferInfo's Py_buffer mutable

### DIFF
--- a/roughpy/src/args/buffer_info.h
+++ b/roughpy/src/args/buffer_info.h
@@ -23,7 +23,8 @@ struct BufferFormat {
 
 class BufferInfo
 {
-    Py_buffer m_view;
+    // This is mutable because the Python API always passes mutable pointers
+    mutable Py_buffer m_view;
     optional<Py_ssize_t> m_size;
 
 public:


### PR DESCRIPTION
This commit updates the BufferInfo class to make the m_view member mutable. This change is necessary because the Python API consistently passes mutable pointers, and we need to reflect that in our code structure.