### PR TITLE
Add templated construct_inplace functions

### DIFF
--- a/core/include/roughpy/core/alloc.h
+++ b/core/include/roughpy/core/alloc.h
@@ -26,6 +26,20 @@ constexpr void construct_inplace(T* dst, Args&&... args)
     ::new (static_cast<void*>(dst)) T(std::forward<Args>(args)...);
 }
 
+template <typename T, typename... Args>
+constexpr void construct_inplace(void* dst, Args&&... args)
+    noexcept(is_nothrow_constructible<T, Args...>::value)
+{
+   ::new (dst) T(std::forward<Args>(args)...);
+}
+
+template <typename T, typename... Args>
+constexpr void construct_inplace(T& dst, Args&&... args)
+    noexcept(is_nothrow_constructible<T, Args...>::value)
+{
+    :: new(static_cast<void*>(std::addressof(dst))) T(std::forward<Args>(args)...);
+}
+
 
 }// namespace rpy
 


### PR DESCRIPTION
Introduce two templated `construct_inplace` functions in alloc.h to facilitate object construction directly in allocated memory. These functions enhance flexibility by supporting both pointer and reference types as the destination for in-place constructions.