### PR TITLE
Fix GitHub actions again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "monthly"
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "monthly"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -73,14 +73,8 @@ jobs:
         os:
           - ubuntu-latest
           - windows-2019
-          - macos-12
-        include:
-          - os: windows-2022
-            tag: "win_amd64"
-          - os: ubuntu-latest
-            tag: "manylinux_x86_64"
-          - os: macos-13
-            tag: "macosx_x86_64"
+          - macos-13 # Uses x64
+          - macos-14 # Uses Apple Silicon
 
     steps:
       - name: Checkout
@@ -95,6 +89,9 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
+      - name: Install build deps on MacOs
+        if: runner.os == 'macOs'
+
       - name: Build and test
         uses: pypa/cibuildwheel@v2.21.3
         env:
@@ -102,7 +99,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,19 @@ on:
       - "examples/**"
       - "doc/**"
       - "README.md"
-      - "*.txt"
       - "CHANGELOG"
       - "tools/*.py"
+      - ".github/workflows/build_wheels.yml"
+      - ".github/dependabot.yml"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "branding/**"
+      - ".gitignore"
+      - "CMakePresets.json"
+      - "THANKS.txt"
+      - "LICENSE.txt"
+      - "VERSION.txt"
+      - "CITATION.cff"
+      - ".gitignore"
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
@@ -72,8 +82,8 @@ jobs:
       run: |
         choco install pkgconfiglite
 
-    - name: install autoconf on macos14
-      if: runner.os == 'MacOs'
+    - name: install autoconf on macos
+      if: runner.os == 'macOs'
       shell: bash
       run: |
         brew install autoconf automake libtool m4 ninja


### PR DESCRIPTION
Updated the tests runner to ignore more files that don't affect the build/testing of RoughPy. Changed the matrix to include MacOS13 and 14 so that wheels are built for Apple Silicon too.
Fixed missing build tool installs on macOS.
