### PR TITLE
fix-different-signedness-comparisons

### DIFF
--- a/algebra/src/libalgebra_lite_internal/tensor_basis_info.h
+++ b/algebra/src/libalgebra_lite_internal/tensor_basis_info.h
@@ -33,12 +33,14 @@
 #ifndef ROUGHPY_ALGEBRA_SRC_LIBALGEBRA_LITE_BASIS_INFO_H
 #define ROUGHPY_ALGEBRA_SRC_LIBALGEBRA_LITE_BASIS_INFO_H
 
+#include <libalgebra_lite/tensor_basis.h>
+
+#include <roughpy/core/types.h>
 #include <roughpy/algebra/basis.h>
 #include <roughpy/algebra/basis_impl.h>
 #include <roughpy/algebra/basis_info.h>
 #include <roughpy/algebra/tensor_basis.h>
 
-#include <libalgebra_lite/tensor_basis.h>
 
 namespace rpy {
 namespace algebra {
@@ -175,7 +177,7 @@ struct BasisInfo<TensorBasis, lal::tensor_basis> {
 
         optional<our_key_type> out {};
 
-        const auto degree = ldegree + rdegree;
+        const auto degree = static_cast<deg_t>(ldegree + rdegree);
         if (degree <= basis->depth()) {
             const auto shift = basis->powers()[rdegree];
             const auto idx = left.index() * shift + right.index();

--- a/roughpy/src/algebra/lie.cpp
+++ b/roughpy/src/algebra/lie.cpp
@@ -115,12 +115,12 @@ static Lie construct_lie(py::object data, py::kwargs kwargs)
 
     auto parsed_data = python::parse_data_argument(data, options);
 
-    bool is_sparse = false;
+    // bool is_sparse = false;
     scalars::KeyScalarArray buffer;
     if (parsed_data.size() == 1) {
         auto& leaf = parsed_data.back();
         buffer = std::move(leaf.data);
-        is_sparse = leaf.value_type == python::ValueType::KeyValue;
+        // is_sparse = leaf.value_type == python::ValueType::KeyValue;
     }
 
     if (helper.ctype == nullptr) {

--- a/roughpy/src/algebra/shuffle_tensor.cpp
+++ b/roughpy/src/algebra/shuffle_tensor.cpp
@@ -137,12 +137,12 @@ static ShuffleTensor construct_shuffle(py::object data, py::kwargs kwargs)
 
     auto parsed_data = python::parse_data_argument(data, options);
 
-    bool is_sparse = false;
+    // bool is_sparse = false;
     scalars::KeyScalarArray buffer;
     if (parsed_data.size() == 1) {
         auto& leaf = parsed_data.back();
         buffer = std::move(leaf.data);
-        is_sparse = leaf.value_type == python::ValueType::KeyValue;
+        // is_sparse = leaf.value_type == python::ValueType::KeyValue;
     }
 
     if (helper.ctype == nullptr) {

--- a/roughpy/src/args/kwargs_to_path_metadata.cpp
+++ b/roughpy/src/args/kwargs_to_path_metadata.cpp
@@ -56,7 +56,6 @@ python::PyStreamMetaData python::kwargs_to_metadata(pybind11::kwargs& kwargs)
             false                                // include_param_as_data
     };
 
-    streams::ChannelType ch_type;
 
     if (kwargs.contains("schema")) {
         auto schema = kwargs_pop(kwargs, "schema");

--- a/roughpy/src/args/kwargs_to_path_metadata.cpp
+++ b/roughpy/src/args/kwargs_to_path_metadata.cpp
@@ -183,7 +183,8 @@ python::PyStreamMetaData python::kwargs_to_metadata(pybind11::kwargs& kwargs)
             algebra_config.width = static_cast<deg_t>(md.schema->width());
             RPY_DBG_ASSERT(md.width == 0);
             md.width = *algebra_config.width;
-        } else if (md.schema->width() != *algebra_config.width) {
+        } else if (static_cast<deg_t>(md.schema->width()) != *algebra_config
+        .width) {
             RPY_THROW(
                     py::value_error,
                     "specified width does not match the schema width"

--- a/roughpy/src/args/parse_data_argument.cpp
+++ b/roughpy/src/args/parse_data_argument.cpp
@@ -448,7 +448,7 @@ void ConversionManager::check_size_and_type_recurse(
 )
 {
     RPY_CHECK(
-            depth < m_options.max_nested,
+            static_cast<dimn_t>(depth) < m_options.max_nested,
             "maximum nested depth reached in this context",
             py::value_error
     );

--- a/roughpy/src/args/parse_data_argument.cpp
+++ b/roughpy/src/args/parse_data_argument.cpp
@@ -425,7 +425,7 @@ void ConversionManager::check_buffer_size(py::buffer buffer, deg_t depth)
     const auto info = buffer.request();
 
     depth += info.ndim;
-    RPY_CHECK(depth <= m_options.max_nested);
+    RPY_CHECK(static_cast<dimn_t>(depth) <= m_options.max_nested);
 
     auto& leaf = add_leaf(buffer, LeafType::Buffer);
 

--- a/roughpy/src/args/parse_data_argument.cpp
+++ b/roughpy/src/args/parse_data_argument.cpp
@@ -81,7 +81,7 @@ private:
 
     void handle_scalar(py::handle value, bool key = false);
     void handle_key_scalar(py::handle value);
-    void handle_lie(py::handle value);
+    [[maybe_unused]] void handle_lie(py::handle value);
 
     void handle_scalar_leaf(LeafItem& leaf);
     void handle_key_scalar_leaf(LeafItem& leaf);

--- a/roughpy/src/args/parse_data_argument.cpp
+++ b/roughpy/src/args/parse_data_argument.cpp
@@ -671,9 +671,7 @@ void ParsedData::fill_ks_stream(scalars::KeyScalarStream& ks_stream)
             case LeafType::Buffer: {
                 if (leaf.size == 0) { break; }
                 if (leaf.shape.size() == 1) {
-                    auto sz = leaf.size;
                     ks_stream.push_back(leaf.data.borrow());
-
                 } else {
                     dimn_t sz = leaf.shape.back();
                     dimn_t offset1 = 0;

--- a/roughpy/src/args/parse_data_argument.cpp
+++ b/roughpy/src/args/parse_data_argument.cpp
@@ -403,7 +403,7 @@ void ConversionManager::check_dl_size(py::capsule dlcap, deg_t depth)
     auto& tensor = managed_tensor->dl_tensor;
 
     depth += tensor.ndim;
-    RPY_CHECK(depth <= m_options.max_nested);
+    RPY_CHECK(static_cast<dimn_t>(depth) <= m_options.max_nested);
 
     auto& leaf = add_leaf(dlcap, LeafType::DLTensor);
 

--- a/scalars/src/key_scalar_array.cpp
+++ b/scalars/src/key_scalar_array.cpp
@@ -149,10 +149,10 @@ void KeyScalarArray::allocate_keys(idimn_t count) {
         if (p_keys != nullptr) { delete[] p_keys; }
 
         if (count == -1) {
-            count = size();
+            count = static_cast<idimn_t>(size());
         }
 
-        RPY_CHECK(count == size());
+        RPY_CHECK(count == static_cast<idimn_t>(size()));
 
         p_keys = new key_type[count] {};
         m_owns_keys = true;

--- a/scalars/src/scalar.cpp
+++ b/scalars/src/scalar.cpp
@@ -461,18 +461,6 @@ devices::TypeInfo Scalar::type_info() const noexcept
     return p_type_and_content_type.get_type_info();
 }
 
-static void print_trivial_bytes(
-    std::ostream& os,
-    const byte* bytes,
-    PackedScalarTypePointer<scalars::dtl::ScalarContentType> p_type
-) {}
-
-static void print_opaque_pointer(
-    std::ostream& os,
-    const void* opaque,
-    PackedScalarTypePointer<scalars::dtl::ScalarContentType> p_type
-) {}
-
 std::ostream& rpy::scalars::operator<<(std::ostream& os, const Scalar& value)
 {
     if (value.fast_is_zero()) {

--- a/scalars/src/scalar/comparison.cpp
+++ b/scalars/src/scalar/comparison.cpp
@@ -91,7 +91,7 @@ constexpr enable_if_t<
         bool>
 compare_wrap_equal(const L& lhs, const R& rhs) noexcept
 {
-    static_assert(sizeof(L) == sizeof(R), "");
+    static_assert(sizeof(L) == sizeof(R), "comparison of integers of different sizes");
     return (lhs >= 0) && static_cast<R>(lhs) == rhs;
 }
 
@@ -102,8 +102,8 @@ constexpr enable_if_t<
         bool>
 compare_wrap_equal(const L& lhs, const R& rhs) noexcept
 {
-    static_assert(sizeof(L) == sizeof(R), "");
-    return (rhs >= 0) && lhs == static_cast<R>(rhs);
+    static_assert(sizeof(L) == sizeof(R), "comparison of integers of different sizes");
+    return (rhs >= 0) && lhs == static_cast<L>(rhs);
 }
 
 template <typename L, typename R>

--- a/scalars/src/scalar_helpers/standard_scalar_type.h
+++ b/scalars/src/scalar_helpers/standard_scalar_type.h
@@ -151,7 +151,6 @@ void StandardScalarType<ScalarImpl>::convert_copy(
         (*src_type)->convert_copy(dst, src);
     }
 
-    auto src_info = src.type_info();
     auto dst_info = dst.type_info();
     /*
      * Now one of the following cases must be true:

--- a/streams/src/schema.cpp
+++ b/streams/src/schema.cpp
@@ -289,8 +289,8 @@ typename StreamSchema::lie_key StreamSchema::time_channel_to_lie_key() const
 
 void StreamSchema::finalize(deg_t n_channels)
 {
-
-    if (n_channels > 0 && n_channels < width()) {
+    auto my_width = static_cast<deg_t>(width());
+    if (n_channels > 0 && n_channels < my_width) {
         RPY_THROW(
                 std::runtime_error,
                 "specified number of channels does not match actual number of "
@@ -298,7 +298,7 @@ void StreamSchema::finalize(deg_t n_channels)
         );
     }
 
-    for (auto i = width(); i < n_channels; ++i) { insert_increment(""); }
+    for (auto i = my_width; i < n_channels; ++i) { insert_increment(""); }
 
     m_is_final = true;
 }


### PR DESCRIPTION
Turning on `-Wal`l highlighted a number of comparisons of diffrent signedness. I've fixed these by one argument to the other type. This is not a good fix, but it is a good stand-in for now until better mechanisms are available.