### PR TITLE
Add ability to launch manually

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: tests
 
 on:
+  workflow_dispatch:
 #  push:
 #    branches: [ "main" ]
 #    paths-ignore:


### PR DESCRIPTION
The tests action should be runnable on demand, not just on pull requests/pushes to main