### PR TITLE
Remove videos because they are too large

### DIFF
--- a/docs/source/_static/terry-trimmed.mp4
+++ b/docs/source/_static/terry-trimmed.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f43dd186363925c74998a7bbed3a830aaced8b34de0c0acec88daca51fe114de
-size 6912950

--- a/docs/source/_static/terry.mp4
+++ b/docs/source/_static/terry.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c000299042c46e14d0fd73337e0479062230269c2dba11373acf3e3e174598e3
-size 291799424


### PR DESCRIPTION
The video files used in the documentation are causing problems with the version control. I've removed them.