### PR TITLE
Update wheel retrieval in GitHub workflow

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -128,8 +128,9 @@ jobs:
       - name: Retrieve wheels
         uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: "cibw-*"
           path: dist
+          merge-multiple: true
 
       - name: Update release
         shell: bash


### PR DESCRIPTION
Modified the 'Retrieve wheels' step to use a specific pattern ("cibw-*") and enabled merge-multiple to true. This ensures that multiple artifacts matching the pattern are merged correctly during the download.