### PR TITLE
No submodule for LibalgebraLite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/libalgebra_lite"]
-	path = external/libalgebra_lite
-	url = https://github.com/datasig-ac-uk/libalgebra-lite

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,11 +193,8 @@ endif ()
 
 
 
-set(LIBALGEBRA_LITE_BUILD_TESTS OFF CACHE INTERNAL "")
-set(LIBALGEBRA_LITE_RATIONAL_COEFFS OFF CACHE INTERNAL "")
-add_subdirectory(external/libalgebra_lite)
-set_property(TARGET Libalgebra_lite PROPERTY C_INCLUDE_WHAT_YOU_USE)
-set_property(TARGET Libalgebra_lite PROPERTY CXX_INCLUDE_WHAT_YOU_USE)
+add_subdirectory(vendored/libalgebra_lite)
+
 
 add_subdirectory(core)
 add_subdirectory(platform)

--- a/algebra/src/libalgebra_lite_internal/rational_coefficients.cpp
+++ b/algebra/src/libalgebra_lite_internal/rational_coefficients.cpp
@@ -7,8 +7,8 @@
 
 namespace lal {
 
-template class coefficient_field<rpy::devices::rational_scalar_type>;
+template struct coefficient_field<rpy::devices::rational_scalar_type>;
 
-template class coefficient_ring<rpy::devices::rational_poly_scalar, rpy::devices::rational_scalar_type>;
+template struct coefficient_ring<rpy::devices::rational_poly_scalar, rpy::devices::rational_scalar_type>;
 
 }

--- a/algebra/src/libalgebra_lite_internal/rational_coefficients.h
+++ b/algebra/src/libalgebra_lite_internal/rational_coefficients.h
@@ -11,9 +11,10 @@
 
 namespace lal {
 
-extern template class coefficient_field<rpy::devices::rational_poly_scalar>;
+extern template struct coefficient_field<rpy::devices::rational_poly_scalar>;
 
-extern template class coefficient_ring<rpy::devices::rational_poly_scalar, rpy::devices::rational_scalar_type>;
+extern template struct coefficient_ring<rpy::devices::rational_poly_scalar,
+rpy::devices::rational_scalar_type>;
 }
 
 namespace rpy {

--- a/vendored/libalgebra_lite/CMakeLists.txt
+++ b/vendored/libalgebra_lite/CMakeLists.txt
@@ -1,0 +1,64 @@
+
+
+
+
+add_library(Libalgebra_lite SHARED
+        algebra/lie_multiplier.cpp
+        algebra/polynomial_multiplier.cpp
+        algebra/polynomial.cpp
+        algebra/half_shuffle_multiplier.cpp
+        algebra/free_tensor_multiplier.cpp
+        algebra/shuffle_multiplier.cpp
+        algebra/polynomial_ring.cpp
+        basis/hall_set.cpp
+        basis/tensor_basis.cpp
+        basis/monomial.cpp
+        basis/polynomial_basis.cpp
+        basis/unpacked_tensor_word.cpp
+        coefficients/floating_fields.cpp
+        detail/integer_maths.h
+        detail/macros.h
+        detail/notnull.h
+        detail/traits.h
+        algebra.h
+        basis.h
+        basis_traits.h
+        coefficients.h
+        dense_vector.h
+        free_tensor.h
+        hall_set.h
+        implementation_types.h
+        index_key.h
+        key_range.h
+        lie.h
+        maps.cpp
+        maps.h
+        operators.h
+        packed_integer.h
+        polynomial.h
+        polynomial_basis.h
+        registry.h
+        shuffle_tensor.h
+        sparse_vector.h
+        tensor_basis.h
+        unpacked_tensor_word.h
+        vector.h
+        vector_base.h
+        vector_bundle.h
+        vector_traits.h
+)
+add_library(Libalgebra_lite::Libalgebra_lite ALIAS Libalgebra_lite)
+
+generate_export_header(Libalgebra_lite)
+
+
+target_include_directories(Libalgebra_lite
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
+
+target_link_libraries(Libalgebra_lite PRIVATE
+        Boost::headers
+)
+

--- a/vendored/libalgebra_lite/CMakeLists.txt
+++ b/vendored/libalgebra_lite/CMakeLists.txt
@@ -62,3 +62,6 @@ target_link_libraries(Libalgebra_lite PRIVATE
         Boost::headers
 )
 
+set_property(TARGET Libalgebra_lite PROPERTY C_INCLUDE_WHAT_YOU_USE)
+set_property(TARGET Libalgebra_lite PROPERTY CXX_INCLUDE_WHAT_YOU_USE)
+

--- a/vendored/libalgebra_lite/LICENSE
+++ b/vendored/libalgebra_lite/LICENSE
@@ -1,0 +1,19 @@
+MIT License Copyright (c) 2023 Libalgebra-lite developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendored/libalgebra_lite/README.md
+++ b/vendored/libalgebra_lite/README.md
@@ -1,0 +1,8 @@
+# LibalgebraLite
+
+Libalgebra Lite was originally included as a submodule, but this caused some 
+maintenance problems. Since we're getting rid of this module in the medium 
+term, we decided to unlink from the main libalgebra lite repository and just 
+vendor the code in the main RoughPy repository. This allows us to make 
+breaking changes to the libalgebra lite codebase that suite our needs, but 
+that we probably don't want to be reflected in the main repository.

--- a/vendored/libalgebra_lite/algebra.h
+++ b/vendored/libalgebra_lite/algebra.h
@@ -1,0 +1,971 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Created by user on 26/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_ALGEBRA_H
+#define LIBALGEBRA_LITE_ALGEBRA_H
+
+#include "implementation_types.h"
+#include "libalgebra_lite_export.h"
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <boost/container/small_vector.hpp>
+
+#include "basis_traits.h"
+#include "coefficients.h"
+#include "vector.h"
+#include "vector_traits.h"
+
+#include "detail/traits.h"
+
+namespace lal {
+
+template <typename Multiplication>
+struct multiplication_traits {
+
+    using mult_ptr = std::shared_ptr<const Multiplication>;
+
+private:
+    template <typename, typename, typename, typename, typename = void>
+    struct has_fma_inplace : false_type {
+    };
+
+    template <typename L, typename R, typename F, typename M>
+    struct has_fma_inplace<
+            L, R, F, M,
+            void_t<decltype(M::template fma_inplace(
+                    declval<L&>(), declval<const R&>(), declval<F>()
+            ))>> : true_type {
+    };
+
+    template <typename, typename, typename, typename, typename = void>
+    struct has_fma_inplace_with_deg : false_type {
+    };
+
+    template <typename L, typename R, typename F, typename M>
+    struct has_fma_inplace_with_deg<
+            L, R, F, M,
+            void_t<decltype(M::template fma_inplace(declval<L&>(), declval<const R&>(), declval<F>()), declval<deg_t>())>>
+        : true_type {
+    };
+
+    template <typename V>
+    using has_degree_t = is_same<
+            typename basis_trait<typename V::basis_type>::degree_tag,
+            with_degree_tag>;
+
+public:
+    template <typename Result, typename Vector1, typename Vector2, typename Fn>
+    static enable_if_t<!has_degree_t<Result>::value> multiply_and_add(
+            const Multiplication& mult, Result& result, const Vector1& lhs,
+            const Vector2& rhs, Fn fn
+    )
+    {
+        if (lhs.empty() || rhs.empty()) { return; }
+
+        mult.fma(
+                result.base_vector(), lhs.base_vector(), rhs.base_vector(), fn
+        );
+    }
+
+    template <typename Result, typename Vector1, typename Vector2>
+    static enable_if_t<!has_degree_t<Result>::value> multiply_and_add(
+            const Multiplication& mult, Result& result, const Vector1& lhs,
+            const Vector2& rhs
+    )
+    {
+        using scalar_type = typename Result::scalar_type;
+        mult.fma(
+                result.base_vector(), lhs.base_vector(), rhs.base_vector(),
+                [](scalar_type s) { return s; }
+        );
+    }
+
+    template <typename Result, typename Vector1, typename Vector2, typename Fn>
+    static enable_if_t<has_degree_t<Result>::value> multiply_and_add(
+            const Multiplication& mult, Result& result, const Vector1& lhs,
+            const Vector2& rhs, Fn fn
+    )
+    {
+        using traits = basis_trait<typename Result::basis_type>;
+        mult.fma(
+                result.base_vector(), lhs.base_vector(), rhs.base_vector(), fn,
+                traits::max_degree(result.basis())
+        );
+    }
+
+    template <typename Result, typename Vector1, typename Vector2>
+    static enable_if_t<has_degree_t<Result>::value> multiply_and_add(
+            const Multiplication& mult, Result& result, const Vector1& lhs,
+            const Vector2& rhs
+    )
+    {
+        using scalar_type = typename Result::scalar_type;
+        using traits = basis_trait<typename Result::basis_type>;
+        mult.fma(
+                result.base_vector(), lhs.base_vector(), rhs.base_vector(),
+                [](scalar_type s) { return s; },
+                traits::max_degree(result.basis())
+        );
+    }
+    //
+    //    template <typename Left, typename Right, typename Fn, typename
+    //    Mult=Multiplication> static enable_if_t<!has_degree_t<Left>::value &&
+    //    has_fma_inplace<Left, Right, Fn, Mult>::value>
+    //    multiply_and_add_inplace(const Multiplication &mult, Left &lhs, const
+    //    Right &rhs, Fn fn) {
+    //        mult.fma_inplace(lhs.vector_type(), rhs.vector_type(), fn);
+    //    }
+    //
+    //    template <typename Left, typename Right, typename Fn, typename
+    //    Mult=Multiplication> static enable_if_t<has_degree_t<Left>::value &&
+    //    has_fma_inplace<Left, Right, Fn, Mult>::value>
+    //    multiply_and_add_inplace(const Multiplication& mult, Left& lhs, const
+    //    Right& rhs, Fn fn)
+    //    {
+    //        using traits = basis_trait<typename Left::basis_type>;
+    //        mult.fma_inplace(lhs.base_vector(), rhs.base_vector(), fn,
+    //                traits::max_degree(lhs.basis()));
+    //    }
+    //
+    //    template <typename Left, typename Right, typename Fn, typename
+    //    Mult=Multiplication> static enable_if_t<has_degree_t<Left>::value &&
+    //    has_fma_inplace<Left, Right, Fn, Mult>::value>
+    //    multiply_and_add_inplace(const Multiplication &mult, Left &lhs, const
+    //    Right &rhs, Fn fn, deg_t max_deg) {
+    //        mult.fma_inplace(lhs.base_vector(), rhs.base_vector(), fn,
+    //        max_deg);
+    //    }
+
+    template <typename Left, typename Right, typename Fn>
+    static enable_if_t<!has_degree_t<Left>::value> multiply_inplace(
+            const Multiplication& mult, Left& lhs, const Right& rhs, Fn fn
+    )
+    {
+        //        Left tmp(lhs.get_basis());
+        //        mult.fma(tmp.base_vector(), lhs.base_vector(),
+        //        rhs.base_vector(), fn); lhs.swap(tmp);
+        mult.multiply_inplace(lhs.base_vector(), rhs.base_vector(), fn);
+    }
+
+    template <typename Left, typename Right, typename Fn>
+    static enable_if_t<has_degree_t<Left>::value> multiply_inplace(
+            const Multiplication& mult, Left& lhs, const Right& rhs, Fn fn,
+            deg_t max_deg
+    )
+    {
+        //        Left tmp(lhs.get_basis());
+        //        mult.fma(tmp.base_vector(), lhs.base_vector(),
+        //        rhs.base_vector(), fn, max_deg); std::swap(lhs, tmp);
+        //        lhs.swap(tmp);
+        mult.multiply_inplace(
+                lhs.base_vector(), rhs.base_vector(), fn, max_deg
+        );
+    }
+
+    template <typename Left, typename Right, typename Fn>
+    static enable_if_t<!has_degree_t<Left>::value> multiply_inplace(
+            const Multiplication& mult, Left& lhs, const Right& rhs, Fn fn,
+            deg_t
+    )
+    {
+        //        Left tmp(lhs.get_basis());
+        //        mult.fma(tmp.base_vector(), lhs.base_vector(),
+        //        rhs.base_vector(), fn, max_deg); std::swap(lhs, tmp);
+        //        lhs.swap(tmp);
+        mult.multiply_inplace(lhs.base_vector(), rhs.base_vector(), fn);
+    }
+
+    template <typename Left, typename Right, typename Fn>
+    static enable_if_t<has_degree_t<Left>::value> multiply_inplace(
+            const Multiplication& mult, Left& lhs, const Right& rhs, Fn fn
+    )
+    {
+        auto max_deg
+                = basis_trait<typename Left::basis_type>::max_degree(lhs.basis()
+                );
+        multiply_inplace(mult, lhs, rhs, fn, max_deg);
+    }
+};
+
+namespace dtl {
+
+template <typename Basis, typename Coefficients>
+class general_multiplication_helper
+{
+protected:
+    using basis_traits = basis_trait<Basis>;
+    using key_type = typename basis_traits::key_type;
+    using coeff_traits = coefficient_trait<Coefficients>;
+    using scalar_type = typename coeff_traits::scalar_type;
+
+    using key_value = pair<key_type, scalar_type>;
+    std::vector<key_value> right_buffer;
+
+public:
+    using const_iterator = typename std::vector<key_value>::const_iterator;
+
+    template <typename Vector>
+    explicit general_multiplication_helper(const Vector& rhs) : right_buffer()
+    {
+        right_buffer.reserve(rhs.size());
+        for (auto item : rhs) {
+            right_buffer.emplace_back(item.key(), item.value());
+        }
+    }
+
+    const_iterator begin() const noexcept { return right_buffer.begin(); }
+    const_iterator end() const noexcept { return right_buffer.end(); }
+};
+
+template <typename It>
+class degree_range_iterator_helper
+{
+    It m_begin, m_end;
+
+public:
+    using iterator = It;
+
+    degree_range_iterator_helper(It begin, It end) : m_begin(begin), m_end(end)
+    {}
+
+    iterator begin() noexcept { return m_begin; }
+    iterator end() noexcept { return m_end; }
+};
+
+template <typename Basis, typename Coefficients>
+class graded_multiplication_helper
+    : protected general_multiplication_helper<Basis, Coefficients>
+{
+    using base_type = general_multiplication_helper<Basis, Coefficients>;
+    using ordering = typename base_type::basis_traits::kv_ordering;
+
+    using base_type::right_buffer;
+    using typename base_type::basis_traits;
+    using typename base_type::key_type;
+    using typename base_type::key_value;
+    using typename base_type::scalar_type;
+
+    using base_iter = typename std::vector<key_value>::const_iterator;
+
+    std::vector<base_iter> degree_ranges;
+    deg_t max_degree;
+
+public:
+    using iterable = degree_range_iterator_helper<base_iter>;
+
+    template <typename Vector>
+    explicit graded_multiplication_helper(const Vector& rhs) : base_type(rhs)
+    {
+        ordering order;
+        std::sort(right_buffer.begin(), right_buffer.end(), order);
+
+        const auto& basis = rhs.basis();
+        max_degree = basis_traits::max_degree(basis);
+        degree_ranges.reserve(max_degree + 1);
+        auto it = right_buffer.cbegin();
+        auto end = right_buffer.cend();
+        degree_ranges.push_back(it);
+        auto degree = 0;
+
+        for (; it != end; ++it) {
+            auto current = basis_traits::degree(basis, it->first);
+            for (; degree < current; ++degree) { degree_ranges.push_back(it); }
+        }
+        for (; degree <= max_degree; ++degree) { degree_ranges.push_back(end); }
+    }
+
+    iterable degree_range(deg_t degree) noexcept
+    {
+        if (degree < 0) {
+            return iterable(right_buffer.begin(), right_buffer.begin());
+        }
+        if (degree > max_degree) {
+            return iterable(right_buffer.end(), right_buffer.end());
+        }
+        return iterable(right_buffer.begin(), degree_ranges[degree + 1]);
+    }
+};
+
+}// namespace dtl
+
+template <
+        typename Multiplier, typename Basis, dimn_t SSO = 1,
+        typename Scalar = int>
+class base_multiplier
+{
+    using basis_traits = basis_trait<Basis>;
+
+public:
+    using key_type = typename basis_traits::key_type;
+    using scalar_type = Scalar;
+    using pair_type = pair<key_type, scalar_type>;
+
+    using product_type = boost::container::small_vector<pair_type, SSO>;
+    using reference = const boost::container::small_vector_base<pair_type>&;
+
+    static product_type uminus(reference arg)
+    {
+        product_type result;
+        result.reserve(arg.size());
+        for (const auto& item : arg) {
+            result.emplace_back(item.first, -item.second);
+        }
+        return result;
+    }
+
+    static product_type add(reference lhs, reference rhs)
+    {
+        std::map<key_type, scalar_type> tmp;
+        tmp.insert(lhs.begin(), lhs.end());
+
+        for (const auto& item : rhs) { tmp[item.first] += item.second; }
+
+        return {tmp.begin(), tmp.end()};
+    }
+
+    static product_type sub(reference lhs, reference rhs)
+    {
+        std::map<key_type, scalar_type> tmp;
+        tmp.insert(lhs.begin(), lhs.end());
+
+        for (const auto& item : rhs) { tmp[item.first] -= item.second; }
+
+        return {tmp.begin(), tmp.end()};
+    }
+
+    product_type mul(const Basis& basis, reference lhs, key_type rhs) const
+    {
+        std::map<key_type, scalar_type> tmp;
+
+        const auto& mult = static_cast<const Multiplier&>(*this);
+        for (const auto& outer : lhs) {
+            for (const auto& inner : mult(basis, outer.first, rhs)) {
+                tmp[inner.first] += outer.second * inner.second;
+            }
+        }
+
+        return {tmp.begin(), tmp.end()};
+    }
+
+    product_type mul(const Basis& basis, key_type lhs, reference rhs) const
+    {
+        std::map<key_type, scalar_type> tmp;
+
+        const auto& mult = static_cast<const Multiplier&>(*this);
+        for (const auto& outer : rhs) {
+            for (const auto& inner : mult(basis, lhs, outer.first)) {
+                tmp[inner.first] += inner.second * outer.second;
+            }
+        }
+
+        return {tmp.begin(), tmp.end()};
+    }
+
+    product_type mul(const Basis& basis, reference lhs, reference rhs) const
+    {
+        std::map<key_type, scalar_type> tmp;
+
+        const auto& mult = static_cast<const Multiplier&>(*this);
+        for (const auto& litem : lhs) {
+            for (const auto& ritem : rhs) {
+                for (const auto& inner :
+                     mult(basis, litem.first, ritem.first)) {
+                    tmp[inner.first]
+                            += inner.second * litem.second * ritem.second;
+                }
+            }
+        }
+
+        return {tmp.begin(), tmp.end()};
+    }
+};
+
+namespace dtl {
+
+template <typename Derived>
+struct derived_or_this {
+    template <typename Base>
+    static const Derived& cast(const Base& arg) noexcept
+    {
+        return static_cast<const Derived&>(arg);
+    }
+};
+
+template <>
+struct derived_or_this<void> {
+    template <typename Base>
+    static const Base& cast(const Base& arg) noexcept
+    {
+        return arg;
+    }
+};
+
+}// namespace dtl
+
+template <typename Multiplier, typename Derived = void>
+class base_multiplication
+{
+
+    template <typename V>
+    using basis_t = typename V::basis_type;
+
+    template <typename V>
+    using key_tp = typename basis_trait<basis_t<V>>::key_type;
+
+    template <typename V>
+    using scal_t = typename V::scalar_type;
+
+    template <typename V, typename Sca>
+    using key_vect = std::vector<
+            pair<typename basis_trait<typename V::basis_type>::key_type, Sca>>;
+
+    template <typename V>
+    using helper_type = dtl::general_multiplication_helper<
+            typename V::basis_type, typename V::coefficient_ring>;
+    template <typename V>
+    using graded_helper_type = dtl::graded_multiplication_helper<
+            typename V::basis_type, typename V::coefficient_ring>;
+
+    //    template <typename OutVector, typename KeyProd, typename Sca>
+    //    void asp_helper(OutVector& out, KeyProd&& key_prod, Sca&& scalar)
+    //    const
+    //    {
+    //        using scalar_type = scal_t<OutVector>;
+    //        scalar_type s(std::forward<Sca>(scalar));
+    //        out.inplace_binary_op(std::forward<KeyProd>(key_prod), [s](scalar_type&
+    //        lhs, const scalar_type& rhs) {
+    //            return lhs += (rhs*s);
+    //        });
+    //    }
+
+    using caster = dtl::derived_or_this<Derived>;
+
+    template <typename OutVector, typename ProductType, typename PSca>
+    void asp_helper(OutVector& out, ProductType&& key_prod, PSca&& scalar) const
+    {
+        using scalar_type = scal_t<OutVector>;
+        scalar_type s(std::forward<PSca>(scalar));
+
+        for (const auto& kv_pair : key_prod) {
+            out[kv_pair.first] += scalar_type(kv_pair.second) * s;
+        }
+    }
+
+protected:
+    Multiplier m_mult;
+
+public:
+    using basis_type = typename Multiplier::basis_type;
+    using key_type = typename basis_trait<basis_type>::key_type;
+    using generic_ref
+            = const boost::container::small_vector_base<pair<key_type, int>>&;
+
+    template <
+            typename... Args,
+            typename
+            = enable_if_t<is_constructible<Multiplier, Args...>::value>>
+    explicit base_multiplication(Args&&... args)
+        : m_mult(std::forward<Args>(args)...)
+    {}
+
+    template <typename Basis, typename Key>
+    decltype(auto) multiply(const Basis& basis, Key lhs, Key rhs) const
+    {
+        return m_mult(basis, lhs, rhs);
+    }
+
+    template <typename Basis>
+    decltype(auto)
+    multiply_generic(const Basis& basis, generic_ref lhs, generic_ref rhs) const
+    {
+        return m_mult.mul(basis, lhs, rhs);
+    }
+
+    template <
+            typename OutVector, typename LeftVector, typename RightVector,
+            typename Fn>
+    void
+    fma(OutVector& out, const LeftVector& lhs, const RightVector& rhs,
+        Fn fn) const
+    {
+        // The helper makes a contiguous copy of rhs key-value pairs
+        // so the inner loop is always contiguous, rather than potentially
+        // a linked list or other cache unfriendly data structure.
+        helper_type<RightVector> helper(rhs);
+        const auto& basis = out.basis();
+
+        for (auto litem : lhs) {
+            for (auto ritem : helper) {
+                asp_helper(
+                        out, m_mult(basis, litem.key(), ritem.first),
+                        fn(litem.value() * ritem.second)
+                );
+            }
+        }
+    }
+
+    template <
+            typename OutVector, typename LeftVector, typename RightVector,
+            typename Fn>
+    void
+    fma(OutVector& out, const LeftVector& lhs, const RightVector& rhs, Fn fn,
+        deg_t max_deg) const
+    {
+        using out_basis_traits = basis_trait<typename OutVector::basis_type>;
+        using lhs_basis_traits = basis_trait<typename LeftVector::basis_type>;
+
+        // The helper makes a contiguous copy of rhs key-value pairs
+        // so the inner loop is always contiguous, rather than potentially
+        // a linked list or other cache unfriendly data structure.
+        // The graded helper also sorts the keys and constructs a buffer
+        // of degree ranges that we can use to truncate products that
+        // would overflow the max degree.
+        graded_helper_type<RightVector> helper(rhs);
+        const auto& basis = out.basis();
+
+        auto out_deg = std::min(
+                out_basis_traits::max_degree(basis), lhs.degree() + rhs.degree()
+        );
+        out.update_degree(out_deg);
+        const auto& lhs_basis = lhs.basis();
+        for (auto litem : lhs) {
+            auto lkey = litem.key();
+            auto lhs_degree = lhs_basis_traits::degree(lhs_basis, lkey);
+            auto rhs_degree = out_deg - lhs_degree;
+            for (auto ritem : helper.degree_range(rhs_degree)) {
+                asp_helper(
+                        out, m_mult(basis, lkey, ritem.first),
+                        fn(litem.value() * ritem.second)
+                );
+            }
+        }
+    }
+
+    template <typename LeftVector, typename RightVector, typename Fn>
+    void
+    multiply_inplace(LeftVector& left, const RightVector& right, Fn op) const
+    {
+        if (!left.empty() && !right.empty()) {
+            LeftVector tmp(left.get_basis());
+            caster::cast(*this).fma(tmp, left, right, op);
+            left = std::move(tmp);
+        } else {
+            left.clear();
+        }
+    }
+    template <typename LeftVector, typename RightVector, typename Fn>
+    void multiply_inplace(
+            LeftVector& left, const RightVector& right, Fn op, deg_t max_deg
+    ) const
+    {
+        if (!left.empty() && !right.empty()) {
+            LeftVector tmp(left.get_basis());
+            tmp.update_degree(std::min(left.degree() + right.degree(), max_deg)
+            );
+            caster::cast(*this).fma(tmp, left, right, op, max_deg);
+            left = std::move(tmp);
+        } else {
+            left.clear();
+        }
+    }
+};
+
+template <
+        typename Basis, typename Coefficients, typename Multiplication,
+        template <typename, typename> class VectorType,
+        template <typename> class StorageModel,
+        template <
+                typename, typename, template <typename, typename> class,
+                template <typename> class, typename...>
+        class Base
+        = vector,
+        typename... BaseArgs>
+class algebra
+    : public Base<Basis, Coefficients, VectorType, StorageModel, BaseArgs...>
+{
+    using base_type
+            = Base<Basis, Coefficients, VectorType, StorageModel, BaseArgs...>;
+
+public:
+    using vector_type = vector<Basis, Coefficients, VectorType, StorageModel>;
+    static_assert(
+            is_same<base_type, vector_type>::value
+                    || is_base_of<vector_type, base_type>::value,
+            "algebra must derive from vector"
+    );
+
+    using multiplication_type = Multiplication;
+
+    using typename vector_type::basis_pointer;
+    using multiplication_pointer = std::shared_ptr<const multiplication_type>;
+
+    using typename vector_type::basis_type;
+    using typename vector_type::coefficient_ring;
+    using typename vector_type::key_type;
+    using typename vector_type::rational_type;
+    using typename vector_type::scalar_type;
+
+private:
+    multiplication_pointer p_mult;
+
+public:
+    //    using vector_type::vector_type;
+
+    algebra()
+        : vector_type(), p_mult(multiplication_registry<Multiplication>::get(
+                                 vector_type::basis()
+                         ))
+    {}
+
+    explicit algebra(basis_pointer basis)
+        : vector_type(std::move(basis)),
+          p_mult(multiplication_registry<Multiplication>::get(
+                  vector_type::basis()
+          ))
+    {}
+
+    explicit algebra(vector_type&& arg)
+        : vector_type(std::move(arg)),
+          p_mult(multiplication_registry<Multiplication>::get(
+                  vector_type::basis()
+          ))
+    {}
+
+    template <typename Scalar>
+    algebra(basis_pointer basis, std::shared_ptr<const Multiplication> mul,
+            std::initializer_list<Scalar> args)
+        : vector_type(std::move(basis), args), p_mult(std::move(mul))
+    {}
+
+    algebra(basis_pointer basis, std::shared_ptr<const Multiplication> mult)
+        : vector_type(basis), p_mult(std::move(mult))
+    {}
+
+    algebra(const vector_type& base, std::shared_ptr<const Multiplication> mult)
+        : vector_type(base), p_mult(std::move(mult))
+    {}
+
+    template <
+            typename... Args,
+            typename
+            = enable_if_t<is_constructible<vector_type, Args...>::value>>
+    explicit algebra(basis_pointer basis, Args... args)
+        : vector_type(std::move(basis), std::forward<Args>(args)...),
+          p_mult(multiplication_registry<Multiplication>::get(
+                  vector_type::basis()
+          ))
+    {}
+
+    template <
+            typename... Args,
+            typename
+            = enable_if_t<is_constructible<vector_type, Args...>::value>>
+    explicit algebra(
+            basis_pointer basis, std::shared_ptr<const Multiplication> mul,
+            Args&&... args
+    )
+        : vector_type(std::move(basis), std::forward<Args>(args)...), p_mult(std::move(mul))
+    {}
+
+    template <
+            template <typename, typename> class OtherVectorType,
+            template <typename> class OtherStorageModel>
+    explicit algebra(const algebra<
+                     Basis, Coefficients, Multiplication, OtherVectorType,
+                     OtherStorageModel>& other)
+        : vector_type((other)), p_mult(other.p_mult)
+    {}
+
+    algebra(const algebra& other) : vector_type(other), p_mult(other.p_mult) {}
+
+    algebra(algebra&& other) noexcept
+        : vector_type(static_cast<vector_type&&>(other)),
+          p_mult(std::move(other.p_mult))
+    {}
+
+    algebra& operator=(const algebra& other)
+    {
+        if (&other != this) {
+            vector_type::operator=(other);
+            p_mult = other.p_mult;
+        }
+        return *this;
+    }
+
+    algebra& operator=(algebra&& other) noexcept
+    {
+        if (&other != this) {
+            p_mult = std::move(other.p_mult);
+            vector_type::operator=(static_cast<vector_type&&>(other));
+        }
+        return *this;
+    }
+
+    std::shared_ptr<const multiplication_type> multiplication() const noexcept
+    {
+        return p_mult;
+    }
+
+    algebra create_alike() const {
+        return algebra(this->get_basis(), p_mult);
+    }
+
+    algebra& add_mul(const algebra& lhs, const algebra& rhs)
+    {
+        using traits = multiplication_traits<Multiplication>;
+        traits::multiply_and_add(
+                *multiplication(), *this, lhs, rhs,
+                [](scalar_type s) { return s; }
+        );
+        return *this;
+    }
+    algebra& sub_mul(const algebra& lhs, const algebra& rhs)
+    {
+        using traits = multiplication_traits<Multiplication>;
+        traits::multiply_and_add(
+                *multiplication(), *this, lhs, rhs,
+                [](scalar_type s) { return -s; }
+        );
+        return *this;
+    }
+
+    algebra& mul_scal_prod(const algebra& rhs, const scalar_type& scal)
+    {
+        using traits = multiplication_traits<Multiplication>;
+        traits::multiply_inplace(
+                *multiplication(), *this, rhs,
+                [scal](scalar_type s) { return s * scal; }
+        );
+        return *this;
+    }
+    algebra& mul_scal_div(const algebra& rhs, const rational_type& scal)
+    {
+        using traits = multiplication_traits<Multiplication>;
+        traits::multiply_inplace(
+                *multiplication(), *this, rhs,
+                [scal](scalar_type s) { return s / scal; }
+        );
+        return *this;
+    }
+
+    algebra&
+    mul_scal_div(const algebra& rhs, const rational_type& scal, deg_t degree)
+    {
+        using traits = multiplication_traits<Multiplication>;
+        traits::multiply_inplace(
+                *multiplication(), *this, rhs,
+                [scal](scalar_type s) { return s / scal; }, degree
+        );
+        return *this;
+    }
+};
+
+template <
+        typename Basis, typename Coefficients, typename Multiplication,
+        template <typename, typename> class VectorType,
+        template <typename> class StorageModel,
+        typename Base = algebra<
+                Basis, Coefficients, Multiplication, VectorType, StorageModel>>
+class unital_algebra : public Base
+{
+    using algebra_base = algebra<
+            Basis, Coefficients, Multiplication, VectorType, StorageModel>;
+
+    static_assert(
+            is_same<Base, algebra_base>::value
+                    || is_base_of<algebra_base, Base>::value,
+            "algebra types must derive from algebra"
+    );
+
+public:
+    using typename algebra_base::basis_pointer;
+    using typename algebra_base::scalar_type;
+
+    using Base::Base;
+
+    template <
+            typename Scalar,
+            typename
+            = enable_if_t<is_constructible<scalar_type, Scalar>::value>>
+    explicit unital_algebra(basis_pointer basis, Scalar val)
+        : algebra_base(
+                std::move(basis),
+                basis_trait<Basis>::first_key(*algebra_base::p_basis),
+                scalar_type(val)
+        )
+    {}
+
+    template <
+            typename Scalar,
+            typename
+            = enable_if_t<is_constructible<scalar_type, Scalar>::value>>
+    explicit unital_algebra(Scalar val)
+        : algebra_base(
+                basis_trait<Basis>::first_key(*algebra_base::p_basis),
+                scalar_type(val)
+        )
+    {}
+};
+
+template <
+        typename Basis, typename Coefficients, typename Multiplication,
+        template <typename, typename> class VectorType,
+        template <typename> class StorageModel,
+        typename Base = algebra<
+                Basis, Coefficients, Multiplication, VectorType, StorageModel>>
+class graded_algebra : public Base
+{
+
+    using algebra_base = algebra<
+            Basis, Coefficients, Multiplication, VectorType, StorageModel>;
+
+    static_assert(
+            is_same<Base, algebra_base>::value
+                    || is_base_of<algebra_base, Base>::value,
+            "algebra types must derive from algebra"
+    );
+
+public:
+    using Base::Base;
+};
+
+template <
+        typename Basis, typename Coefficients, typename Multiplication,
+        template <typename, typename> class VectorType,
+        template <typename> class StorageModel>
+using graded_unital_algebra = unital_algebra<
+        Basis, Coefficients, Multiplication, VectorType, StorageModel,
+        graded_algebra<
+                Basis, Coefficients, Multiplication, VectorType, StorageModel>>;
+
+namespace dtl {
+
+template <typename Algebra>
+class is_algebra
+{
+    template <
+            typename Basis, typename Coefficients, typename Multiplication,
+            template <typename, typename> class VType,
+            template <typename> class SModel>
+    static true_type
+    test(algebra<Basis, Coefficients, Multiplication, VType, SModel>&);
+
+    static false_type test(...);
+
+public:
+    static constexpr bool value = decltype(test(declval<Algebra&>()))::value;
+};
+
+}// namespace dtl
+
+template <typename Algebra>
+enable_if_t<dtl::is_algebra<Algebra>::value, Algebra>
+operator*(const Algebra& lhs, const Algebra& rhs)
+{
+    using traits = multiplication_traits<typename Algebra::multiplication_type>;
+    using scalar_type = typename Algebra::scalar_type;
+
+    auto multiplication = lhs.multiplication();
+    if (!multiplication) { multiplication = rhs.multiplication(); }
+    Algebra result(lhs.get_basis(), multiplication);
+    if (multiplication && !lhs.empty() && !rhs.empty()) {
+        traits::multiply_and_add(
+                *multiplication, result, lhs, rhs,
+                [](scalar_type s) { return s; }
+        );
+    }
+    return result;
+}
+
+template <typename Algebra>
+enable_if_t<dtl::is_algebra<Algebra>::value, Algebra&>
+operator*=(Algebra& lhs, const Algebra& rhs)
+{
+    using traits = multiplication_traits<typename Algebra::multiplication_type>;
+    using scalar_type = typename Algebra::scalar_type;
+    if (rhs.empty()) {
+        lhs.clear();
+        return lhs;
+    }
+    auto multiplication = lhs.multiplication();
+    if (!multiplication) { multiplication = rhs.multiplication(); }
+
+    if (multiplication && !lhs.empty()) {
+        traits::multiply_inplace(
+                *multiplication, lhs, rhs, [](scalar_type arg) { return arg; }
+        );
+    }
+    return lhs;
+}
+
+template <typename Algebra>
+enable_if_t<dtl::is_algebra<Algebra>::value, Algebra>
+commutator(const Algebra& lhs, const Algebra& rhs)
+{
+    using traits = multiplication_traits<typename Algebra::multiplication_type>;
+    using scalar_type = typename Algebra::scalar_type;
+
+    auto multiplication = lhs.multiplication();
+    if (!multiplication) { multiplication = rhs.multiplication(); }
+
+    Algebra result(lhs.get_basis(), multiplication);
+    if (multiplication && !lhs.empty() && !rhs.empty()) {
+        traits::multiply_and_add(*multiplication, result, lhs, rhs);
+        traits::multiply_and_add(
+                *multiplication, result, rhs, lhs, [](const scalar_type& arg) {
+                    return -arg;
+                }
+        );
+    }
+    return result;
+}
+
+
+
+template <typename Multiplication, typename LVector, typename RVector>
+LVector multiply(const Multiplication& multiplication, const LVector& left,
+                 const
+                 RVector& right) {
+    using traits = multiplication_traits<Multiplication>;
+    LVector result = left.create_alike();
+    traits::multiply_and_add(multiplication, result, left, right);
+    return result;
+}
+
+
+}// namespace lal
+
+#endif// LIBALGEBRA_LITE_ALGEBRA_H

--- a/vendored/libalgebra_lite/algebra.h
+++ b/vendored/libalgebra_lite/algebra.h
@@ -65,7 +65,7 @@ private:
     template <typename L, typename R, typename F, typename M>
     struct has_fma_inplace<
             L, R, F, M,
-            void_t<decltype(M::template fma_inplace(
+            void_t<decltype(M::fma_inplace(
                     declval<L&>(), declval<const R&>(), declval<F>()
             ))>> : true_type {
     };
@@ -77,7 +77,7 @@ private:
     template <typename L, typename R, typename F, typename M>
     struct has_fma_inplace_with_deg<
             L, R, F, M,
-            void_t<decltype(M::template fma_inplace(declval<L&>(), declval<const R&>(), declval<F>()), declval<deg_t>())>>
+            void_t<decltype(M::fma_inplace(declval<L&>(), declval<const R&>(), declval<F>()), declval<deg_t>())>>
         : true_type {
     };
 

--- a/vendored/libalgebra_lite/algebra/free_tensor_multiplier.cpp
+++ b/vendored/libalgebra_lite/algebra/free_tensor_multiplier.cpp
@@ -1,0 +1,30 @@
+//
+// Created by user on 04/09/22.
+//
+
+#include "libalgebra_lite/free_tensor.h"
+
+
+using namespace lal;
+
+
+
+
+typename free_tensor_multiplier::product_type
+free_tensor_multiplier::operator()(
+        const tensor_basis& basis,
+        free_tensor_multiplier::key_type lhs,
+        free_tensor_multiplier::key_type rhs) const
+{
+    // Note that product_type is small and the product only ever
+    // has 1 element (if any) so no allocation takes place
+    if (lhs.degree() + rhs.degree() <= static_cast<dimn_t>(basis.depth())) {
+        return product_type{{concat_product(basis, lhs, rhs), 1}};
+    }
+    return {};
+}
+
+
+namespace lal {
+template class multiplication_registry<free_tensor_multiplication>;
+}

--- a/vendored/libalgebra_lite/algebra/half_shuffle_multiplier.cpp
+++ b/vendored/libalgebra_lite/algebra/half_shuffle_multiplier.cpp
@@ -1,0 +1,189 @@
+//
+// Created by sam on 03/09/22.
+//
+
+#include "libalgebra_lite/shuffle_tensor.h"
+#include "libalgebra_lite/free_tensor.h"
+
+
+
+
+
+using namespace lal;
+
+namespace lal {
+template class base_multiplier<left_half_shuffle_tensor_multiplier, tensor_basis>;
+template class base_multiplier<right_half_shuffle_tensor_multiplier, tensor_basis>;
+
+
+std::ostream& operator<<(std::ostream& os, std::pair<const tensor_basis*, index_key<>> arg)
+{
+    return arg.first->print_key(os, arg.second);
+}
+
+
+} // namespace lal
+
+
+typename left_half_shuffle_tensor_multiplier::product_type
+left_half_shuffle_tensor_multiplier::shuffle(
+        const tensor_basis& basis, key_type lhs, key_type rhs) const
+{
+    const auto lhs_deg = lhs.degree();
+    const auto rhs_deg = rhs.degree();
+
+    if (lhs_deg == 0) {
+        return {{rhs, 1}};
+    }
+    if (rhs_deg == 0) {
+        return {{lhs, 1}};
+    }
+
+//    const auto& left = operator()(basis, lhs, rhs);
+//    const auto& right = operator()(basis, rhs, lhs);
+    return base_type::add(operator()(basis, lhs, rhs),
+            operator()(basis, rhs, lhs));
+//    return base_type::add(left, right);
+}
+
+typename left_half_shuffle_tensor_multiplier::product_type
+lal::left_half_shuffle_tensor_multiplier::key_prod_impl(
+        const tensor_basis& basis,
+        key_type lhs, key_type rhs) const
+{
+    using ftm = free_tensor_multiplier;
+
+    std::map<key_type, scalar_type> tmp;
+
+    const auto lhs_deg = static_cast<deg_t>(lhs.degree());
+    const auto rhs_deg = static_cast<deg_t>(rhs.degree());
+
+    if (lhs_deg + rhs_deg <= basis.depth()) {
+
+        if (lhs_deg == 0) {
+            return {};
+        }
+        if (rhs_deg == 0) {
+            return {{lhs, 1}};
+        }
+
+        const auto lparent = basis.lparent(lhs);
+        const auto& right_part = shuffle(basis, basis.rparent(lhs), rhs);
+
+        for (const auto& item : right_part) {
+            tmp[ftm::concat_product(basis, lparent, item.first)] += item.second;
+        }
+    }
+
+    return {tmp.begin(), tmp.end()};
+}
+
+
+typename left_half_shuffle_tensor_multiplier::reference
+left_half_shuffle_tensor_multiplier::operator()(
+        const tensor_basis& basis, key_type lhs, key_type rhs) const
+{
+    static const boost::container::small_vector<typename base_type::pair_type, 0> null;
+
+    if (static_cast<deg_t>(lhs.degree() + rhs.degree()) > basis.depth()) {
+        return null;
+    }
+
+    parent_type parents{lhs, rhs};
+    auto found = m_cache.find(parents);
+    if (found != m_cache.end()) {
+        return found->second;
+    }
+
+    return m_cache[parents] = key_prod_impl(basis, lhs, rhs);
+}
+
+typename right_half_shuffle_tensor_multiplier::parent_type
+right_half_shuffle_tensor_multiplier::split_at_right(
+        const tensor_basis& basis, key_type key) const noexcept
+{
+    const auto width = basis.width();
+    const auto deg = key.degree();
+    const auto index = key.index();
+
+    if (deg == 0) {
+        return { key, key };
+    }
+    if (deg == 1) {
+        const key_type null(0, 0);
+        return { null, key };
+    }
+
+    return { key_type(key.degree()-1, index / width),
+             key_type(1, index % width) };
+}
+
+typename right_half_shuffle_tensor_multiplier::product_type
+right_half_shuffle_tensor_multiplier::key_prod_impl(
+        const tensor_basis& basis,
+        key_type lhs,
+        key_type rhs) const
+{
+
+    std::map<key_type, scalar_type> tmp;
+
+    const auto lhs_deg = static_cast<deg_t>(lhs.degree());
+    const auto rhs_deg = static_cast<deg_t>(rhs.degree());
+
+    if (lhs_deg + rhs_deg <= basis.depth()) {
+
+        if (lhs_deg == 0) {
+            return {};
+        }
+        if (rhs_deg == 0) {
+            return {{lhs, 1}};
+        }
+
+        const auto parents = split_at_right(basis, rhs);
+        const auto& left_part = shuffle(basis, lhs, parents.first);
+
+        for (const auto& item : left_part) {
+            tmp[free_tensor_multiplier::concat_product(basis, item.first, parents.second)] += item.second;
+        }
+    }
+
+    return {tmp.begin(), tmp.end()};
+}
+typename right_half_shuffle_tensor_multiplier::product_type
+right_half_shuffle_tensor_multiplier::shuffle(
+        const tensor_basis& basis,
+        key_type lhs, key_type rhs) const
+{
+    const auto lhs_deg = lhs.degree();
+    const auto rhs_deg = rhs.degree();
+
+    if (lhs_deg==0) {
+        return {{rhs, 1}};
+    }
+    if (rhs_deg==0) {
+        return {{lhs, 1}};
+    }
+
+    return base_type::add(operator()(basis, lhs, rhs),
+            operator()(basis, rhs, lhs));
+}
+
+typename right_half_shuffle_tensor_multiplier::reference
+right_half_shuffle_tensor_multiplier::operator()(
+        const tensor_basis& basis,
+        key_type lhs, key_type rhs) const
+{
+    static const boost::container::small_vector<typename base_type::pair_type, 0> null;
+
+    if (lhs.degree() + rhs.degree() > static_cast<dimn_t>(basis.depth())) {
+        return null;
+    }
+
+    parent_type parents{lhs, rhs};
+    auto found = m_cache.find(parents);
+    if (found != m_cache.end()) {
+        return found->second;
+    }
+
+    return m_cache[parents] = key_prod_impl(basis, lhs, rhs);
+}

--- a/vendored/libalgebra_lite/algebra/lie_multiplier.cpp
+++ b/vendored/libalgebra_lite/algebra/lie_multiplier.cpp
@@ -1,0 +1,73 @@
+//
+// Created by user on 27/08/22.
+//
+
+
+#include "libalgebra_lite/lie.h"
+
+#include <mutex>
+#include <unordered_map>
+
+#include <boost/functional/hash.hpp>
+
+namespace lal {
+
+template class base_multiplier<lie_multiplier, hall_basis, 2>;
+
+lie_multiplier::product_type
+lie_multiplier::key_prod_impl(const hall_basis& basis, key_type lhs, key_type rhs) const
+{
+    assert(basis.width() == m_width);
+
+    if (lhs>rhs) {
+        return lie_multiplier::uminus(operator()(basis, rhs, lhs));
+    }
+
+    product_type result;
+    if (basis.degree(lhs) + basis.degree(rhs) > basis.depth()) {
+        return result;
+    }
+
+    auto found = basis.find(parent_type(lhs, rhs));
+    if (found.found) {
+        result.emplace_back(found.it->second, 1);
+    } else {
+        auto lparent = basis.lparent(rhs);
+        auto rparent = basis.rparent(rhs);
+
+        auto result_left = mul(basis, operator()(basis, lhs, lparent), rparent);
+        auto result_right = mul(basis, operator()(basis, lhs, rparent), lparent);
+
+        return sub(result_left, result_right);
+    }
+
+    return result;
+}
+
+
+lie_multiplier::reference lie_multiplier::operator()(
+        const hall_basis& basis,
+        lie_multiplier::key_type lhs, lie_multiplier::key_type rhs) const
+{
+    static const product_type null;
+    if (lhs == rhs) {
+        return null;
+    }
+
+    std::lock_guard<std::recursive_mutex> access(m_lock);
+
+    parent_type parents {lhs, rhs};
+    auto& found = m_cache[parents];
+    if (!found.empty()) {
+        return found;
+    }
+
+    found = key_prod_impl(basis, lhs, rhs);
+    return found;
+}
+
+
+
+template class multiplication_registry<lie_multiplication>;
+
+} // namespace alg

--- a/vendored/libalgebra_lite/algebra/polynomial.cpp
+++ b/vendored/libalgebra_lite/algebra/polynomial.cpp
@@ -1,0 +1,15 @@
+//
+// Created by user on 30/08/22.
+//
+
+#include "libalgebra_lite/polynomial.h"
+
+namespace lal {
+
+template class polynomial<double_field>;
+template class polynomial<float_field>;
+
+#ifdef LAL_ENABLE_RATIONAL_COEFFS
+template class polynomial<rational_field>;
+#endif
+}

--- a/vendored/libalgebra_lite/algebra/polynomial_multiplier.cpp
+++ b/vendored/libalgebra_lite/algebra/polynomial_multiplier.cpp
@@ -1,0 +1,38 @@
+//
+// Created by user on 30/08/22.
+//
+
+
+#include "libalgebra_lite/polynomial.h"
+
+#include <map>
+
+
+namespace lal {
+
+
+typename polynomial_multiplier::product_type
+polynomial_multiplier::operator()(
+        const polynomial_basis& basis,
+        const key_type& lhs, const key_type& rhs) const
+{
+    std::map<letter_type, deg_t> tmp(lhs.begin(), lhs.end());
+
+    for (const auto& item : rhs) {
+        tmp[item.first] += item.second;
+    }
+    product_type result;
+    result.emplace_back(key_type(tmp.begin(), tmp.end()), 1);
+
+    return result;
+}
+
+
+std::shared_ptr<const base_multiplication<polynomial_multiplier>>
+multiplication_registry<base_multiplication<polynomial_multiplier>>::get()
+{
+    static const std::shared_ptr<const multiplication> mult(new multiplication);
+    return mult;
+}
+
+}

--- a/vendored/libalgebra_lite/algebra/polynomial_ring.cpp
+++ b/vendored/libalgebra_lite/algebra/polynomial_ring.cpp
@@ -1,0 +1,19 @@
+//
+// Created by user on 01/09/22.
+//
+
+
+#include "libalgebra_lite/coefficients.h"
+#include "libalgebra_lite/polynomial.h"
+
+
+namespace lal {
+
+template struct coefficient_ring<polynomial<float_field>, float>;
+template struct coefficient_ring<polynomial<double_field>, double>;
+
+#ifdef LAL_ENABLE_RATIONAL_COEFFS
+template struct coefficient_ring<polynomial<rational_field>, typename rational_field::scalar_type>;
+#endif
+
+}

--- a/vendored/libalgebra_lite/algebra/shuffle_multiplier.cpp
+++ b/vendored/libalgebra_lite/algebra/shuffle_multiplier.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Created by sam on 03/09/22.
+//
+
+#include "libalgebra_lite/shuffle_tensor.h"
+
+
+
+
+using namespace lal;
+
+
+typename shuffle_tensor_multiplier::base_type::product_type
+shuffle_tensor_multiplier::operator()(
+        const tensor_basis& basis,
+        typename base_type::key_type lhs,
+        typename base_type::key_type rhs) const
+{
+    if (static_cast<deg_t>(lhs.degree() + rhs.degree()) > basis.depth()) {
+        return {};
+    }
+
+
+    return half_type::shuffle(basis, lhs, rhs);
+}
+
+
+
+namespace lal {
+template class multiplication_registry<right_half_shuffle_multiplication>;
+template class multiplication_registry<left_half_shuffle_multiplication>;
+template class multiplication_registry<shuffle_tensor_multiplication>;
+}

--- a/vendored/libalgebra_lite/basis.h
+++ b/vendored/libalgebra_lite/basis.h
@@ -1,0 +1,23 @@
+//
+// Created by user on 07/02/23.
+//
+
+#ifndef LIBALGEBRA_LITE_INCLUDE_BASIS_H
+#define LIBALGEBRA_LITE_INCLUDE_BASIS_H
+
+#include "implementation_types.h"
+
+#include <memory>
+
+#include "detail/notnull.h"
+
+namespace lal {
+
+
+
+template <typename Basis>
+using basis_pointer = dtl::not_null<const Basis>;
+
+} // namespace lal
+
+#endif //LIBALGEBRA_LITE_INCLUDE_BASIS_H

--- a/vendored/libalgebra_lite/basis/hall_set.cpp
+++ b/vendored/libalgebra_lite/basis/hall_set.cpp
@@ -1,0 +1,230 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Created by user on 26/07/22.
+//
+
+#include "libalgebra_lite/hall_set.h"
+
+#include <algorithm>
+#include <unordered_map>
+#include <iostream>
+#include <functional>
+
+namespace lal {
+
+
+hall_set::hall_set(hall_set::degree_type width, hall_set::degree_type depth)
+        :  current_degree(0)
+{
+    data.reserve(1 + width);
+    letters.reserve(width);
+    m_sizes.reserve(2);
+    l2k.reserve(width);
+    degree_ranges.reserve(2);
+
+    key_type zero_key(0, 0);
+
+    data.push_back({zero_key, zero_key});
+    degree_ranges.push_back({0, 1});
+    m_sizes.push_back(0);
+
+    for (letter_type l = 1; l <= static_cast<letter_type>(width); ++l) {
+        key_type key(1, l-1);
+//        std::cout << zero_key << ' ' << key << ' ' << key << '\n';
+        parent_type parents{zero_key, key};
+        letters.push_back(l);
+        data.push_back(parents);
+        reverse_map.insert(std::make_pair(parents, key));
+        l2k.push_back(key);
+    }
+
+    std::pair<size_type, size_type> range {
+            degree_ranges[current_degree].second,
+            data.size()
+    };
+
+    degree_ranges.push_back(range);
+    m_sizes.push_back(width);
+    ++current_degree;
+
+    if (depth > 1) {
+        grow_up(depth);
+    }
+}
+
+void hall_set::grow_up(hall_set::degree_type new_depth)
+{
+
+    for (degree_type d = current_degree + 1; d <= new_depth; ++d) {
+        size_type k_index = 0;
+        for (degree_type e = 1; 2 * e <= d; ++e) {
+            letter_type i_lower, i_upper, j_lower, j_upper;
+            i_lower = degree_ranges[e].first;
+            i_upper = degree_ranges[e].second;
+            j_lower = degree_ranges[d - e].first;
+            j_upper = degree_ranges[d - e].second;
+
+            for (letter_type i = i_lower; i < i_upper; ++i) {
+                key_type ik(e, i - i_lower);
+                for (letter_type j = std::max(j_lower, i + 1); j < j_upper; ++j) {
+                    key_type jk(d-e, j-j_lower);
+                    if (data[j].first <= ik) {
+                        key_type new_key (d, k_index++);
+                        parent_type parents(ik, jk);
+                        data.push_back(parents);
+                        reverse_map.insert(std::make_pair(parents, new_key));
+//                        std::cout << parents.first << ' ' << parents.second  << ' ' << new_key << '\n';
+                    }
+                }
+            }
+        }
+
+        std::pair<size_type, size_type> range;
+        range.first = degree_ranges[current_degree].second;
+        range.second = data.size();
+        degree_ranges.push_back(range);
+        // The hall set contains an entry for the "god element" 0,
+        // so subtract one from the size.
+        m_sizes.push_back(data.size() - 1);
+
+        ++current_degree;
+    }
+}
+
+hall_set::key_type hall_set::key_of_letter(let_t let) const noexcept
+{
+    return typename hall_set::key_type {1, let-1};
+}
+hall_set::size_type hall_set::size(deg_t deg) const noexcept
+{
+    if (deg >= 0 && static_cast<dimn_t>(deg) < m_sizes.size()) {
+        return m_sizes[deg];
+    }
+    if (deg < 0 && deg >= -static_cast<idimn_t>(m_sizes.size())) {
+        return m_sizes[m_sizes.size() + deg];
+    }
+    return m_sizes.back();
+}
+hall_set::hall_set(const hall_set& existing, hall_set::degree_type deg)
+{
+
+}
+hall_set::size_type hall_set::size_of_degree(deg_t arg) const noexcept
+{
+    auto range = degree_ranges[arg];
+    return range.second - range.first;
+}
+hall_set::letter_type hall_set::get_letter(dimn_t idx) const noexcept
+{
+    return let_t(idx+1);
+}
+typename hall_set::find_result hall_set::find(hall_set::parent_type parent) const noexcept
+{
+    find_result result;
+    result.it = reverse_map.find(parent);
+    result.found = (result.it != reverse_map.end());
+    return result;
+}
+bool hall_set::letter(const hall_set::key_type &key) const noexcept
+{
+    return key.degree() == 1;
+}
+const hall_set::parent_type &hall_set::operator[](const hall_set::key_type &key) const noexcept
+{
+    const auto degree = key.degree();
+    auto index = key.index();
+    auto offset = degree_ranges[degree].first;
+    assert(index + offset < degree_ranges[degree].second);
+    assert(degree == data[index+offset].first.degree() + data[index+offset].second.degree());
+    return data[index + offset];
+//    return data[key.index() + size(deg_t(key.degree()-1)) + 1];
+}
+const hall_set::key_type &hall_set::operator[](const hall_set::parent_type &parent) const
+{
+    auto found = reverse_map.find(parent);
+    if (found != reverse_map.end()) {
+        assert(found->second.degree() == parent.first.degree() +parent.second.degree());
+        return found->second;
+    }
+    return root_element;
+}
+dimn_t hall_set::index_of_key(hall_set::key_type arg) const noexcept
+{
+    assert(arg.degree() > 0);
+    return arg.index() + size(deg_t(arg.degree())-1);
+}
+hall_set::key_type hall_set::key_of_index(hall_set::size_type index) const noexcept
+{
+    auto found = std::lower_bound(
+            ++m_sizes.begin(),
+            m_sizes.end(),
+            index,
+            std::less_equal<>()
+            );
+    if (found == m_sizes.end()) {
+        return root_element;
+    }
+    assert(found != m_sizes.begin());
+    auto deg = static_cast<deg_t>(found - m_sizes.begin());
+    auto range_begin = *(--found);
+    return key_type(deg, index - range_begin);
+}
+
+std::string hall_basis::letter_to_string(let_t letter)
+{
+    return std::to_string(letter);
+}
+std::string hall_basis::key_to_string_op(const std::string& left, const std::string& right)
+{
+    return "[" + left + "," + right + "]";
+}
+
+constexpr typename hall_set::key_type hall_set::root_element;
+constexpr typename hall_set::parent_type hall_set::root_parent;
+
+typename hall_set::find_result hall_basis::find(hall_basis::parent_type parents) const noexcept
+{
+    return p_hallset->find(parents);
+}
+std::ostream& hall_basis::print_key(std::ostream& os, hall_basis::key_type key) const
+{
+    return os << m_key_to_string(key);
+}
+template class basis_registry<hall_basis>;
+
+void hall_basis::advance_key(hall_basis::key_type &key) const {
+    const auto degree = static_cast<deg_t>(key.degree());
+    const auto bound = p_hallset->size_of_degree(degree);
+    ++key;
+    if (key.index() >= bound) {
+        key = key_type(degree+1, 0);
+    }
+}
+
+} // namespace lal

--- a/vendored/libalgebra_lite/basis/monomial.cpp
+++ b/vendored/libalgebra_lite/basis/monomial.cpp
@@ -1,0 +1,26 @@
+//
+// Created by user on 01/09/22.
+//
+
+
+#include <libalgebra_lite/polynomial_basis.h>
+#include <libalgebra_lite/packed_integer.h>
+
+using namespace lal;
+
+template class dtl::packed_integer<dimn_t, char>;
+
+deg_t lal::monomial::operator[](letter_type let) const noexcept {
+    auto found = m_data.find(let);
+    if (found != m_data.end()) {
+        return found->second;
+    }
+    return 0;
+}
+deg_t monomial::degree() const noexcept
+{
+    return std::accumulate(
+            m_data.begin(), m_data.end(), 0,
+            [](const auto& curr, const auto& key) { return curr + key.second; }
+    );
+}

--- a/vendored/libalgebra_lite/basis/polynomial_basis.cpp
+++ b/vendored/libalgebra_lite/basis/polynomial_basis.cpp
@@ -1,0 +1,69 @@
+//
+// Created by user on 05/09/22.
+//
+
+#include "libalgebra_lite/polynomial_basis.h"
+
+#include <mutex>
+#include <unordered_map>
+#include <ostream>
+
+namespace lal {
+
+
+std::ostream& operator<<(std::ostream& os, const monomial& arg)
+{
+    bool first = true;
+    for (const auto& item : arg) {
+        if (first) {
+            first = false;
+        }
+        else {
+            os << ' ';
+        }
+        if (item.second > 0) {
+            os << item.first;
+            if (item.second > 1) {
+                os << '^' << item.second;
+            }
+        }
+
+    }
+    return os;
+}
+
+monomial& monomial::operator*=(const monomial& rhs)
+{
+    const auto lend = m_data.end();
+    for (const auto& item : rhs.m_data) {
+        auto it = m_data.find(item.first);
+        if (it == lend) {
+            m_data.insert(item);
+        } else {
+            it->second += item.second;
+        }
+    }
+
+    return *this;
+}
+
+monomial operator*(const monomial& lhs, const monomial& rhs)
+{
+    monomial result(lhs);
+    result *= rhs;
+    return result;
+}
+
+
+std::ostream& polynomial_basis::print_key(std::ostream& os, const polynomial_basis::key_type& key) const
+{
+    return os << key;
+}
+
+basis_pointer<polynomial_basis> basis_registry<polynomial_basis>::get()
+{
+    static const std::unique_ptr<const polynomial_basis> basis(new polynomial_basis);
+    return basis_pointer<polynomial_basis>(basis);
+}
+
+}

--- a/vendored/libalgebra_lite/basis/tensor_basis.cpp
+++ b/vendored/libalgebra_lite/basis/tensor_basis.cpp
@@ -1,0 +1,92 @@
+//
+// Created by user on 27/07/22.
+//
+#include "libalgebra_lite/tensor_basis.h"
+
+#include <algorithm>
+#include <functional>
+
+namespace lal {
+
+
+tensor_basis::tensor_basis(deg_t width, deg_t depth) :
+        m_width (width), m_depth(depth)
+{
+    m_powers.reserve(depth+1);
+    m_sizes.reserve(depth+2);
+    m_powers.push_back(1);
+    m_sizes.push_back(1);
+
+    for (deg_t d = 1; d<=depth; ++d) {
+        m_powers.push_back(m_powers.back()*static_cast<dimn_t>(width));
+        m_sizes.push_back(1+static_cast<dimn_t>(width)*m_sizes.back());
+    }
+    m_sizes.push_back(1+static_cast<dimn_t>(width)*m_sizes.back());
+}
+
+dimn_t tensor_basis::key_to_index(tensor_basis::key_type arg) const noexcept
+{
+    return start_of_degree(deg_t(arg.degree())) + arg.index();
+}
+tensor_basis::key_type tensor_basis::index_to_key(dimn_t arg) const noexcept
+{
+    if (arg == 0) {
+        return key_type(0, 0);
+    }
+
+    auto it = std::lower_bound(m_sizes.begin(),
+            m_sizes.end(), arg, std::less_equal<>());
+
+    if (it == m_sizes.end()) {
+        return key_type(0, 0);
+    }
+
+    auto degree = static_cast<deg_t>(it - m_sizes.begin());
+    return key_type(degree, arg - *(--it));
+}
+dimn_t tensor_basis::size_of_degree(deg_t deg) const noexcept
+{
+    return m_powers[deg];
+}
+
+std::string tensor_basis::key_to_string(const tensor_basis::key_type& key) const
+{
+    std::stringstream ss;
+    print_key(ss, key);
+    return ss.str();
+}
+std::ostream& tensor_basis::print_key(std::ostream& os, const tensor_basis::key_type& key) const
+{
+    std::vector<let_t> tmp;
+    auto deg = static_cast<deg_t>(key.degree());
+    tmp.reserve(deg);
+    auto idx = key.index();
+    for (deg_t i=0; i<deg; ++i) {
+        tmp.push_back(1 + (idx % m_width));
+        idx /= m_width;
+    }
+
+    bool first = true;
+    auto end = tmp.crend();
+    for (auto it = tmp.crbegin(); it != end; ++it) {
+        if (first) {
+            first = false;
+        } else {
+            os << ',';
+        }
+        os << *it;
+    }
+    return os;
+}
+
+void tensor_basis::advance_key(tensor_basis::key_type &key) const noexcept {
+    const auto degree = static_cast<deg_t>(key.degree());
+    ++key;
+    if (key.index() >= m_powers[degree]) {
+        key = key_type(degree+1, 0);
+    }
+}
+
+template class basis_registry<tensor_basis>;
+
+}

--- a/vendored/libalgebra_lite/basis/unpacked_tensor_word.cpp
+++ b/vendored/libalgebra_lite/basis/unpacked_tensor_word.cpp
@@ -1,0 +1,209 @@
+//
+// Created by user on 25/01/23.
+//
+
+#include "libalgebra_lite/unpacked_tensor_word.h"
+
+#include <algorithm>
+
+namespace lal {
+
+unpacked_tensor_word::unpacked_tensor_word(deg_t width, tensor_basis::key_type key)
+    : m_data(), m_width(width)
+{
+    auto deg = static_cast<deg_t>(key.degree());
+    m_data.reserve(deg);
+    auto index = key.index();
+    for (deg_t i = 0; i<deg; ++i) {
+        auto old = index;
+        index /= width;
+        m_data.emplace_back(old-index*width);
+    }
+}
+
+template <typename V>
+static bool check_letters(deg_t width, const V& letters) {
+    using letter_type = typename V::value_type;
+    return std::all_of(letters.begin(), letters.end(),
+            [width](letter_type i) { return i < width; });
+//    for (const auto& item : letters) {
+//        if (item >= width) {
+//            return false;
+//        }
+//    }
+//    return true;
+}
+
+unpacked_tensor_word::unpacked_tensor_word(deg_t width, const std::vector<letter_type>& data)
+    : m_data(data.begin(), data.end()), m_width(width)
+{
+    assert(check_letters(width, m_data));
+}
+unpacked_tensor_word::unpacked_tensor_word(deg_t width, unpacked_tensor_word::vec_type&& data) noexcept
+    : m_data(std::move(data)), m_width(width)
+{
+    assert(check_letters(width, m_data));
+}
+
+unpacked_tensor_word::unpacked_tensor_word(deg_t width, deg_t depth)
+    : m_data(depth), m_width(width)
+{
+}
+
+void unpacked_tensor_word::advance(deg_t number)
+{
+    const auto degree = m_data.size();
+    if (degree == 0) { return; }
+    assert(number < std::numeric_limits<letter_type>::max());
+    dimn_t position = 0;
+    do {
+        auto& let = m_data[position];
+        let += number;
+        number = 0;
+        if (let >= m_width) {
+            number = let / m_width;
+            let = let - number*m_width;
+            ++position;
+        }
+    }
+    while (number > 0 && position < degree);
+}
+
+
+unpacked_tensor_word& unpacked_tensor_word::operator++()
+{
+    advance(1);
+    return *this;
+}
+
+const unpacked_tensor_word unpacked_tensor_word::operator++(int)
+{
+   unpacked_tensor_word tmp(*this);
+   advance(1);
+   return tmp;
+}
+
+unpacked_tensor_word::index_type unpacked_tensor_word::pack_with_base(deg_t base, letter_type offset) const noexcept
+{
+    assert(base >= m_width);
+    index_type result = 0;
+    auto degree = m_data.size();
+    for (dimn_t i=1; i<=degree; ++i) {
+        result *= base;
+        result += offset + m_data[degree - i];
+    }
+    return result;
+}
+
+unpacked_tensor_word::index_type unpacked_tensor_word::to_index() const noexcept
+{
+    return pack_with_base(m_width);
+}
+
+unpacked_tensor_word::index_type unpacked_tensor_word::to_reverse_index() const noexcept
+{
+    index_type result = 0;
+    for (const auto& let : m_data) {
+        result *= m_width;
+        result += let;
+    }
+    return result;
+}
+
+typename tensor_basis::key_type unpacked_tensor_word::pack() const noexcept
+{
+    return typename tensor_basis::key_type{degree(), to_index()};
+}
+
+unpacked_tensor_word& unpacked_tensor_word::reverse() noexcept
+{
+    std::reverse(m_data.begin(), m_data.end());
+    return *this;
+}
+
+unpacked_tensor_word unpacked_tensor_word::split_left(deg_t left_degree)
+{
+    if (left_degree >= degree()) {
+        unpacked_tensor_word tmp(*this);
+        m_data.clear();
+        return tmp;
+    }
+
+    auto right_size = m_data.size() - left_degree;
+    vec_type left_letters(m_data.end()-left_degree, m_data.end());
+    m_data.resize(right_size);
+    assert(left_letters.size() + m_data.size() == right_size + left_degree);
+    return {m_width, std::move(left_letters)};
+}
+
+std::pair<unpacked_tensor_word, unpacked_tensor_word> unpacked_tensor_word::split(deg_t left_letters) const
+{
+    auto right = *this;
+    auto left = right.split_left(left_letters);
+    return {left, right};
+}
+
+unpacked_tensor_word unpacked_tensor_word::operator*(const unpacked_tensor_word &other) const {
+    vec_type new_data;
+    new_data.reserve(m_data.size() + other.m_data.size());
+    new_data.insert(new_data.end(), other.m_data.begin(), other.m_data.end());
+    new_data.insert(new_data.end(), m_data.begin(), m_data.end());
+    return {std::max(m_width, other.m_width), std::move(new_data)};
+}
+
+bool unpacked_tensor_word::operator==(const unpacked_tensor_word& other) const noexcept
+{
+    return degree() == other.degree() && std::equal(m_data.begin(), m_data.end(), other.m_data.begin());
+}
+bool unpacked_tensor_word::operator!=(const unpacked_tensor_word& other) const noexcept
+{
+    return !operator==(other);
+}
+bool unpacked_tensor_word::operator<(const unpacked_tensor_word& other) const noexcept
+{
+    auto ldegree = degree();
+    auto rdegree = other.degree();
+    if (ldegree > rdegree) {
+        return false;
+    }
+
+    if (ldegree < rdegree) {
+        return true;
+    }
+
+    return std::lexicographical_compare(m_data.begin(), m_data.end(),
+            other.m_data.begin(), other.m_data.end());
+}
+bool unpacked_tensor_word::operator<=(const unpacked_tensor_word& other) const noexcept
+{
+    return !operator>(other);
+}
+bool unpacked_tensor_word::operator>(const unpacked_tensor_word& other) const noexcept
+{
+    return other.operator<(*this);
+}
+bool unpacked_tensor_word::operator>=(const unpacked_tensor_word& other) const noexcept
+{
+    return !operator<(other);
+}
+
+
+} // lal
+
+
+using namespace lal;
+
+std::ostream& lal::operator<<(std::ostream& os, const unpacked_tensor_word& word)
+{
+    bool first = true;
+    for (deg_t i = 0; i<word.degree(); ++i) {
+        if (first) {
+            first = false;
+        }
+        else {
+            os << ',';
+        }
+        os << 1 + word[i];
+    }
+    return os;
+}

--- a/vendored/libalgebra_lite/basis_traits.h
+++ b/vendored/libalgebra_lite/basis_traits.h
@@ -1,0 +1,126 @@
+//
+// Created by user on 25/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_BASIS_TRAITS_H
+#define LIBALGEBRA_LITE_BASIS_TRAITS_H
+
+#include "implementation_types.h"
+
+#include <boost/type_traits/is_detected.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <utility>
+#include <memory>
+
+namespace lal {
+
+struct with_degree_tag {};
+struct without_degree_tag {};
+
+namespace dtl {
+
+template <typename Key, typename KeyOrder>
+struct key_value_ordering
+{
+    template <typename S>
+    using pair = std::pair<Key, S>;
+
+    KeyOrder order;
+
+    template <typename S>
+    bool operator()(const pair<S>& lhs, const pair<S>& rhs) const noexcept
+    {
+        return order(lhs.first, rhs.first);
+    }
+
+};
+
+
+template <typename Basis>
+class has_degree_tag_helper {
+
+    template <typename B=Basis>
+    static typename B::degree_tag choose(void*);
+
+    static without_degree_tag choose(...);
+
+public:
+    using type = decltype(choose(nullptr));
+};
+
+template <typename B>
+using advance_key_t = decltype(std::declval<const B&>().advance_key(std::declval<typename B::key_type&>()));
+
+template <typename Basis, bool=boost::is_detected<advance_key_t, Basis>::value>
+struct advance_key_helper {
+
+    static void advance_key(const Basis& b, typename Basis::key_type& key) { ++key; }
+};
+
+template <typename Basis>
+struct advance_key_helper<Basis, true> {
+
+    static void advance_key(const Basis& b, typename Basis::key_type& key) {
+        b.advance_key(key);
+    }
+
+};
+
+
+
+} // namespace dtl
+
+template <typename Basis>
+struct basis_trait {
+    using key_type = typename Basis::key_type;
+    using degree_tag = typename dtl::has_degree_tag_helper<Basis>::type;
+
+    static dimn_t max_dimension(const Basis& basis) noexcept { return basis.size(-1); };
+
+    static dimn_t key_to_index(const Basis& basis, const key_type& k) noexcept { return basis.key_to_index(k); }
+    static key_type index_to_key(const Basis& basis, dimn_t idx) noexcept { return basis.index_to_key(idx); }
+    static deg_t degree(const Basis& basis, const key_type& key) noexcept
+    { return basis.degree(key); }
+    static deg_t max_degree(const Basis& basis) noexcept
+    { return basis.depth(); }
+
+    static dimn_t start_of_degree(const Basis& basis, deg_t deg) noexcept
+    { return basis.start_of_degree(deg); }
+    static dimn_t size(const Basis& basis, deg_t deg) noexcept
+    { return basis.size(static_cast<int>(deg)); }
+    static std::pair<dimn_t, deg_t> get_next_dimension(const Basis& basis, dimn_t dim, deg_t hint=0)
+    {
+        const auto& sizes = basis.sizes();
+        const auto begin = sizes.begin();
+        const auto end = sizes.end();
+        auto it = std::lower_bound(begin, end, dim ,std::less_equal<>());
+        if (it == end) {
+            return {max_dimension(basis), 0};
+        }
+        return {*it, static_cast<deg_t>(it - begin)};
+    }
+
+    using key_ordering = std::less<key_type>;
+    using kv_ordering = dtl::key_value_ordering<key_type, key_ordering>;
+
+    static void advance_key(const Basis& basis, key_type& key)
+    {
+        dtl::advance_key_helper<Basis>::advance_key(basis, key);
+    }
+
+    static key_type first_key(const Basis& basis) { return basis.first_key(); }
+
+};
+
+
+template <typename Basis1, typename Basis2>
+struct is_basis_compatible : std::false_type
+{};
+
+
+
+} // namespace alg
+
+#endif //LIBALGEBRA_LITE_BASIS_TRAITS_H

--- a/vendored/libalgebra_lite/coefficients.h
+++ b/vendored/libalgebra_lite/coefficients.h
@@ -1,0 +1,450 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Created by user on 26/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_COEFFICIENTS_H
+#define LIBALGEBRA_LITE_COEFFICIENTS_H
+
+#include "implementation_types.h"
+#include "libalgebra_lite_export.h"
+
+#include <memory>
+
+#include "detail/traits.h"
+
+#ifdef LAL_ENABLE_RATIONAL_COEFFS
+#include "rationals.h"
+#endif
+
+namespace lal {
+
+template <typename Coeff>
+struct coefficient_trait {
+    using coefficient_ring = Coeff;
+    using scalar_type = typename Coeff::scalar_type;
+    using rational_type = typename Coeff::rational_type;
+    using default_alloc = std::allocator<scalar_type>;
+};
+
+#define LAL_RING_GENERATE_BINOP(NAME, OP, RET_T, LHS_T, RHS_T)                 \
+    template <typename Lhs = LHS_T, typename Rhs = RHS_T>                      \
+    static constexpr RET_T NAME(const Lhs& lhs, const Rhs& rhs)                \
+    {                                                                          \
+        return lhs OP rhs;                                                     \
+    }                                                                          \
+                                                                               \
+    template <typename Rhs = RHS_T>                                            \
+    static constexpr RET_T NAME##_inplace(RET_T& lhs, const Rhs& rhs)          \
+    {                                                                          \
+        return (lhs OP## = rhs);                                               \
+    }
+
+template <typename Scalar, typename Rational>
+struct coefficient_ring {
+    using scalar_type = Scalar;
+    using rational_type = Rational;
+
+    static const scalar_type& zero() noexcept
+    {
+        static const scalar_type zero{};
+        return zero;
+    }
+    static const scalar_type& one() noexcept
+    {
+        static const scalar_type one(1);
+        return one;
+    }
+    static const scalar_type& mone() noexcept
+    {
+        static const scalar_type mone(-1);
+        return mone;
+    }
+
+    static constexpr scalar_type uminus(const scalar_type& arg) { return -arg; }
+
+    static inline bool is_invertible(const scalar_type& arg) noexcept
+    {
+        return arg != zero();
+    }
+    static constexpr const rational_type& as_rational(const scalar_type& arg
+    ) noexcept
+    {
+        static_assert(
+                is_convertible<const Scalar&, const Rational&>::value,
+                "default conversion to rational is only defined when scalar "
+                "type "
+                "is convertible to rational type (as references)"
+        );
+        return static_cast<const rational_type&>(arg);
+    }
+
+    LAL_RING_GENERATE_BINOP(add, +, scalar_type, scalar_type, scalar_type)
+    LAL_RING_GENERATE_BINOP(sub, -, scalar_type, scalar_type, scalar_type)
+    LAL_RING_GENERATE_BINOP(mul, *, scalar_type, scalar_type, scalar_type)
+    LAL_RING_GENERATE_BINOP(div, /, scalar_type, scalar_type, rational_type)
+};
+#undef LAL_RING_GENERATE_BINOP
+
+template <typename Scalar>
+struct coefficient_field : public coefficient_ring<Scalar, Scalar> {
+};
+
+LAL_EXPORT_TEMPLATE_STRUCT(coefficient_field, double)
+LAL_EXPORT_TEMPLATE_STRUCT(coefficient_field, float)
+
+using double_field = coefficient_field<double>;
+using float_field = coefficient_field<float>;
+
+#ifdef LAL_ENABLE_RATIONAL_COEFFS
+LAL_EXPORT_TEMPLATE_STRUCT(coefficient_field, dtl::rational_scalar_type)
+using rational_field = coefficient_field<dtl::rational_scalar_type>;
+#endif
+
+template <>
+struct coefficient_trait<float> {
+    using coefficient_ring = float_field;
+    using scalar_type = float;
+    using rational_type = float;
+};
+
+template <>
+struct coefficient_trait<double> {
+    using coefficient_ring = double_field;
+    using scalar_type = double;
+    using rational_type = double;
+};
+
+#ifdef LAL_ENABLE_RATIONAL_COEFFS
+template <>
+struct coefficient_trait<dtl::rational_scalar_type> {
+    using coefficient_ring = rational_field;
+    using scalar_type = dtl::rational_scalar_type;
+    using rational_type = dtl::rational_scalar_type;
+};
+#endif
+
+namespace ops {
+
+template <typename Scalar>
+struct identity {
+//    template <typename S>
+//    enable_if_t<is_same<Scalar, S>::value, const Scalar&>
+//    operator()(const S& arg) const
+//    {
+//        return arg;
+//    }
+//    template <typename S>
+//    enable_if_t<!is_same<Scalar, S>::value, Scalar>
+//    operator()(const S& arg) const
+//    {
+//        return static_cast<Scalar>(arg);
+//    }
+    Scalar operator()(Scalar arg) const { return arg; }
+};
+
+template <typename Scalar>
+struct unary_minus {
+    template <typename S>
+    Scalar operator()(const S& arg) const
+    {
+        return -static_cast<Scalar>(arg);
+    }
+};
+
+template <typename Scalar>
+struct add {
+    template <typename L, typename R = L>
+    Scalar operator()(const L& left, const R& right) const
+    {
+        return static_cast<Scalar>(left) + right;
+    }
+};
+
+template <typename Scalar>
+struct sub {
+    template <typename L, typename R = L>
+    Scalar operator()(const L& left, const R& right) const
+    {
+        return static_cast<Scalar>(left) - right;
+    }
+};
+
+template <typename Scalar>
+struct multiply {
+    template <typename L, typename R = L>
+    Scalar operator()(const L& left, const R& right) const
+    {
+        return static_cast<Scalar>(left) * right;
+    }
+};
+
+template <typename Scalar>
+struct divide {
+    template <typename L, typename R = L>
+    Scalar operator()(const L& left, const R& right) const
+    {
+        return static_cast<Scalar>(left) / right;
+    }
+};
+
+struct add_inplace {
+//    template <typename S, typename R = S>
+//    S& operator()(S& left, const R& right) const
+//    {
+//        return left += right;
+//    }
+
+    template <typename S, typename R>
+    S operator()(S left, const R& right) const
+    {
+        return left += right;
+    }
+};
+
+struct sub_inplace {
+    template <typename S, typename R = S>
+    S operator()(S left, const R& right) const
+    {
+        return left -= right;
+    }
+};
+
+struct multiply_inplace {
+    template <typename S, typename R = S>
+    S operator()(S left, const R& right) const
+    {
+        return left *= right;
+    }
+};
+
+struct divide_inplace {
+    template <typename S, typename R = S>
+    S operator()(S left, const R& right) const
+    {
+        return left /= right;
+    }
+};
+
+template <typename Scalar, typename M=Scalar>
+struct pre_multiply {
+    M multiplier;
+
+    template <
+            typename _M,
+            typename = enable_if_t<!is_same<_M, pre_multiply>::value>>
+    explicit pre_multiply(_M&& arg) : multiplier(std::forward<_M>(arg))
+    {}
+
+    template <typename S=M>
+    Scalar operator()(const S& arg) const
+    {
+        return multiplier * static_cast<Scalar>(arg);
+    }
+};
+
+template <typename Scalar, typename M=Scalar>
+struct post_multiply {
+    M multiplier;
+
+    template <
+            typename _M,
+            typename = enable_if_t<!is_same<_M, post_multiply>::value>>
+    explicit post_multiply(_M&& arg) : multiplier(std::forward<_M>(arg))
+    {}
+
+    template <typename S=M>
+    Scalar operator()(const S& arg) const
+    {
+        return static_cast<Scalar>(arg) * multiplier;
+    }
+};
+
+template <typename Scalar, typename D>
+struct post_divide {
+    D divisor;
+
+    template <
+            typename _D,
+            typename = enable_if_t<!is_same<_D, post_divide>::value>>
+    explicit post_divide(_D&& arg) : divisor(std::forward<_D>(arg))
+    {}
+
+    template <typename S>
+    Scalar operator()(const S& arg) const
+    {
+        return static_cast<Scalar>(arg) / divisor;
+    }
+};
+
+template <typename M>
+struct post_multiply_inplace {
+    M multiplier;
+
+    template <
+            typename _M,
+            typename = enable_if_t<!is_same<_M, post_multiply_inplace>::value>>
+    explicit post_multiply_inplace(_M&& arg) : multiplier(std::forward<_M>(arg))
+    {}
+
+    template <typename S>
+    S& operator()(S& arg) const
+    {
+        return arg *= multiplier;
+    }
+};
+
+template <typename D>
+struct post_divide_inplace {
+    D divisor;
+
+    template <
+            typename _D,
+            typename = enable_if_t<!is_same<_D, post_divide_inplace>::value>>
+    explicit post_divide_inplace(_D&& arg) : divisor(std::forward<_D>(arg))
+    {}
+
+    template <typename S>
+    S& operator()(S& arg) const
+    {
+        return arg /= divisor;
+    }
+};
+
+template <typename M>
+struct add_pre_multiply_inplace {
+    M multiplier;
+
+    template <
+            typename _M,
+            typename
+            = enable_if_t<!is_same<_M, add_pre_multiply_inplace>::value>>
+    explicit add_pre_multiply_inplace(_M&& m) : multiplier(std::forward<_M>(m))
+    {}
+
+    template <typename S, typename R = S>
+    S& operator()(S& left, const R& right) const
+    {
+        return left += multiplier * right;
+    }
+};
+template <typename M>
+struct add_post_multiply_inplace {
+    M multiplier;
+
+    template <
+            typename _M,
+            typename
+            = enable_if_t<!is_same<_M, add_post_multiply_inplace>::value>>
+    explicit add_post_multiply_inplace(_M&& m) : multiplier(std::forward<_M>(m))
+    {}
+
+    template <typename S, typename R = S>
+    S operator()(S left, const R& right) const
+    {
+        return left += right * multiplier;
+    }
+};
+
+template <typename D>
+struct add_post_divide_inplace {
+    D divisor;
+
+    template <
+            typename _D,
+            typename
+            = enable_if_t<!is_same<_D, add_post_divide_inplace>::value>>
+    explicit add_post_divide_inplace(_D&& d) : divisor(std::forward<_D>(d))
+    {}
+
+    template <typename S, typename R = S>
+    S operator()(S left, const R& right) const
+    {
+        return left += right / divisor;
+    }
+};
+
+template <typename M>
+struct sub_pre_multiply_inplace {
+    M multiplier;
+
+    template <
+            typename _M,
+            typename
+            = enable_if_t<!is_same<_M, sub_pre_multiply_inplace>::value>>
+    explicit sub_pre_multiply_inplace(_M&& m) : multiplier(std::forward<_M>(m))
+    {}
+
+    template <typename S, typename R = S>
+    S operator()(S left, const R& right) const
+    {
+        return left -= multiplier * right;
+    }
+};
+template <typename M>
+struct sub_post_multiply_inplace {
+    M multiplier;
+
+    template <
+            typename _M,
+            typename
+            = enable_if_t<!is_same<_M, sub_post_multiply_inplace>::value>>
+    explicit sub_post_multiply_inplace(_M&& m) : multiplier(std::forward<_M>(m))
+    {}
+
+    template <typename S, typename R = S>
+    S operator()(S left, const R& right) const
+    {
+        return left -= right * multiplier;
+    }
+};
+
+template <typename D>
+struct sub_post_divide_inplace {
+    D divisor;
+
+    template <
+            typename _D,
+            typename
+            = enable_if_t<!is_same<_D, sub_post_divide_inplace>::value>>
+    explicit sub_post_divide_inplace(_D&& d) : divisor(std::forward<_D>(d))
+    {}
+
+    template <typename S, typename R = S>
+    S operator()(S left, const R& right) const
+    {
+        return left -= right / divisor;
+    }
+};
+
+}// namespace ops
+
+}// namespace lal
+
+#endif// LIBALGEBRA_LITE_COEFFICIENTS_H

--- a/vendored/libalgebra_lite/coefficients/floating_fields.cpp
+++ b/vendored/libalgebra_lite/coefficients/floating_fields.cpp
@@ -1,0 +1,13 @@
+//
+// Created by user on 01/09/22.
+//
+
+
+#include "libalgebra_lite/coefficients.h"
+
+namespace lal {
+
+template struct coefficient_field<float>;
+template struct coefficient_field<double>;
+
+}

--- a/vendored/libalgebra_lite/coefficients/rational_field.cpp
+++ b/vendored/libalgebra_lite/coefficients/rational_field.cpp
@@ -1,0 +1,13 @@
+//
+// Created by user on 01/09/22.
+//
+
+
+
+#include "libalgebra_lite/coefficients.h"
+
+namespace lal {
+
+template struct coefficient_field<dtl::rational_scalar_type>;
+
+}

--- a/vendored/libalgebra_lite/dense_vector.h
+++ b/vendored/libalgebra_lite/dense_vector.h
@@ -1,0 +1,462 @@
+//
+// Created by user on 23/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_DENSE_VECTOR_H
+#define LIBALGEBRA_LITE_DENSE_VECTOR_H
+
+#include "implementation_types.h"
+
+#include <memory>
+#include <type_traits>
+
+#include "basis_traits.h"
+#include "coefficients.h"
+#include "vector_base.h"
+#include "vector_traits.h"
+
+namespace lal {
+
+namespace dtl {
+
+template <typename Basis, typename Scalar, typename Iterator>
+class dense_vector_const_iterator;
+
+template <typename Basis, typename Scalar, typename Iterator>
+class dense_vector_iterator;
+
+}// namespace dtl
+
+template <typename Basis>
+class key_range;
+
+template <
+        typename Basis, typename Coefficients,
+        template <typename, typename...> class VectorType, typename... Args>
+class dense_vector_base : public vectors::vector_base<Basis, Coefficients>
+{
+    using vec_base = vectors::vector_base<Basis, Coefficients>;
+    using typename vec_base::basis_traits;
+    using typename vec_base::coeff_traits;
+
+public:
+    using typename vec_base::basis_pointer;
+    using typename vec_base::basis_type;
+    using typename vec_base::coefficient_ring;
+    using typename vec_base::key_type;
+    using typename vec_base::rational_type;
+    using typename vec_base::scalar_type;
+
+private:
+    using storage_type = VectorType<scalar_type, Args...>;
+
+    using vec_base::p_basis;
+    storage_type m_storage{};
+    deg_t m_degree = 0;
+
+public:
+    using size_type = typename storage_type::size_type;
+    using difference_type = typename storage_type::difference_type;
+    using iterator = dtl::dense_vector_iterator<
+            Basis, scalar_type, typename storage_type::iterator>;
+    using const_iterator = dtl::dense_vector_const_iterator<
+            Basis, scalar_type, typename storage_type::const_iterator>;
+    using pointer = typename storage_type::pointer;
+    using const_pointer = typename storage_type::const_pointer;
+    using reference = typename storage_type::reference;
+    using const_reference = typename storage_type::const_reference;
+
+    dense_vector_base(basis_pointer basis, key_type k, scalar_type s)
+        : vec_base(basis), m_storage()
+    {
+        auto index = p_basis->key_to_index(k);
+        resize(index);
+        m_storage[index] = s;
+    }
+
+    explicit dense_vector_base(basis_pointer basis) : vec_base(basis) {}
+
+    dense_vector_base(
+            basis_pointer basis, std::initializer_list<scalar_type> args
+    )
+        : vec_base(basis), m_storage(args)
+    {
+        resize(args.size());
+    }
+
+    template <typename InputIt>
+    dense_vector_base(basis_pointer basis, InputIt begin, InputIt end)
+        : vec_base(basis), m_storage(begin, end)
+    {
+        resize(m_storage.size());
+    }
+
+    explicit dense_vector_base(basis_pointer basis, size_type n)
+        : vec_base(basis), m_storage()
+    {
+        resize(n);
+    }
+
+    template <typename S>
+    explicit dense_vector_base(basis_pointer basis, size_type n, const S& val)
+        : vec_base(basis), m_storage()
+    {
+        resize(n, val);
+    }
+
+    void swap(dense_vector_base& right) {
+        std::swap(m_storage, right.m_storage);
+        std::swap(m_degree, right.m_degree);
+        vec_base::swap(right);
+    }
+
+private:
+    size_type adjust_size(size_type n) const noexcept
+    {
+        auto next = basis_traits::get_next_dimension(*p_basis, n);
+        return std::min(basis_traits::max_dimension(*p_basis), next.first);
+    }
+
+public:
+    void update_degree(deg_t degree) noexcept { m_degree = degree; }
+
+    void reserve_exact(size_type n, deg_t degree = 0)
+    {
+        m_storage.reserve(n);
+        m_degree = degree;
+    }
+
+    void resize_exact(size_type n, deg_t degree = 0)
+    {
+        m_storage.resize(n, coefficient_ring::zero());
+        m_degree = degree;
+    }
+
+    void resize_exact(size_type n, const scalar_type& scalar, deg_t degree = 0)
+    {
+        m_storage.resize(n, scalar);
+        m_degree = degree;
+    }
+
+    void reserve(size_type n)
+    {
+        auto next = basis_traits::get_next_dimension(*p_basis, n);
+        reserve_exact(next.first, next.second);
+    }
+    void resize(size_type n)
+    {
+        auto next = basis_traits::get_next_dimension(*p_basis, n);
+        resize_exact(next.first, next.second);
+    }
+
+    template <typename S>
+    void resize(size_type n, const S& val)
+    {
+        auto next = basis_traits::get_next_dimension(*p_basis, n);
+        resize_exact(next.first, val, next.second);
+    }
+
+    iterator begin() noexcept { return iterator(&*p_basis, m_storage.begin()); }
+    iterator end() noexcept { return iterator(&*p_basis, m_storage.end()); }
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(&*p_basis, m_storage.begin());
+    }
+    const_iterator end() const noexcept
+    {
+        return const_iterator(&*p_basis, m_storage.end());
+    }
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator(&*p_basis, m_storage.begin());
+    }
+    const_iterator cend() const noexcept
+    {
+        return const_iterator(&*p_basis, m_storage.end());
+    }
+
+    size_type size() const noexcept
+    {
+        const auto& zero = Coefficients::zero();
+        return std::count_if(
+                m_storage.begin(), m_storage.end(),
+                [&zero](const scalar_type& s) { return s != zero; }
+        );
+    }
+    constexpr size_type dimension() const noexcept { return m_storage.size(); }
+    constexpr deg_t degree() const noexcept { return m_degree; }
+    constexpr bool empty() const noexcept { return m_storage.empty(); }
+
+    template <typename Index>
+    reference operator[](Index idx) noexcept
+    {
+        auto key = p_basis->key_to_index(idx);
+        if (key >= m_storage.size()) { resize(key); }
+        return m_storage[key];
+    }
+
+    template <typename Index>
+    const_reference operator[](Index idx) const noexcept
+    {
+        return m_storage[p_basis->key_to_index(idx)];
+    }
+
+    pointer as_mut_ptr() noexcept { return m_storage.data(); }
+    const_pointer as_ptr() const noexcept { return m_storage.data(); }
+
+    void clear() noexcept(noexcept(m_storage.clear())) { m_storage.clear(); }
+
+    // these need to be implemented in terms of kernels.
+
+    template <typename UnaryOp>
+    dense_vector_base unary_op(UnaryOp op) const
+    {
+        dense_vector_base result(p_basis);
+        result.reserve_exact(m_storage.size(), m_degree);
+
+        const auto begin = m_storage.begin();
+        const auto end = m_storage.end();
+
+        for (auto it = begin; it != end; ++it) {
+            result.m_storage.emplace_back(op(*it));
+        }
+
+        return result;
+    }
+
+    template <typename UnaryOp>
+    dense_vector_base& inplace_unary_op(UnaryOp op)
+    {
+        const auto begin = m_storage.begin();
+        const auto end = m_storage.end();
+        for (auto it = begin; it != end; ++it) { op(*it); }
+        return *this;
+    }
+
+    template <typename BinaryOp>
+    dense_vector_base binary_op(const dense_vector_base& arg, BinaryOp op) const
+    {
+        dense_vector_base result(p_basis);
+
+        const difference_type lhs_size(m_storage.size());
+        const difference_type rhs_size(arg.m_storage.size());
+
+        result.reserve_exact(
+                std::max(lhs_size, rhs_size), std::max(m_degree, arg.m_degree)
+        );
+
+        const auto mid = std::min(lhs_size, rhs_size);
+        const auto& zero = coefficient_ring::zero();
+
+        for (difference_type i = 0; i < mid; ++i) {
+            result.m_storage.emplace_back(op(m_storage[i], arg.m_storage[i]));
+        }
+
+        for (auto i = mid; i < lhs_size; ++i) {
+            result.m_storage.emplace_back(op(m_storage[i], zero));
+        }
+
+        for (auto i = mid; i < rhs_size; ++i) {
+            result.m_storage.emplace_back(op(zero, arg.m_storage[i]));
+        }
+
+        return result;
+    }
+
+    template <typename InplaceBinaryOp>
+    dense_vector_base&
+    inplace_binary_op(const dense_vector_base& rhs, InplaceBinaryOp op)
+    {
+        const difference_type lhs_size(m_storage.size());
+        const difference_type rhs_size(rhs.m_storage.size());
+
+        if (rhs_size > lhs_size) { resize_exact(rhs_size, rhs.m_degree); }
+
+        const auto& zero = coefficient_ring::zero();
+        const auto mid = std::min(lhs_size, rhs_size);
+
+        for (difference_type i = 0; i < mid; ++i) {
+            op(m_storage[i], rhs.m_storage[i]);
+        }
+
+        for (auto i = mid; i < lhs_size; ++i) { op(m_storage[i], zero); }
+
+        for (auto i = mid; i < rhs_size; ++i) {
+            op(m_storage[i], rhs.m_storage[i]);
+        }
+
+        return *this;
+    }
+
+    bool operator==(const dense_vector_base& rhs) const noexcept
+    {
+        auto mid = std::min(m_storage.size(), rhs.m_storage.size());
+
+        for (dimn_t i = 0; i < mid; ++i) {
+            if (m_storage[i] != rhs.m_storage[i]) { return false; }
+        }
+
+        const auto& zero = coefficient_ring::zero();
+
+        for (dimn_t i = mid; i < m_storage.size(); ++i) {
+            if (m_storage[i] != zero) { return false; }
+        }
+
+        for (dimn_t i = mid; i < rhs.m_storage.size(); ++i) {
+            if (rhs.m_storage[i] != zero) { return false; }
+        }
+
+        return true;
+    }
+};
+
+template <typename Basis, typename Coefficients>
+using dense_vector = dense_vector_base<Basis, Coefficients, std::vector>;
+
+
+namespace dtl {
+
+template <typename KeyRef, typename ScaRef>
+class dense_iterator_item
+{
+    template <typename B, typename C, typename I>
+    friend class dense_vector_iterator;
+
+    template <typename B, typename C, typename I>
+    friend class dense_vector_const_iterator;
+
+    KeyRef m_key;
+    ScaRef m_sca;
+
+    dense_iterator_item(KeyRef key, ScaRef sca) : m_key(key), m_sca(sca) {}
+
+public:
+    dense_iterator_item* operator->() noexcept { return this; }
+
+    KeyRef key() const noexcept { return m_key; }
+    ScaRef value() const noexcept { return m_sca; }
+};
+
+template <typename Basis, typename Coefficients, typename Iterator>
+class dense_vector_iterator
+{
+    using basis_traits = basis_trait<Basis>;
+    using key_type = typename basis_traits::key_type;
+    using coeff_traits = coefficient_trait<Coefficients>;
+    using scalar_type = typename coeff_traits::scalar_type;
+    using basis_pointer = lal::basis_pointer<Basis>;
+    //    using iterator_category = std::forward_iterator_tag;
+
+    const Basis* p_basis = nullptr;
+    Iterator p_data;
+    key_type m_key;
+
+    using it_traits = std::iterator_traits<Iterator>;
+
+public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = dtl::dense_iterator_item<
+            const key_type&, typename it_traits::reference>;
+    using reference = value_type;
+    using pointer = value_type;
+    using iterator_category = std::forward_iterator_tag;
+
+    dense_vector_iterator() = default;
+
+    dense_vector_iterator(const Basis* basis, Iterator data)
+        : p_basis(basis), p_data(data),
+          m_key(basis_traits::index_to_key(*basis, 0))
+    {}
+
+    dense_vector_iterator& operator++()
+    {
+        ++p_data;
+        ++m_key;
+        return *this;
+    }
+
+    const dense_vector_iterator operator++(int)
+    {
+        auto current(*this);
+        operator++();
+        return current;
+    }
+
+    reference operator*() const noexcept { return {m_key, *p_data}; }
+
+    pointer operator->() const noexcept { return {m_key, *p_data}; }
+
+    bool operator==(const dense_vector_iterator& other) const noexcept
+    {
+        return p_data == other.p_data;
+    }
+
+    bool operator!=(const dense_vector_iterator& other) const noexcept
+    {
+        return p_data != other.p_data;
+    }
+};
+
+template <typename Basis, typename Coefficients, typename Iterator>
+class dense_vector_const_iterator
+{
+    using basis_traits = basis_trait<Basis>;
+    using key_type = typename basis_traits::key_type;
+    using coeff_traits = coefficient_trait<Coefficients>;
+    using scalar_type = typename coeff_traits::scalar_type;
+
+    const Basis* p_basis = nullptr;
+    Iterator p_data;
+    key_type m_key;
+
+    using it_traits = std::iterator_traits<Iterator>;
+
+public:
+    using value_type = dtl::dense_iterator_item<
+            const key_type&, typename it_traits::reference>;
+    using reference = value_type;
+    using pointer = value_type;
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::forward_iterator_tag;
+
+    dense_vector_const_iterator() = default;
+
+    dense_vector_const_iterator(const Basis* basis, Iterator data)
+        : p_basis(basis), p_data(data),
+          m_key(basis_traits::index_to_key(*basis, 0))
+    {}
+
+    dense_vector_const_iterator& operator++()
+    {
+        ++p_data;
+        basis_traits::advance_key(*p_basis, m_key);
+        return *this;
+    }
+
+    const dense_vector_const_iterator operator++(int)
+    {
+        auto current(*this);
+        operator++();
+        return current;
+    }
+
+    reference operator*() const noexcept { return {m_key, *p_data}; }
+
+    pointer operator->() const noexcept { return {m_key, *p_data}; }
+
+    bool operator==(const dense_vector_const_iterator& other) const noexcept
+    {
+        return p_data == other.p_data;
+    }
+
+    bool operator!=(const dense_vector_const_iterator& other) const noexcept
+    {
+        return p_data != other.p_data;
+    }
+};
+
+}// namespace dtl
+
+}// namespace lal
+
+#endif// LIBALGEBRA_LITE_DENSE_VECTOR_H

--- a/vendored/libalgebra_lite/detail/integer_maths.h
+++ b/vendored/libalgebra_lite/detail/integer_maths.h
@@ -1,0 +1,23 @@
+//
+// Created by user on 13/07/23.
+//
+
+#ifndef LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_INTEGER_MATHS_H_
+#define LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_INTEGER_MATHS_H_
+
+#include "macros.h"
+#include "traits.h"
+
+namespace lal {
+
+template <typename I>
+constexpr enable_if_t<is_integral<I>::value, bool> is_even(I integer) noexcept
+{
+    return (integer & 1) == 0;
+}
+
+
+}
+
+
+#endif// LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_INTEGER_MATHS_H_

--- a/vendored/libalgebra_lite/detail/macros.h
+++ b/vendored/libalgebra_lite/detail/macros.h
@@ -1,0 +1,131 @@
+#ifndef LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_MACROS_H_
+#define LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_MACROS_H_
+
+#include <cassert>
+#include <stdexcept>
+
+#define LAL_STRINGIFY_IMPL(ARG) #ARG
+#define LAL_STRINGIFY(ARG) LAL_STRINGIFY_IMPL(ARG)
+
+#define LAL_JOIN_IMPL2(LHS, RHS) LHS##RHS
+#define LAL_JOIN_IMPL(LHS, RHS) LAL_JOIN_IMPL2(LHS, RHS)
+#define LAL_JOIN(LHS, RHS) LAL_JOIN_IMPL(LHS, RHS)
+
+#if defined(_MSV_VER) && defined(_MSVC_LANG)
+#  define LAL_MSVC _MSC_VER
+#  define LAL_CPP_VERSION _MSVC_LANG
+#else
+#  define LAL_CPP_VERSION __cplusplus
+#  undef LAL_MSVC
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#  define LAL_GCC __GNUC__
+#else
+#  undef LAL_GCC
+#endif
+
+#ifdef __clang__
+#  define LAL_CLANG __clang__
+#else
+#  undef LAL_CLANG
+#endif
+
+#if defined(__linux__)
+#  define LAL_PLATFORM_LINUX 1
+#elif defined(__APPLE__) && defined(__MACH__)
+#  define LAL_PLATFORM_OSX 1
+#elif defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__)
+#  define LAL_PLATFORM_WINDOWS 1
+#endif
+
+#ifdef LAL_PLATFORM_WINDOWS
+#  define LAL_COMPILE_DLL
+#endif
+
+#ifdef __has_builtin
+#  define LAL_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#  define LAL_HAS_BUILTIN(x) 0
+#endif
+
+#ifdef __has_feature
+#  define LAL_HAS_FEATURE(x) (__has_feature(x))
+#else
+#  define LAL_HAS_FEATURE(x) 0
+#endif
+
+#ifdef __has_cpp_attribute
+#  define LAL_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#else
+#  define LAL_HAS_CPP_ATTRIBUTE(x) 0
+#endif
+
+#ifdef __has_attribute
+#  define LAL_HAS_ATTRIBUTE(x) __has_attribute(x)
+#else
+#  define LAL_HAS_ATTRIBUTE(x) 0
+#endif
+
+#ifdef __has_extension
+#  define LAL_HAS_EXTENSION(x) __has_extension(x)
+#else
+#  define LAL_HAS_EXTENSION(x) LAL_HAS_FEATURE(x)
+#endif
+
+#if defined(_DEBUG) || !defined(NDEBUG)                                        \
+        || !defined(__OPTIMIZE__) && !defined(LAL_DEBUG)
+#  define LAL_DEBUG 1
+#else
+#  undef LAL_DEBUG
+#endif
+
+#ifdef LAL_MSVC
+#  define LAL_PRAGMA(ARG) __pragma(ARG)
+#else
+#  define LAL_PRAGMA(ARG) _Pragma(LAL_STRINGIFY(ARG))
+#endif
+
+#ifndef LAL_DEBUG
+#  ifdef LAL_MSVC
+#    define LAL_INLINE_ALWAYS __forceinline
+#  elif LAL_HAS_ATTRIBUTE(always_inline)
+#    define LAL_INLINE_ALWAYS inline __attribute__((always_inline))
+#  else
+#    define LAL_INLINE_ALWAYS inline
+#  endif
+#else
+#  define LAL_INLINE_ALWAYS inline
+#endif
+
+#ifdef LAL_MSVC
+#  define LAL_RESTRICT __restrict
+#elif defined(LAL_GCC) || defined(LAL_CLANG)
+#  define LAL_RESTRICT __restrict__
+#else
+#  define LAL_RESTRICT
+#endif
+
+#if LAL_HAS_CPP_ATTRIBUTE(maybe_unused)
+#  define LAL_UNUSED [[maybe_unused]]
+#else
+#  define LAL_UNUSED
+#endif
+
+#if LAL_HAS_CPP_ATTRIBUTE(nodiscard)
+#  define LAL_NO_DISCARD [[nodiscard]]
+#else
+#  define LAL_NO_DISCARD
+#endif
+
+#if LAL_HAS_CPP_ATTRIBUTE(noreturn)
+#  define LAL_NO_RETURN [[noreturn]]
+#else
+#  define LAL_NO_RETURN
+#endif
+
+
+
+
+
+#endif// LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_MACROS_H_

--- a/vendored/libalgebra_lite/detail/notnull.h
+++ b/vendored/libalgebra_lite/detail/notnull.h
@@ -1,0 +1,64 @@
+//
+// Created by user on 07/02/23.
+//
+
+#ifndef LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_NOTNULL_H
+#define LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_NOTNULL_H
+
+
+#include <cassert>
+#include <memory>
+
+namespace lal {
+namespace dtl {
+
+template <typename T>
+class not_null
+{
+    T* p_data;
+
+public:
+
+    not_null() = delete;
+
+    constexpr explicit not_null(T* ptr) : p_data(ptr)
+    {
+        assert(ptr != nullptr);
+    }
+
+    constexpr explicit not_null(const std::unique_ptr<T>& ptr) : p_data(ptr.get()) {
+        assert(static_cast<bool>(ptr));
+    }
+
+    not_null(std::nullptr_t) = delete;
+    constexpr not_null(const not_null&) = default;
+    constexpr not_null(not_null&&) noexcept = default;
+
+    constexpr operator T*() const noexcept { return p_data; }
+
+    constexpr not_null& operator=(const not_null&) noexcept = default;
+    constexpr not_null& operator=(not_null&&) noexcept = default;
+
+    constexpr not_null& operator=(T* other) noexcept
+    {
+        if (other != p_data) {
+            p_data = other;
+        }
+        return *this;
+    }
+
+    constexpr not_null& operator=(std::nullptr_t) = delete;
+
+
+    constexpr T* operator->() const noexcept { return p_data; }
+    constexpr T& operator*() const noexcept { return *p_data; }
+
+};
+
+
+} // namespace dtl
+} // namespace lal
+
+
+
+#endif //LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_NOTNULL_H

--- a/vendored/libalgebra_lite/detail/traits.h
+++ b/vendored/libalgebra_lite/detail/traits.h
@@ -1,0 +1,147 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Created by user on 12/07/23.
+//
+
+#ifndef LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_TRAITS_H_
+#define LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_TRAITS_H_
+
+#include "macros.h"
+
+#include <type_traits>
+#include <utility>
+
+#include <boost/call_traits.hpp>
+#include <boost/container_hash/hash.hpp>
+#include <boost/type_traits/copy_cv.hpp>
+#include <boost/type_traits/copy_cv_ref.hpp>
+#include <boost/type_traits/detected.hpp>
+#include <boost/type_traits/detected_or.hpp>
+#include <boost/type_traits/is_detected.hpp>
+#include <boost/type_traits/remove_cv_ref.hpp>
+
+
+namespace lal {
+
+using std::declval;
+using std::integral_constant;
+using std::true_type;
+using std::false_type;
+
+using std::is_array;
+using std::is_class;
+using std::is_enum;
+using std::is_floating_point;
+using std::is_function;
+using std::is_integral;
+using std::is_lvalue_reference;
+using std::is_member_function_pointer;
+using std::is_member_object_pointer;
+using std::is_null_pointer;
+using std::is_pointer;
+using std::is_rvalue_reference;
+using std::is_union;
+using std::is_void;
+
+using std::is_arithmetic;
+using std::is_compound;
+using std::is_fundamental;
+using std::is_member_pointer;
+using std::is_object;
+using std::is_reference;
+using std::is_scalar;
+
+using std::is_abstract;
+using std::is_const;
+using std::is_empty;
+using std::is_final;
+using std::is_polymorphic;
+using std::is_signed;
+using std::is_standard_layout;
+using std::is_trivial;
+using std::is_trivially_copyable;
+using std::is_unsigned;
+using std::is_volatile;
+
+using std::is_constructible;
+using std::is_default_constructible;
+using std::is_nothrow_constructible;
+using std::is_nothrow_default_constructible;
+using std::is_trivially_constructible;
+using std::is_trivially_default_constructible;
+
+using std::is_base_of;
+using std::is_convertible;
+using std::is_same;
+
+using std::add_const_t;
+using std::add_cv_t;
+using std::add_volatile_t;
+using std::remove_const_t;
+using std::remove_cv_t;
+using std::remove_volatile_t;
+
+using std::add_lvalue_reference_t;
+using std::add_pointer_t;
+using std::add_rvalue_reference_t;
+using std::make_signed_t;
+using std::make_unsigned_t;
+using std::remove_all_extents_t;
+using std::remove_extent_t;
+using std::remove_pointer_t;
+using std::remove_reference_t;
+
+using std::common_type;
+using std::conditional_t;
+using std::decay;
+using std::enable_if_t;
+using std::underlying_type_t;
+
+using boost::copy_cv_ref_t;
+using boost::copy_cv_t;
+using boost::detected_or_t;
+using boost::detected_t;
+using boost::remove_cv_ref_t;
+
+using boost::is_detected;
+
+#if defined(__cpp_lib_void_t) && __cpp_lib_void_t >= 201411L
+  using std::void_t;
+#else
+  using boost::void_t;
+#endif
+
+
+using boost::hash;
+
+} // namespace lal
+
+
+
+#endif// LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_DETAIL_TRAITS_H_

--- a/vendored/libalgebra_lite/free_tensor.h
+++ b/vendored/libalgebra_lite/free_tensor.h
@@ -1,0 +1,1127 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Created by user on 31/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_FREE_TENSOR_H
+#define LIBALGEBRA_LITE_FREE_TENSOR_H
+
+#include "implementation_types.h"
+#include "libalgebra_lite_export.h"
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <boost/functional/hash.hpp>
+#include <boost/mpl/vector.hpp>
+
+#include "algebra.h"
+#include "basis_traits.h"
+#include "coefficients.h"
+#include "dense_vector.h"
+#include "detail/integer_maths.h"
+#include "registry.h"
+#include "tensor_basis.h"
+#include "unpacked_tensor_word.h"
+#include "vector_traits.h"
+
+namespace lal {
+
+template <
+        typename, template <typename, typename> class,
+        template <typename> class>
+class free_tensor;
+
+namespace dtl {
+
+#define LAL_IS_TENSOR(V) is_same<typename V::basis_type, tensor_basis>::value
+
+#define LAL_SAME_COEFFS(V1, V2)                                                \
+    is_same<typename V1::coefficient_ring, typename V2::coefficient_ring>::value
+
+#define LAL_TENSOR_COMPAT_RVV(R, V1, V2)                                       \
+    enable_if_t<                                                               \
+            LAL_IS_TENSOR(R) && LAL_IS_TENSOR(V1) && LAL_IS_TENSOR(V2)         \
+            && LAL_SAME_COEFFS(R, V1) && LAL_SAME_COEFFS(R, V2)>
+
+template <typename Coefficients>
+class dense_multiplication_helper
+{
+    using traits = coefficient_trait<Coefficients>;
+    using scalar_type = typename traits::scalar_type;
+
+    std::vector<scalar_type> left_read_buffer;
+    std::vector<scalar_type> right_read_buffer;
+    std::vector<scalar_type> write_buffer;
+    std::vector<scalar_type> reverse_buffer;
+    const tensor_basis* p_basis;
+    const scalar_type* left_ptr;
+    const scalar_type* right_ptr;
+
+    scalar_type* out_ptr;
+    deg_t lhs_deg;
+    deg_t rhs_deg;
+    using key_type = typename tensor_basis::key_type;
+
+    using tensor_type = dense_vector<tensor_basis, Coefficients>;
+
+public:
+    dimn_t tile_width;
+    dimn_t tile_size;
+    deg_t tile_letters;
+
+    dense_multiplication_helper(
+            tensor_type& out, const tensor_type& lhs, const tensor_type& rhs
+    )
+        : p_basis(&out.basis()), lhs_deg(lhs.degree()), rhs_deg(rhs.degree())
+    {
+        const auto& powers = p_basis->powers();
+
+        // TODO: replace with logic
+        tile_letters = 1;
+
+        left_ptr = lhs.as_ptr();
+        right_ptr = rhs.as_ptr();
+        out_ptr = out.as_mut_ptr();
+
+        tile_width = powers[tile_letters];
+        tile_size = tile_width * tile_width;
+
+        left_read_buffer.resize(tile_width);
+        right_read_buffer.resize(tile_width);
+        write_buffer.resize(tile_size);
+
+        if (lhs.degree() > 1) {
+            reverse_buffer.resize(p_basis->size(lhs.degree() - 1));
+        }
+    }
+
+    const scalar_type& left_unit() const noexcept { return *left_ptr; }
+    const scalar_type& right_unit() const noexcept { return *right_ptr; }
+
+    const scalar_type* left_tile() const noexcept
+    {
+        return left_read_buffer.data();
+    }
+    const scalar_type* right_tile() const noexcept
+    {
+        return right_read_buffer.data();
+    }
+    scalar_type* write_tile() noexcept { return write_buffer.data(); }
+
+    deg_t lhs_degree() const noexcept { return lhs_deg; }
+    deg_t rhs_degree() const noexcept { return rhs_deg; }
+
+    const scalar_type* left_fwd_read(key_type k) const noexcept
+    {
+        auto offset = p_basis->start_of_degree(static_cast<deg_t>(k.degree()));
+        return left_ptr + k.index() * tile_width + offset;
+    }
+    const scalar_type* right_fwd_read(key_type k) const noexcept
+    {
+        auto offset = p_basis->start_of_degree(static_cast<deg_t>(k.degree()));
+        return right_ptr + k.index() * tile_width + offset;
+    }
+    scalar_type* fwd_write(key_type k) const noexcept
+    {
+        auto offset = p_basis->start_of_degree(static_cast<deg_t>(k.degree()));
+        return out_ptr + k.index() * tile_width + offset;
+    }
+
+    void read_left_tile(key_type k) noexcept
+    {
+        auto offset = p_basis->start_of_degree(static_cast<deg_t>(k.degree()));
+        const auto* reverse_ptr
+                = reverse_buffer.data() + k.index() * tile_width + offset;
+        std::copy(
+                reverse_ptr, reverse_ptr + tile_width, left_read_buffer.data()
+        );
+    }
+    void read_right_tile(key_type k)
+    {
+        auto offset = p_basis->start_of_degree(static_cast<deg_t>(k.degree()));
+        const auto* fwd_ptr = right_ptr + k.index() * tile_width + offset;
+        std::copy(fwd_ptr, fwd_ptr + tile_width, right_read_buffer.data());
+    }
+    void write_tile_in(key_type k, key_type kr)
+    {
+        const auto offset
+                = p_basis->start_of_degree(k.degree() + 2 * tile_letters);
+        const auto* in_ptr = out_ptr + k.index() * tile_width + offset;
+        auto* tile_ptr = write_tile();
+        const auto stride = p_basis->powers()[k.degree() + tile_letters];
+
+        for (dimn_t i = 0; i < tile_width; ++i) {
+            for (dimn_t j = 0; j < tile_width; ++j) {
+                tile_ptr[i * tile_width + j] = in_ptr[i * stride + j];
+            }
+        }
+    }
+
+    void write_tile_out(key_type k, key_type kr)
+    {
+        const auto deg = k.degree();
+        const auto offset = p_basis->start_of_degree(deg + 2 * tile_letters);
+        const auto stride = p_basis->powers()[deg + tile_letters];
+
+        auto* ptr = out_ptr + k.index() * tile_width + offset;
+        auto* tile_ptr = write_tile();
+
+        for (dimn_t i = 0; i < tile_width; ++i) {
+            for (dimn_t j = 0; j < tile_width; ++j) {
+                ptr[i * stride + j] = tile_ptr[i * tile_width + j];
+            }
+        }
+
+        if (deg < p_basis->depth()) {
+            // Write reverse data
+        }
+    }
+
+    key_type reverse(key_type k) const noexcept
+    {
+        const auto width = p_basis->width();
+        auto idx = k.index();
+
+        typename key_type::index_type result_idx = 0;
+        while (idx) {
+            result_idx *= width;
+            result_idx += idx % width;
+            idx /= width;
+        }
+
+        return key_type{k.degree(), result_idx};
+    }
+    pair<key_type, key_type>
+    split_key(key_type k, deg_t lhs_size) const noexcept
+    {
+        auto rhs_size = k.degree() - lhs_size;
+        auto split = p_basis->powers()[rhs_size];
+        return {key_type(lhs_size, k.index() / split),
+                key_type(rhs_size, k.index() % split)};
+    }
+
+    dimn_t stride(deg_t deg) const noexcept
+    {
+        return p_basis->powers()[deg - tile_letters];
+    }
+
+    key_type combine(key_type lhs, key_type rhs)
+    {
+        const auto rhs_deg = rhs.degree();
+        const auto shift = p_basis->powers()[rhs_deg];
+        return key_type{
+                lhs.degree() + rhs_deg, lhs.index() * shift + rhs.index()};
+    }
+    dimn_t combine(dimn_t lhs, key_type rhs)
+    {
+        const auto rhs_deg = rhs.degree();
+        const auto shift = p_basis->powers()[rhs_deg];
+        return lhs * shift + rhs.index();
+    }
+
+    pair<dimn_t, dimn_t> range_size(deg_t lhs, deg_t rhs) const noexcept
+    {
+        const auto& powers = p_basis->powers();
+        return {powers[lhs], powers[rhs]};
+    }
+
+    dimn_t range_size(deg_t deg) const noexcept
+    {
+        return p_basis->powers()[deg];
+    }
+};
+
+}// namespace dtl
+
+class LIBALGEBRA_LITE_EXPORT free_tensor_multiplier
+    : public base_multiplier<free_tensor_multiplier, tensor_basis>
+{
+
+public:
+    using key_type = typename tensor_basis::key_type;
+    using basis_type = tensor_basis;
+
+    explicit free_tensor_multiplier(deg_t width) {}
+
+    static key_type
+    concat_product(const tensor_basis& basis, key_type lhs, key_type rhs)
+    {
+        const auto lhs_deg = lhs.degree();
+        const auto rhs_deg = rhs.degree();
+        const auto shift = basis.powers()[rhs_deg];
+
+        const auto idx = lhs.index() * shift + rhs.index();
+        return key_type(lhs_deg + rhs_deg, idx);
+    }
+
+    using product_type = boost::container::small_vector<pair<key_type, int>, 1>;
+
+    product_type
+    operator()(const tensor_basis& basis, key_type lhs, key_type rhs) const;
+};
+
+class LIBALGEBRA_LITE_EXPORT free_tensor_multiplication
+    : public base_multiplication<
+              free_tensor_multiplier, free_tensor_multiplication>
+{
+    using base_type = base_multiplication<
+            free_tensor_multiplier, free_tensor_multiplication>;
+
+    template <typename C>
+    using ctraits = coefficient_trait<C>;
+
+    template <typename C>
+    using sca_ref = typename ctraits<C>::scalar_type&;
+    template <typename C>
+    using sca_cref = const typename ctraits<C>::scalar_type&;
+    template <typename C>
+    using sca_ptr = typename ctraits<C>::scalar_type*;
+    template <typename C>
+    using sca_rptr = typename ctraits<C>::scalar_type* LAL_RESTRICT;
+    template <typename C>
+    using sca_cptr = const typename ctraits<C>::scalar_type*;
+    template <typename C>
+    using sca_crptr = const typename ctraits<C>::scalar_type* LAL_RESTRICT;
+
+    using key_type = typename tensor_basis::key_type;
+
+    template <typename Coefficients, typename Fn>
+    void fma_dense_traditional(
+            dtl::dense_multiplication_helper<Coefficients>& helper, Fn fn,
+            deg_t out_degree
+    ) const
+    {
+        auto lhs_deg = helper.lhs_degree();
+        auto rhs_deg = helper.rhs_degree();
+
+        for (deg_t out_deg = out_degree; out_deg >= 0; --out_deg) {
+            auto lhs_deg_min = std::max(0, out_deg - rhs_deg);
+            auto lhs_deg_max = std::min(out_deg, lhs_deg);
+
+            auto* out_ptr = helper.fwd_write(key_type(out_deg, 0));
+
+            for (deg_t lh_deg = lhs_deg_max; lh_deg >= lhs_deg_min; --lh_deg) {
+                auto rh_deg = out_deg - lh_deg;
+
+                auto lhs_ptr = helper.left_fwd_read(key_type(lh_deg, 0));
+                auto rhs_ptr = helper.right_fwd_read(key_type(rh_deg, 0));
+
+                auto range_sizes = helper.range_size(lh_deg, rh_deg);
+
+                auto* p = out_ptr;
+                for (dimn_t i = 0; i < range_sizes.first; ++i) {
+                    for (dimn_t j = 0; j < range_sizes.second; ++j) {
+                        *(p++) += fn(lhs_ptr[i] * rhs_ptr[j]);
+                    }
+                }
+            }
+        }
+    }
+
+    template <typename C, typename Fn>
+    LAL_INLINE_ALWAYS static void impl_db0(
+            sca_rptr<C> tile, sca_crptr<C> lhs_ptr, sca_cref<C> rhs_unit,
+            dimn_t stride, dimn_t tile_width, Fn op
+    ) noexcept
+    {}
+    template <typename C, typename Fn>
+    LAL_INLINE_ALWAYS static void impl_0bd(
+            sca_rptr<C> tile, sca_cref<C> lhs_unit, sca_crptr<C> rhs_ptr,
+            dimn_t stride, dimn_t tile_width, Fn op
+    ) noexcept
+    {}
+
+    template <typename C, typename Fn>
+    LAL_INLINE_ALWAYS static void impl_mid(
+            sca_rptr<C> tile, sca_crptr<C> lhs_tile, sca_crptr<C> rhs_tile,
+            dimn_t stride, dimn_t tile_width, Fn op
+    ) noexcept
+    {}
+
+    template <typename C, typename Fn>
+    LAL_INLINE_ALWAYS static void impl_lb1(
+            sca_rptr<C> tile, sca_cref<C> lhs_val, sca_crptr<C> rhs_tile,
+            dimn_t lhs_index, dimn_t tile_width, Fn op
+    ) noexcept
+    {}
+
+    template <typename C, typename Fn>
+    LAL_INLINE_ALWAYS static void impl_1br(
+            sca_rptr<C> tile, sca_crptr<C> lhs_tile, sca_cref<C> rhs_val,
+            dimn_t index, dimn_t tile_width, Fn op
+    ) noexcept
+    {}
+
+    template <typename Coefficients, typename Fn>
+    void fma_dense_tiled(
+            dtl::dense_multiplication_helper<Coefficients>& helper, Fn fn,
+            deg_t out_degree
+    ) const
+    {
+        using key_type = tensor_basis::key_type;
+
+        auto lhs_deg = helper.lhs_degree();
+        auto rhs_deg = helper.rhs_degree();
+
+        auto* tile = helper.write_tile();
+        const auto* left_rtile = helper.left_tile();
+        const auto* right_rtile = helper.right_tile();
+
+        for (deg_t out_deg = out_degree; out_deg > 2 * helper.tile_letters;
+             --out_deg) {
+            const auto stride = helper.stride(out_deg);
+            const auto adj_deg = out_deg - 2 * helper.tile_letters;
+
+            // end is not actually a valid key, but it serves as a marker.
+            key_type start{adj_deg, 0},
+                    end{adj_deg, helper.range_size(adj_deg)};
+
+            for (auto k = start; k < end; ++k) {
+                auto k_reverse = helper.reverse(k);
+
+                helper.write_tile_in(k, k_reverse);
+
+                {
+                    const auto& lhs_unit = helper.left_unit();
+                    const auto* rhs_ptr = helper.right_fwd_read(k);
+
+                    for (dimn_t i = 0; i < helper.tile_width; ++i) {
+                        for (dimn_t j = 0; j < helper.tile_width; ++j) {
+                            tile[i * helper.tile_width + j]
+                                    += fn(lhs_unit * rhs_ptr[i * stride + j]);
+                        }
+                    }
+                }
+
+                {
+                    const auto* lhs_ptr = helper.left_fwd_read(k);
+                    const auto& rhs_unit = helper.right_unit();
+                    for (dimn_t i = 0; i < helper.tile_width; ++i) {
+                        for (dimn_t j = 0; j < helper.tile_width; ++j) {
+                            tile[i * helper.tile_width + j]
+                                    += fn(lhs_ptr[i * stride + j] * rhs_unit);
+                        }
+                    }
+                }
+
+                for (deg_t lh_deg = 1; lh_deg < helper.tile_letters; ++lh_deg) {
+                    auto rh_deg = adj_deg - lh_deg;
+                    for (dimn_t i = 0; i < helper.tile_width; ++i) {
+                        const auto split = helper.split_key(k, lh_deg);
+                        const auto& lhs_val
+                                = *helper.left_fwd_read(split.first);
+                        helper.read_right_tile(helper.combine(split.first, k));
+                        for (dimn_t j = 0; j < helper.tile_width; ++j) {
+                            tile[i * helper.tile_width + j]
+                                    += fn(lhs_val * right_rtile[j]);
+                        }
+                    }
+                }
+
+                for (deg_t lh_deg = 0; lh_deg < adj_deg; ++lh_deg) {
+                    const auto rh_deg = adj_deg - lh_deg;
+                    auto split = helper.split_key(k, lh_deg);
+                    helper.read_left_tile(helper.reverse(split.first));
+                    helper.read_right_tile(split.second);
+
+                    for (dimn_t i = 0; i < helper.tile_width; ++i) {
+                        for (dimn_t j = 0; j < helper.tile_width; ++j) {
+                            tile[i * helper.tile_width + j]
+                                    += fn(left_rtile[i] * right_rtile[j]);
+                        }
+                    }
+                }
+
+                for (deg_t rh_deg = 1; rh_deg < helper.tile_letters; ++rh_deg) {
+                    const auto lh_deg = adj_deg - rh_deg;
+                    for (dimn_t j = 0; j < helper.tile_width; ++j) {
+                        const auto split
+                                = helper.split_key(key_type(rh_deg, j), lh_deg);
+                        const auto& rhs_val
+                                = *helper.right_fwd_read(helper.combine(
+                                        k_reverse, helper.reverse(split.first)
+                                ));
+                        helper.read_left_tile(split.second);
+
+                        for (dimn_t i = 0; i < helper.tile_width; ++i) {
+                            tile[i * helper.tile_width + j]
+                                    += fn(left_rtile[i] * rhs_val);
+                        }
+                    }
+                }
+
+                helper.write_tile_out(k, k_reverse);
+            }
+        }
+
+        fma_dense_traditional(helper, fn, 2 * helper.tile_letters);
+    }
+
+public:
+    template <typename Coeff>
+    using dense_tensor_vec = dense_vector<tensor_basis, Coeff>;
+
+    using base_type::base_type;
+
+    using base_type::fma;
+    using base_type::multiply_inplace;
+
+    template <typename Coeff, typename Op>
+    void
+    fma(dense_tensor_vec<Coeff>& out, const dense_tensor_vec<Coeff>& lhs,
+        const dense_tensor_vec<Coeff>& rhs, Op op) const
+    {
+        fma(out, lhs, rhs, op, out.basis().depth());
+    }
+
+    template <typename Coeff, typename Op>
+    void
+    fma(dense_tensor_vec<Coeff>& out, const dense_tensor_vec<Coeff>& lhs,
+        const dense_tensor_vec<Coeff>& rhs, Op op, deg_t max_degree) const
+    {
+        const auto& basis = out.basis();
+        if (max_degree >= basis.depth()) { max_degree = basis.depth(); }
+
+        deg_t out_degree = std::min(max_degree, lhs.degree() + rhs.degree());
+
+        const auto out_size = basis.size(out_degree);
+        if (out.size() < out_size) {
+            /*
+             * The resize function will look for the smallest dimension larger
+             * than the requested dim, so if we give it size, it will look for
+             * the smallest dimension greater than size, not simply size. Thus,
+             * we subtract 1 to make sure the next smallest dimension is equal
+             * to size.
+             */
+            out.resize(out_size - 1);
+        }
+
+        dtl::dense_multiplication_helper<Coeff> helper(out, lhs, rhs);
+        //        if (out_degree > 2*helper.tile_letters) {
+        //            fma_dense_tiled(helper, op, out_degree);
+        //        } else {
+        fma_dense_traditional(helper, op, out_degree);
+        //        }
+    }
+};
+
+#undef LAL_TENSOR_COMPAT_RVV
+#undef LAL_SAME_COEFFS
+#undef LAL_IS_TENSOR
+
+namespace dtl {
+
+template <typename Coefficients>
+class antipode_helper
+{
+    using scalar_type = typename Coefficients::scalar_type;
+    using pointer = scalar_type*;
+    using const_pointer = const scalar_type*;
+
+    std::vector<pair<dimn_t, dimn_t>> permute;
+    pointer tile;
+
+    lal::basis_pointer<tensor_basis> p_basis;
+    deg_t tile_letters;
+    dimn_t tile_width;
+    dimn_t tile_size;
+    bool do_signing = true;
+
+    void read_tile(const_pointer src, dimn_t stride) const
+    {
+        for (dimn_t i = 0; i < tile_width; ++i) {
+            for (dimn_t j = 0; j < tile_width; ++j) {
+                tile[i * tile_width + j] = src[i * stride + j];
+            }
+        }
+    }
+
+    void write_tile(pointer dst, dimn_t stride) const
+    {
+        for (dimn_t i = 0; i < tile_width; ++i) {
+            for (dimn_t j = 0; j < tile_width; ++j) {
+                dst[i * stride + j] = std::move(tile[i * tile_width + j]);
+            }
+        }
+    }
+
+    void handle_dense_untiled_level(
+            pointer LAL_RESTRICT dst, const_pointer LAL_RESTRICT src,
+            deg_t degree
+    ) const
+    {
+        if (degree == 0) {
+            // Degree 0 is easy, just copy the data from src to dst.
+            *dst = *src;
+        } else if (degree == 1) {
+            // Degree 1 is like degree 0, no permutation is needed so we only
+            // need to worry about signing
+            for (dimn_t i = 0; i < static_cast<dimn_t>(p_basis->width()); ++i) {
+                if (do_signing) {
+                    dst[i] = -src[i];
+                } else {
+                    dst[i] = src[i];
+                }
+            }
+        } else {
+            for (dimn_t i = 0; i < p_basis->powers()[degree]; ++i) {
+                auto ri = p_basis->reverse_idx(degree, i);
+                if (do_signing && !is_even(degree)) {
+                    dst[ri] = -src[i];
+                } else {
+                    dst[ri] = src[i];
+                }
+            }
+        }
+    }
+
+    void permute_tile() const
+    {
+        for (const auto& pids : permute) {
+            std::swap(tile[pids.first], tile[pids.second]);
+        }
+    }
+
+    void sign_tile() const
+    {
+        for (dimn_t i = 0; i < tile_size; ++i) { tile[i] = -tile[i]; }
+    }
+
+    void handle_dense_tiled_level(
+            pointer LAL_RESTRICT dst, const_pointer LAL_RESTRICT src,
+            deg_t degree
+    ) const
+    {
+        auto middle_degree = degree - 2 * tile_letters;
+        auto stride = p_basis->powers()[degree - tile_letters];
+        unpacked_tensor_word word(p_basis->width(), middle_degree);
+
+        for (dimn_t i = 0; i < p_basis->powers()[middle_degree]; ++i, ++word) {
+            auto ridx = word.to_reverse_index();
+            //            auto ridx = p_basis->reverse_idx(middle_degree, i);
+
+            read_tile(src + i * tile_width, stride);
+            if (do_signing && !is_even(degree)) { sign_tile(); }
+            permute_tile();
+
+            write_tile(dst + ridx * tile_width, stride);
+        }
+    }
+
+    template <template <typename, typename> class VectorType>
+    void handle_antipode(
+            VectorType<tensor_basis, Coefficients>& result,
+            const VectorType<tensor_basis, Coefficients>& arg
+    ) const;
+
+    template <template <typename, typename...> class Storage>
+    void handle_antipode(
+            dense_vector_base<tensor_basis, Coefficients, Storage>& result,
+            const dense_vector_base<tensor_basis, Coefficients, Storage>& arg
+    ) const;
+
+public:
+    explicit antipode_helper(lal::basis_pointer<tensor_basis> basis)
+        : p_basis(basis)
+    {
+#if defined(LAL_MAX_TILE_LETTERS) && LAL_MAX_TILE_LETTERS == 0
+        tile_letters = 0;
+        tile_width = 0;
+#else
+#  if defined(LAL_MAX_TILE_LETTERS) && LAL_MAX_TILE_LETTERS > 0
+        constexpr deg_t max_letters = LAL_MAX_TILE_LETTERS;
+#  else
+        constexpr deg_t max_letters = 3;
+#  endif
+        tile_letters = std::min(max_letters, p_basis->depth() / 2);
+        tile_width = p_basis->powers()[tile_letters];
+#endif
+        tile_size = tile_width * tile_width;
+        if (tile_size > 0) {
+            tile = new scalar_type[tile_size]{};
+
+            std::unordered_set<dimn_t> seen;
+
+            for (dimn_t i = 0; i < tile_width; ++i) {
+                auto ri = p_basis->reverse_idx(tile_letters, i);
+                for (dimn_t j = 0; j < tile_width; ++j) {
+                    auto rj = p_basis->reverse_idx(tile_letters, j);
+                    auto idx = i * tile_width + j;
+                    auto ridx = rj * tile_width + ri;
+                    if (ridx != idx && seen.find(idx) == seen.end()) {
+                        seen.insert(idx);
+                        seen.insert(ridx);
+                        permute.push_back({idx, ridx});
+                    }
+                }
+            }
+        } else {
+            tile = nullptr;
+        }
+    }
+    ~antipode_helper() { delete[] tile; }
+
+    template <typename Tensor>
+    enable_if_t<
+            is_same<Coefficients, typename Tensor::coefficient_ring>::value,
+            Tensor>
+    operator()(const Tensor& arg) const
+    {
+        Tensor result(p_basis, arg.multiplication());
+        handle_antipode(result.base_vector(), arg.base_vector());
+        return result;
+    }
+};
+
+template <typename Coefficients>
+template <template <typename, typename> class VectorType>
+void antipode_helper<Coefficients>::handle_antipode(
+        VectorType<tensor_basis, Coefficients>& result,
+        const VectorType<tensor_basis, Coefficients>& arg
+) const
+{
+    for (auto&& term : arg) {
+        auto key = p_basis->reverse_key(term.key());
+        if (do_signing && !is_even(key.degree())) {
+            result[key] = -term.value();
+        } else {
+            result[key] = term.value();
+        }
+    }
+}
+template <typename Coefficients>
+template <template <typename, typename...> class Storage>
+void antipode_helper<Coefficients>::handle_antipode(
+        dense_vector_base<tensor_basis, Coefficients, Storage>& result,
+        const dense_vector_base<tensor_basis, Coefficients, Storage>& arg
+) const
+{
+    result.resize_exact(arg.dimension());
+    auto* optr = result.as_mut_ptr();
+    const auto* iptr = arg.as_ptr();
+    const auto max_degree = arg.degree();
+    result.update_degree(max_degree);
+    deg_t deg = 0;
+
+    const auto untiled_levels = (tile_letters > 0)
+            ? std::min(max_degree, 2 * tile_letters - 1)
+            : max_degree;
+
+    for (; deg <= untiled_levels; ++deg) {
+        handle_dense_untiled_level(optr, iptr, deg);
+        optr += p_basis->powers()[deg];
+        iptr += p_basis->powers()[deg];
+    }
+
+    // Handle the higher levels with tiling.
+    // Note this loop will do nothing if all the levels have already been done
+    for (; deg <= max_degree; ++deg) {
+        handle_dense_tiled_level(optr, iptr, deg);
+        optr += p_basis->powers()[deg];
+        iptr += p_basis->powers()[deg];
+    }
+}
+
+}// namespace dtl
+
+template <
+        typename Coefficients, template <typename, typename> class VectorType,
+        template <typename> class StorageModel>
+class free_tensor
+    : public algebra<
+              tensor_basis, Coefficients, free_tensor_multiplication,
+              VectorType, StorageModel>
+{
+    using algebra_type = algebra<
+            tensor_basis, Coefficients, free_tensor_multiplication, VectorType,
+            StorageModel>;
+
+    static void resize_to_degree(
+            free_tensor<Coefficients, dense_vector, StorageModel>& arg,
+            deg_t degree
+    )
+    {
+        assert(degree <= basis_trait<tensor_basis>::max_degree(arg.basis()));
+        auto size = arg.basis().size(degree);
+        /*
+         * The resize function will look for the smallest dimension larger than
+         * the requested dim, so if we give it size, it will look for the
+         * smallest dimension greater than size, not simply size. Thus, we
+         * subtract 1 to make sure the next smallest dimension is equal to size.
+         */
+        arg.base_vector().resize(size - 1);
+        arg.base_vector().update_degree(degree);
+    }
+
+    template <template <typename, typename> class OVT>
+    static void resize_to_degree(
+            free_tensor<Coefficients, OVT, StorageModel>& arg, deg_t degree
+    )
+    {
+        arg.base_vector().update_degree(degree);
+    }
+
+public:
+    using typename algebra_type::basis_type;
+    using typename algebra_type::coefficient_ring;
+    using typename algebra_type::key_type;
+    using typename algebra_type::rational_type;
+    using typename algebra_type::scalar_type;
+
+    using typename algebra_type::basis_pointer;
+    using typename algebra_type::multiplication_pointer;
+
+    using algebra_type::algebra_type;
+
+    free_tensor(
+            basis_pointer basis, multiplication_pointer mul, scalar_type arg
+    )
+        : algebra_type(basis, mul, key_type(0, 0), std::move(arg))
+    {}
+
+    free_tensor(basis_pointer basis, scalar_type arg)
+        : algebra_type(basis, key_type(0, 0), std::move(arg))
+    {}
+
+    free_tensor create_alike() const
+    {
+        return free_tensor(this->get_basis(), this->multiplication());
+    }
+
+    free_tensor& fmexp_inplace(const free_tensor& exp_arg)
+    {
+        free_tensor original(*this), x(exp_arg);
+
+        x[key_type(0, 0)] = scalar_type(0);
+
+        auto degree = this->basis().depth();
+        resize_to_degree(*this, degree);
+        for (deg_t i = degree; i >= 1; --i) {
+            this->mul_scal_div(x, rational_type(i), degree - i + 1);
+            *this += original;
+        }
+
+        return *this;
+    }
+
+    free_tensor fmexp(const free_tensor& exp_arg) const
+    {
+        free_tensor result(*this), x(exp_arg);
+
+        x[key_type(0, 0)] = scalar_type(0);
+
+        auto degree = this->basis().depth();
+        resize_to_degree(result, degree);
+
+        for (deg_t i = degree; i >= 1; --i) {
+            result.mul_scal_div(x, rational_type(i), degree - i + 1);
+            result += *this;
+        }
+
+        return result;
+    }
+
+    friend free_tensor exp(const free_tensor& arg)
+    {
+        free_tensor result(
+                arg.get_basis(), arg.multiplication(), scalar_type(1)
+        );
+        free_tensor one(arg.get_basis(), arg.multiplication(), scalar_type(1));
+
+        const auto degree = arg.basis().depth();
+        resize_to_degree(result, degree);
+        for (deg_t i = degree; i >= 1; --i) {
+            result.mul_scal_div(arg, rational_type(i));
+            result += one;
+        }
+
+        return result;
+    }
+
+    friend free_tensor log(const free_tensor& arg)
+    {
+
+        auto x = arg;
+        x[typename tensor_basis::key_type(0, 0)] = scalar_type(0);
+
+        free_tensor result(arg.get_basis(), arg.multiplication());
+        const auto degree = arg.basis().depth();
+        resize_to_degree(result, degree);
+
+        free_tensor one(arg.get_basis(), arg.multiplication(), scalar_type(1));
+        for (deg_t i = degree; i >= 1; --i) {
+            if (i % 2 == 0) {
+                result.sub_scal_div(one, rational_type(i));
+            } else {
+                result.add_scal_div(one, rational_type(i));
+            }
+            result *= x;
+        }
+
+        return result;
+    }
+
+    friend free_tensor inverse(const free_tensor& arg)
+    {
+        const auto& unit = arg[key_type(0, 0)];
+        assert(coefficient_ring::is_invertible(unit));
+        const auto& a = coefficient_ring::as_rational(arg[key_type(0, 0)]);
+        auto x = arg;
+        x[key_type(0, 0)] = Coefficients::zero();
+
+        const auto degree = arg.basis().depth();
+        free_tensor a_inverse(
+                arg.get_basis(), arg.multiplication(), scalar_type(1) / a
+        );
+        free_tensor result(a_inverse);
+        resize_to_degree(result, degree);
+
+        auto z = x / a;
+        for (deg_t d = 0; d < degree; ++d) { result = a_inverse + z * result; }
+
+        return result;
+    }
+
+    friend free_tensor antipode(const free_tensor& arg)
+    {
+        dtl::antipode_helper<Coefficients> helper(arg.get_basis());
+        return helper(arg);
+    }
+};
+
+LAL_EXPORT_TEMPLATE_CLASS(multiplication_registry, free_tensor_multiplication)
+
+template <typename LTensor, typename RTensor>
+inline LTensor free_tensor_multiply(const LTensor& left, const RTensor& right)
+{
+    const auto ftm = multiplication_registry<free_tensor_multiplication>::get(
+            left.basis()
+    );
+    return multiply(*ftm, left, right);
+}
+
+namespace dtl {
+inline namespace unstable {
+
+template <typename Tensor>
+class left_ftm_adjoint
+{
+    const Tensor* multiplier;
+
+    using coefficient_ring = typename Tensor::coefficient_ring;
+    using s_t = typename coefficient_ring::scalar_type;
+
+public:
+    explicit left_ftm_adjoint(const Tensor& arg) : multiplier(&arg) {}
+
+    template <typename Shuffle>
+    enable_if_t<
+            is_same<typename Tensor::coefficient_ring,
+                    typename Shuffle::coefficient_ring>::value
+                    && is_same<
+                            typename Shuffle::basis_type, tensor_basis>::value,
+            Shuffle>
+    operator()(const Shuffle& arg) const
+    {
+        Shuffle result(arg.get_basis(), arg.multiplication());
+        eval(result.base_vector(), arg.base_vector(),
+             multiplier->base_vector());
+        return result;
+    }
+
+private:
+    template <typename V, typename B>
+    enable_if_t<is_same<typename V::basis_type, tensor_basis>::value>
+    eval(V& result, const V& arg, const B& mul) const
+    {
+        using s_t = typename coefficient_ring::scalar_type;
+        for (auto&& pr : mul) {
+            const auto& val = pr.value();
+            result.inplace_binary_op(
+                    shift_down(arg, pr.key()),
+                    [&val](const s_t& l, const s_t& r) { return l + val * r; }
+            );
+        }
+    }
+
+    template <
+            template <typename, typename...> class VSM,
+            template <typename, typename> class BT>
+    void
+    eval(dense_vector_base<tensor_basis, coefficient_ring, VSM>& result,
+         const dense_vector_base<tensor_basis, coefficient_ring, VSM>& arg,
+         const BT<tensor_basis, coefficient_ring>& mul) const
+    {
+        const auto& basis = result.basis();
+        const auto& powers = basis.powers();
+
+        const auto arg_deg = arg.degree();
+        result.resize_exact(basis.size(arg_deg));
+
+        for (auto&& pr : mul) {
+            const auto key = pr.key();
+            const auto prefix_degree = key.degree();
+            const auto index = key.index();
+            const auto& value = pr.value();
+
+            for (deg_t degree = prefix_degree; degree <= arg_deg; ++degree) {
+                auto suffix_degree = degree - prefix_degree;
+                auto* optr = result.as_mut_ptr()
+                        + basis.start_of_degree(suffix_degree);
+                const auto* iptr = arg.as_ptr() + index * powers[suffix_degree];
+
+                for (dimn_t i = 0; i < powers[suffix_degree]; ++i) {
+                    optr[i] += value * iptr[i];
+                }
+            }
+        }
+    }
+
+    template <
+            template <typename, typename...> class VSM,
+            template <typename, typename...> class BSM>
+    void
+    eval(dense_vector_base<tensor_basis, coefficient_ring, VSM>& result,
+         const dense_vector_base<tensor_basis, coefficient_ring, VSM>& arg,
+         const dense_vector_base<tensor_basis, coefficient_ring, BSM>& mul
+    ) const
+    {
+        const auto& basis = result.basis();
+        const auto* sizes = basis.sizes().data();
+        const auto* powers = basis.powers().data();
+
+        const auto arg_deg = arg.degree();
+        const auto param_deg = mul.degree();
+        const auto target_deg = std::min(arg_deg, param_deg);
+        result.resize_exact(sizes[arg_deg]);
+
+        auto* optr = result.as_mut_ptr();
+        const auto* aptr = arg.as_ptr();
+        const auto* pptr = mul.as_ptr();
+
+        const auto& param_unit = *pptr;
+
+        if (param_unit != coefficient_ring::zero()) {
+            for (dimn_t i = 0; i < arg.dimension(); ++i) {
+                optr[i] = param_unit * aptr[i];
+            }
+        }
+
+//        aptr += 1;
+//        pptr += 1;
+        for (deg_t prefix_deg = 1; prefix_deg <= target_deg; ++prefix_deg) {
+            aptr += powers[prefix_deg-1];
+            pptr += powers[prefix_deg-1];
+            eval_single_dense(
+                    optr, aptr, pptr, powers, sizes, prefix_deg, arg_deg
+            );
+
+        }
+    }
+
+    template <typename Arg>
+    static Arg shift_down(const Arg& arg, typename tensor_basis::key_type word)
+    {
+        const auto& basis = arg.basis();
+        Arg result(arg);
+        Arg working(arg.get_basis());
+
+        while (word.degree() > 0) {
+            auto parents = basis.parents(word);
+            word = parents.second;
+
+            for (auto&& pr : result) {
+                auto key = pr.key();
+                auto prparents = basis.parents(key);
+                if (key.degree() > 0 && prparents.first == parents.first) {
+                    working[prparents.second]
+                            = static_cast<const Arg&>(result)[key];
+                }
+            }
+            result.swap(working);
+            working.clear();
+        }
+        return result;
+    }
+
+    static void eval_single_dense(
+            s_t* LAL_RESTRICT optr, const s_t* LAL_RESTRICT aptr,
+            const s_t* LAL_RESTRICT pptr, const dimn_t* powers,
+            const dimn_t* sizes, deg_t param_deg, deg_t arg_deg
+    )
+    {
+        assert(param_deg <= arg_deg);
+        if (param_deg == arg_deg) {
+            auto& unit = optr[0];
+            for (dimn_t i=0; i<powers[param_deg]; ++i) {
+                unit += pptr[i]*aptr[i];
+            }
+            return;
+        }
+
+
+        auto* dst = optr;
+        for (deg_t degree = param_deg; degree <= arg_deg; ++degree) {
+            auto result_deg = degree - param_deg;
+
+            for (dimn_t pidx = 0; pidx < powers[param_deg]; ++pidx) {
+                const auto* src = aptr + pidx*powers[result_deg];
+                const auto& val = pptr[pidx];
+
+                for (dimn_t aidx = 0; aidx < powers[result_deg]; ++aidx) {
+                    dst[aidx] += val * src[aidx];
+                }
+            }
+
+            aptr += powers[degree];
+            dst += powers[result_deg];
+        }
+    }
+};
+
+}// namespace unstable
+}// namespace dtl
+
+template <typename Tensor, typename Shuffle>
+Shuffle
+left_free_tensor_multiply_adjoint(const Tensor& param, const Shuffle& arg)
+{
+    dtl::left_ftm_adjoint<Tensor> op(param);
+    return op(arg);
+}
+
+}// namespace lal
+
+#endif// LIBALGEBRA_LITE_FREE_TENSOR_H

--- a/vendored/libalgebra_lite/hall_set.h
+++ b/vendored/libalgebra_lite/hall_set.h
@@ -1,0 +1,249 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Created by user on 26/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_HALL_SET_H
+#define LIBALGEBRA_LITE_HALL_SET_H
+
+#include "implementation_types.h"
+#include "libalgebra_lite_export.h"
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <boost/container/flat_map.hpp>
+
+#include "index_key.h"
+#include "registry.h"
+#include "basis_traits.h"
+
+namespace lal {
+
+
+
+class LIBALGEBRA_LITE_EXPORT hall_set {
+public:
+    using letter_type = let_t;
+    using degree_type = deg_t;
+    using key_type = index_key<>;
+    using size_type = dimn_t;
+    using parent_type = std::pair<key_type, key_type>;
+private:
+    using data_type = std::vector<parent_type>;
+    using reverse_map_type = boost::container::flat_map<parent_type, key_type>;
+//    using reverse_map_type = std::map<parent_type, key_type>;
+    using l2k_map_type = std::vector<key_type>;
+    using size_vector_type = std::vector<size_type>;
+    using degree_range_map_type = std::vector<std::pair<size_type, size_type>>;
+
+    degree_type current_degree;
+
+    std::vector<letter_type> letters;
+    data_type data;
+    reverse_map_type reverse_map;
+    l2k_map_type l2k;
+    degree_range_map_type degree_ranges;
+    size_vector_type m_sizes;
+
+public:
+
+    struct find_result
+    {
+        typename reverse_map_type::const_iterator it;
+        bool found;
+    };
+
+
+    static constexpr key_type root_element {0, 0};
+    static constexpr parent_type root_parent {root_element, root_element};
+
+    explicit hall_set(degree_type width, degree_type depth=1);
+    explicit hall_set(const hall_set& existing, degree_type deg);
+
+    void grow_up(degree_type deg);
+
+
+    key_type key_of_letter(let_t) const noexcept;
+    size_type size(deg_t) const noexcept;
+    const std::vector<dimn_t>& sizes() const noexcept { return m_sizes; }
+
+    size_type size_of_degree(deg_t) const noexcept;
+    bool letter(const key_type&) const noexcept;
+    letter_type get_letter(dimn_t idx) const noexcept;
+
+    find_result find(parent_type parent) const noexcept;
+
+    size_type index_of_key(key_type arg) const noexcept;
+    key_type key_of_index(size_type index) const noexcept;
+
+    const parent_type &operator[](const key_type&) const noexcept;
+    const key_type& operator[](const parent_type&) const;
+};
+
+
+template<typename Func,
+        typename Binop,
+        typename ReturnType=decltype(std::declval<Func>()(std::declval<let_t>()))>
+class hall_extension {
+public:
+    using key_type = typename hall_set::key_type;
+    using return_type = ReturnType;
+private:
+    using cached_type = decltype(std::declval<Func>()(std::declval<let_t>()));
+
+    std::shared_ptr<const hall_set> m_hall_set;
+    Func m_func;
+    Binop m_binop;
+    mutable std::unordered_map<key_type, cached_type> m_cache;
+    mutable std::recursive_mutex m_lock;
+public:
+
+    explicit hall_extension(std::shared_ptr<const hall_set> hs, Func&& func, Binop&& binop);
+
+    return_type operator()(key_type key) const;
+
+};
+
+
+class LIBALGEBRA_LITE_EXPORT hall_basis
+{
+    deg_t m_width;
+    deg_t m_depth;
+    std::shared_ptr<const hall_set> p_hallset;
+
+    static std::string letter_to_string(let_t letter);
+    static std::string key_to_string_op(const std::string& left, const std::string& right);
+
+
+    hall_extension<decltype(&letter_to_string),
+            decltype(&key_to_string_op),
+            const std::string&> m_key_to_string;
+
+public:
+
+    using key_type = typename hall_set::key_type;
+    using parent_type = typename hall_set::parent_type;
+    using degree_tag LAL_UNUSED = with_degree_tag;
+
+    hall_basis(deg_t width, deg_t depth) : m_width(width), m_depth(depth),
+        p_hallset(new hall_set(width, depth)),
+        m_key_to_string(p_hallset, &letter_to_string, &key_to_string_op)
+    {}
+
+    deg_t width() const noexcept { return m_width; }
+    deg_t depth() const noexcept { return m_depth; }
+
+    static constexpr deg_t degree(const key_type& arg) noexcept
+    { return deg_t(arg.degree()); }
+
+    bool letter(const key_type& arg) const noexcept {
+        return arg.degree() == 1;
+    }
+    parent_type parents(const key_type& arg) const noexcept
+    { return (*p_hallset)[arg]; }
+    key_type lparent(const key_type& arg) const noexcept
+    { return parents(arg).first; }
+    key_type rparent(const key_type& arg) const noexcept
+    { return parents(arg).second; }
+    key_type key_of_letter(let_t letter) const noexcept
+    { return p_hallset->key_of_letter(letter); }
+    let_t first_letter(const key_type& key) const noexcept
+    { return p_hallset->get_letter((*p_hallset)[key].first.index()); }
+    let_t to_letter(const key_type& key) const noexcept
+    { return p_hallset->get_letter(key.index()); }
+    dimn_t size(int deg) const noexcept
+    {
+        return p_hallset->size(deg < 0 ? m_depth : static_cast<deg_t>(deg));
+    }
+
+    const std::vector<dimn_t>& sizes() const noexcept
+    { return p_hallset->sizes(); }
+
+    dimn_t start_of_degree(deg_t deg) const noexcept
+    {
+        return (deg == 0) ? 0 : p_hallset->size(deg-1);
+    }
+    dimn_t size_of_degree(deg_t deg) const noexcept { return p_hallset->size_of_degree(deg); }
+    typename hall_set::find_result find(parent_type parents) const noexcept;
+
+    dimn_t key_to_index(key_type arg) const noexcept { return p_hallset->index_of_key(arg); }
+    key_type index_to_key(dimn_t arg) const noexcept { return p_hallset->key_of_index(arg); }
+
+
+    std::shared_ptr<const hall_set> get_hall_set() const noexcept { return p_hallset; }
+
+    std::ostream& print_key(std::ostream& os, key_type key) const;
+
+
+    void advance_key(key_type& key) const;
+};
+
+
+
+
+
+
+template<typename Func, typename Binop, typename ReturnType>
+hall_extension<Func, Binop, ReturnType>::hall_extension(std::shared_ptr<const hall_set> hs, Func&& func, Binop&& binop)
+        : m_hall_set(std::move(hs)),
+        m_func(std::forward<Func>(func)),
+        m_binop(std::forward<Binop>(binop))
+{
+}
+
+template<typename Func, typename Binop, typename ReturnType>
+ReturnType
+hall_extension<Func, Binop, ReturnType>::operator()(
+        hall_extension::key_type key) const
+{
+    std::lock_guard<std::recursive_mutex> access(m_lock);
+
+    assert(key.degree() != 0);
+    auto found = m_cache.find(key);
+    if (found!=m_cache.end()) {
+        return found->second;
+    }
+
+    if (m_hall_set->letter(key)) {
+        return m_cache[key] = m_func(m_hall_set->get_letter(key.index()));
+    }
+
+    auto parents = (*m_hall_set)[key];
+    return m_cache[key] = m_binop(operator()(parents.first), operator()(parents.second));
+}
+
+LAL_EXPORT_TEMPLATE_CLASS(basis_registry, hall_basis)
+
+} // namespace lal
+
+#endif //LIBALGEBRA_LITE_HALL_SET_H

--- a/vendored/libalgebra_lite/implementation_types.h
+++ b/vendored/libalgebra_lite/implementation_types.h
@@ -1,0 +1,55 @@
+//
+// Created by user on 23/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_IMPLEMENTATION_TYPES_H
+#define LIBALGEBRA_LITE_IMPLEMENTATION_TYPES_H
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+
+#include "detail/macros.h"
+
+#ifdef LAL_USE_LIBAGEBRA
+#include <libalgebra/libalgebra.h>
+#endif
+
+
+namespace lal {
+
+using dimn_t = std::size_t;
+using idimn_t = std::ptrdiff_t;
+using deg_t = std::int32_t;
+
+using let_t = std::size_t;
+
+using std::pair;
+
+
+} // namespace lal
+
+
+
+#ifdef _WIN32
+#ifdef Libalgebra_Lite_EXPORTS
+#define LAL_EXPORT_TEMPLATE_CLASS(TMPL, ...) \
+    extern template class TMPL<__VA_ARGS__>;
+#define LAL_EXPORT_TEMPLATE_STRUCT(TMPL, ...) \
+    extern template struct TMPL<__VA_ARGS__>;
+#else
+#define LAL_EXPORT_TEMPLATE_CLASS(TMPL, ...) \
+    template class LIBALGEBRA_LITE_EXPORT TMPL<__VA_ARGS__>;
+#define LAL_EXPORT_TEMPLATE_STRUCT(TMPL, ...) \
+    template struct LIBALGEBRA_LITE_EXPORT TMPL<__VA_ARGS__>;
+#endif
+#else
+#define LAL_EXPORT_TEMPLATE_CLASS(TMPL, ...) \
+    extern template class LIBALGEBRA_LITE_EXPORT TMPL<__VA_ARGS__>;
+#define LAL_EXPORT_TEMPLATE_STRUCT(TMPL, ...) \
+    extern template struct LIBALGEBRA_LITE_EXPORT TMPL<__VA_ARGS__>;
+#endif
+
+
+#endif //LIBALGEBRA_LITE_IMPLEMENTATION_TYPES_H

--- a/vendored/libalgebra_lite/index_key.h
+++ b/vendored/libalgebra_lite/index_key.h
@@ -1,0 +1,147 @@
+//
+// Created by user on 25/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_INDEX_KEY_H
+#define LIBALGEBRA_LITE_INDEX_KEY_H
+
+#include "implementation_types.h"
+
+#include <limits>
+#include <ostream>
+#include <unordered_map>
+
+namespace lal {
+
+namespace dtl {
+struct index_key_access;
+} // namespace dtl
+
+template <int DegreeDigits=4, typename Int=dimn_t>
+class index_key
+{
+    using limits = std::numeric_limits<Int>;
+    static constexpr int degree_digits = DegreeDigits;
+
+    static_assert(DegreeDigits < limits::digits, "DegreeDigits cannot exceed number of digits of Int");
+    static constexpr int index_bits = limits::digits - DegreeDigits;
+    static constexpr Int index_mask = (Int(1) << index_bits) - 1;
+    static constexpr Int degree_mask = ~index_mask;
+
+    Int m_data;
+
+    friend struct dtl::index_key_access;
+
+    explicit constexpr index_key(Int raw) : m_data(raw)
+    {}
+
+public:
+    static constexpr deg_t max_degree = (deg_t(1) << degree_digits) - 1;
+
+    using index_type = Int;
+
+    explicit constexpr index_key() : m_data(0)
+    {}
+
+    explicit constexpr index_key(deg_t degree, index_type index)
+        : m_data((Int(degree) << index_bits) + index)
+    {}
+
+    template <typename DegreeInt, typename IndexInt>
+    explicit constexpr index_key(DegreeInt degree, IndexInt index)
+        : m_data((Int(degree) << index_bits) + Int(index))
+    {}
+
+    constexpr Int index() const noexcept
+    {
+        return m_data & index_mask;
+    }
+
+    constexpr Int degree() const noexcept
+    {
+        return (m_data & degree_mask) >> index_bits;
+    }
+
+    constexpr bool operator==(const index_key& other) const noexcept
+    { return m_data == other.m_data; }
+    constexpr bool operator!=(const index_key& other) const noexcept
+    { return m_data != other.m_data; }
+    constexpr bool operator<(const index_key& other) const noexcept
+    { return m_data < other.m_data; }
+    constexpr bool operator<=(const index_key& other) const noexcept
+    { return m_data <= other.m_data; }
+    constexpr bool operator>(const index_key& other) const noexcept
+    { return m_data > other.m_data; }
+    constexpr bool operator>=(const index_key& other) const noexcept
+    { return m_data >= other.m_data; }
+
+    template <int OtherDegreeDigits, typename OtherType>
+    constexpr bool operator==(const index_key<OtherDegreeDigits, OtherType>& other) const noexcept
+    { return degree() == Int(other.degree()) && index() == Int(other.index()); }
+    template <int OtherDegreeDigits, typename OtherType>
+    constexpr bool operator!=(const index_key<OtherDegreeDigits, OtherType>& other) const noexcept
+    { return degree() != Int(other.degree()) || index() != Int(other.index()); }
+    template <int OtherDegreeDigits, typename OtherType>
+    constexpr bool operator<(const index_key<OtherDegreeDigits, OtherType>& other) const noexcept
+    { return degree() < Int(other.degree()) || (degree() == Int(other.degree()) && index() < Int(other.index())); }
+    template<int OtherDegreeDigits, typename OtherType>
+    constexpr bool operator<=(const index_key<OtherDegreeDigits, OtherType>& other) const noexcept
+    { return degree()<Int(other.degree()) || (degree()==Int(other.degree()) && index()<=Int(other.index())); }
+    template <int OtherDegreeDigits, typename OtherType>
+    constexpr bool operator>(const index_key<OtherDegreeDigits, OtherType>& other) const noexcept
+    { return degree()>Int(other.degree()) || (degree()==Int(other.degree()) && index()>Int(other.index())); }
+    template<int OtherDegreeDigits, typename OtherType>
+    constexpr bool operator>=(const index_key<OtherDegreeDigits, OtherType>& other) const noexcept
+    { return degree()>Int(other.degree()) || (degree()==Int(other.degree()) && index()>=Int(other.index())); }
+
+    index_key& operator++() noexcept
+    {
+        ++m_data;
+        return *this;
+    }
+
+    friend std::size_t hash_value(const index_key& arg) noexcept
+    {
+        return arg.m_data;
+    }
+
+};
+
+template <int DegreeDigits, typename Int>
+std::ostream& operator<<(std::ostream& os, const index_key<DegreeDigits, Int>& arg) noexcept
+{
+    return os << "index_key(" << arg.degree() << ", " << arg.index() << ')';
+}
+
+
+namespace dtl {
+
+struct index_key_access
+{
+    template <int DegreeDigits, typename Int>
+    static constexpr Int raw(const index_key<DegreeDigits, Int>& arg) noexcept
+    { return arg.m_data; }
+
+    template <int DegreeDigits, typename Int>
+    static constexpr index_key<DegreeDigits, Int> from_raw(Int raw) noexcept
+    { return index_key<DegreeDigits, Int>(raw); }
+
+};
+
+} // namespace dtl
+
+
+} // namespace lal
+
+namespace std {
+
+template <int DegreeDigits, typename Int>
+struct hash<lal::index_key<DegreeDigits, Int>> {
+    constexpr size_t operator()(const lal::index_key<DegreeDigits, Int>& arg) const noexcept
+    { return size_t(lal::dtl::index_key_access::raw(arg)); }
+};
+
+}
+
+
+#endif //LIBALGEBRA_LITE_INDEX_KEY_H

--- a/vendored/libalgebra_lite/key_range.h
+++ b/vendored/libalgebra_lite/key_range.h
@@ -1,0 +1,39 @@
+//
+// Created by user on 08/08/22.
+//
+
+#ifndef LIBALGEBRA_LITE_KEY_RANGE_H
+#define LIBALGEBRA_LITE_KEY_RANGE_H
+
+#include "implementation_types.h"
+#include "basis_traits.h"
+
+namespace lal {
+
+template <typename Basis>
+class key_range
+{
+    using traits = basis_trait<Basis>;
+    using key_type = typename traits::key_type;
+
+    const Basis* p_basis;
+    const key_type start_key;
+    const key_type end_key;
+
+
+public:
+
+    key_range(const Basis* p_basis, key_type begin, key_type end);
+    key_range(const Basis* p_basis, std::pair<key_type, key_type> keys);
+
+    dimn_t begin_idx() const noexcept
+    { return traits::key_to_index(*p_basis, start_key); }
+    dimn_t end_idx() const noexcept
+    { return traits::key_to_index(*p_basis, end_key); }
+
+};
+
+} // namespace lal
+
+
+#endif //LIBALGEBRA_LITE_KEY_RANGE_H

--- a/vendored/libalgebra_lite/lie.h
+++ b/vendored/libalgebra_lite/lie.h
@@ -1,0 +1,81 @@
+//
+// Created by user on 12/08/22.
+//
+
+#ifndef LIBALGEBRA_LITE_LIE_H
+#define LIBALGEBRA_LITE_LIE_H
+
+#include "implementation_types.h"
+#include "libalgebra_lite_export.h"
+
+#include <mutex>
+#include <unordered_map>
+
+#include <boost/container/small_vector.hpp>
+#include <boost/functional/hash.hpp>
+
+#include "algebra.h"
+#include "hall_set.h"
+#include "registry.h"
+
+namespace lal {
+
+class lie_multiplier;
+
+LAL_EXPORT_TEMPLATE_CLASS(base_multiplier, lie_multiplier, hall_basis, 2)
+
+class LIBALGEBRA_LITE_EXPORT lie_multiplier
+    : public base_multiplier<lie_multiplier, hall_basis, 2>
+{
+    using base_type = base_multiplier<lie_multiplier, hall_basis, 2>;
+
+    deg_t m_width;
+
+    using typename base_type::key_type;
+    using typename base_type::product_type;
+    using typename base_type::reference;
+
+    using parent_type = std::pair<key_type, key_type>;
+
+    mutable std::unordered_map<
+            parent_type, product_type, boost::hash<parent_type>>
+            m_cache;
+    mutable std::recursive_mutex m_lock;
+
+    product_type
+    key_prod_impl(const hall_basis& basis, key_type lhs, key_type rhs) const;
+
+public:
+    using basis_type = hall_basis;
+
+    explicit lie_multiplier(deg_t width) : m_width(width) {}
+
+    reference
+    operator()(const hall_basis& basis, key_type lhs, key_type rhs) const;
+};
+
+struct LIBALGEBRA_LITE_EXPORT lie_multiplication
+    : public base_multiplication<lie_multiplier> {
+    using base = base_multiplication<lie_multiplier>;
+    using base::base;
+};
+
+template <
+        typename Coefficients, template <typename, typename> class VectorType,
+        template <typename> class StorageModel>
+using lie = algebra<
+        hall_basis, Coefficients, lie_multiplication, VectorType, StorageModel>;
+
+LAL_EXPORT_TEMPLATE_CLASS(multiplication_registry, lie_multiplication)
+
+template <typename LLie, typename RLie>
+inline LLie lie_multiply(const LLie& left, const RLie& right)
+{
+    const auto liem
+            = multiplication_registry<lie_multiplication>::get(left.basis());
+    return multiply(*liem, left, right);
+}
+
+}// namespace lal
+
+#endif// LIBALGEBRA_LITE_LIE_H

--- a/vendored/libalgebra_lite/maps.cpp
+++ b/vendored/libalgebra_lite/maps.cpp
@@ -1,0 +1,98 @@
+//
+// Created by user on 05/09/22.
+//
+
+#include "libalgebra_lite/maps.h"
+
+
+#include <mutex>
+#include <unordered_map>
+
+#include <boost/functional/hash.hpp>
+
+using namespace lal;
+
+maps::maps(basis_pointer<tensor_basis> tbasis, basis_pointer<hall_basis> lbasis)
+   : p_tensor_basis(std::move(tbasis)), p_lie_basis(std::move(lbasis)),
+   p_impl(new dtl::maps_implementation(p_tensor_basis, p_lie_basis))
+{
+
+}
+
+maps::~maps() {
+    delete p_impl;
+}
+
+dtl::generic_commutator::tensor_type dtl::generic_commutator::operator()(
+        ref_type lhs,
+        ref_type rhs) const
+{
+    std::map<key_type, int> tmp;
+
+    for (const auto& lhs_val : lhs) {
+        for (const auto& rhs_val : rhs) {
+            for (const auto& inner : m_mul.multiply(m_basis, lhs_val.first, rhs_val.first)) {
+                tmp[inner.first] += inner.second*lhs_val.second*rhs_val.second;
+            }
+            for (const auto& inner : m_mul.multiply(m_basis, rhs_val.first, lhs_val.first)) {
+                tmp[inner.first] -= inner.second*rhs_val.second*lhs_val.second;
+            }
+        }
+    }
+    return {tmp.begin(), tmp.end()};
+}
+
+typename dtl::maps_implementation::generic_tensor dtl::maps_implementation::expand_letter(let_t letter)
+{
+    return {{ tkey_type(1, letter-1), 1 }};
+}
+typename dtl::maps_implementation::glie_ref dtl::maps_implementation::rbracketing(
+        dtl::maps_implementation::tkey_type tkey) const
+{
+    static const boost::container::small_vector<std::pair<tkey_type, int>, 0> null;
+
+    if (tkey.degree()==0) {
+        return null;
+    }
+
+    std::lock_guard<std::recursive_mutex> access(m_rbracketing_lock);
+
+    auto& found = m_rbracketing_cache[tkey];
+    if (found.set) {
+        return found.value;
+    }
+
+    found.set = true;
+    if (p_tensor_basis->letter(tkey)) {
+        found.value.emplace_back(lkey_type(1, tkey.index()), 1);
+        return found.value;
+    }
+
+    auto lhs = p_tensor_basis->lparent(tkey);
+    auto rhs = p_tensor_basis->rparent(tkey);
+
+    return found.value = p_lie_mul->multiply_generic(*p_lie_basis, rbracketing(lhs), rbracketing(rhs));
+}
+typename dtl::maps_implementation::gtensor_ref dtl::maps_implementation::expand(
+        dtl::maps_implementation::lkey_type lkey) const
+{
+    return m_expand(lkey);
+}
+
+maps::maps(deg_t width, deg_t depth)
+    : p_tensor_basis(basis_registry<tensor_basis>::get(width, depth)),
+      p_lie_basis(basis_registry<hall_basis>::get(width, depth))
+{
+    static std::mutex lock;
+    static std::unordered_map<std::pair<deg_t, deg_t>, std::unique_ptr<const dtl::maps_implementation>,
+                              boost::hash<std::pair<deg_t, deg_t>>> cache;
+
+    std::lock_guard<std::mutex> access(lock);
+    auto& found = cache[{width, depth}];
+    if (found) {
+        p_impl = found.get();
+    }
+
+    found = std::make_unique<const dtl::maps_implementation>(p_tensor_basis, p_lie_basis);
+    p_impl = found.get();
+}

--- a/vendored/libalgebra_lite/maps.h
+++ b/vendored/libalgebra_lite/maps.h
@@ -1,0 +1,226 @@
+//
+// Created by user on 12/08/22.
+//
+
+#ifndef LIBALGEBRA_LITE_MAPS_H
+#define LIBALGEBRA_LITE_MAPS_H
+
+#include "implementation_types.h"
+#include "libalgebra_lite_export.h"
+
+#include <boost/container/small_vector.hpp>
+
+#include "free_tensor.h"
+#include "lie.h"
+#include "tensor_basis.h"
+
+namespace lal {
+
+namespace dtl {
+
+class generic_commutator
+{
+    const tensor_basis& m_basis;
+    const free_tensor_multiplication& m_mul;
+
+public:
+    using key_type = typename tensor_basis::key_type;
+    using pair_type = std::pair<key_type, int>;
+    using tensor_type = boost::container::small_vector<pair_type, 1>;
+    using ref_type = const boost::container::small_vector_base<pair_type>&;
+
+    generic_commutator(
+            const tensor_basis& basis, const free_tensor_multiplication& mul
+    )
+        : m_basis(basis), m_mul(mul)
+    {}
+
+    tensor_type operator()(ref_type lhs, ref_type rhs) const;
+};
+
+struct rbracketing_cache_item {
+    using key_type = typename tensor_basis::key_type;
+    boost::container::small_vector<std::pair<key_type, int>, 1> value;
+    bool set = false;
+};
+
+class LIBALGEBRA_LITE_EXPORT maps_implementation
+{
+    const tensor_basis* p_tensor_basis;
+    const hall_basis* p_lie_basis;
+    std::shared_ptr<const lie_multiplication> p_lie_mul;
+    std::shared_ptr<const free_tensor_multiplication> p_ftensor_mul;
+
+public:
+    using lkey_type = typename hall_basis::key_type;
+    using tkey_type = typename tensor_basis::key_type;
+    using generic_scalar_type = int;
+
+    using lie_pair = std::pair<lkey_type, generic_scalar_type>;
+    using tensor_pair = std::pair<tkey_type, generic_scalar_type>;
+    using generic_lie = boost::container::small_vector<lie_pair, 1>;
+    using generic_tensor = boost::container::small_vector<tensor_pair, 1>;
+
+    using gtensor_ref = const boost::container::small_vector_base<tensor_pair>&;
+    using glie_ref = const boost::container::small_vector_base<lie_pair>&;
+
+private:
+    static generic_tensor expand_letter(let_t letter);
+
+    hall_extension<decltype(&expand_letter), generic_commutator, gtensor_ref>
+            m_expand;
+
+    mutable std::unordered_map<tkey_type, dtl::rbracketing_cache_item>
+            m_rbracketing_cache;
+    mutable std::recursive_mutex m_rbracketing_lock;
+
+public:
+    maps_implementation(const tensor_basis* tbasis, const hall_basis* lbasis)
+        : p_tensor_basis(tbasis), p_lie_basis(lbasis),
+          p_lie_mul(multiplication_registry<lie_multiplication>::get(
+                  lbasis->width()
+          )),
+          p_ftensor_mul(
+                  multiplication_registry<free_tensor_multiplication>::get(
+                          tbasis->width()
+                  )
+          ),
+          m_expand(
+                  p_lie_basis->get_hall_set(), &expand_letter,
+                  generic_commutator(*p_tensor_basis, *p_ftensor_mul)
+          )
+    {}
+
+    glie_ref rbracketing(tkey_type tkey) const;
+    gtensor_ref expand(lkey_type lkey) const;
+};
+
+}// namespace dtl
+
+class LIBALGEBRA_LITE_EXPORT maps
+{
+    basis_pointer<tensor_basis> p_tensor_basis;
+    basis_pointer<hall_basis> p_lie_basis;
+    const dtl::maps_implementation* p_impl;
+
+public:
+    using tkey_type = typename tensor_basis::key_type;
+    using lkey_type = typename hall_basis::key_type;
+    using generic_scalar_type =
+            typename dtl::maps_implementation::generic_scalar_type;
+    using generic_lie = typename dtl::maps_implementation::generic_lie;
+    using generic_tensor = typename dtl::maps_implementation::generic_tensor;
+    using glie_ref = typename dtl::maps_implementation::glie_ref;
+    using gtensor_ref = typename dtl::maps_implementation::gtensor_ref;
+
+    maps(basis_pointer<tensor_basis> tbasis, basis_pointer<hall_basis> lbasis);
+    maps(deg_t width, deg_t depth);
+    ~maps();
+
+    glie_ref rbracketing(tkey_type tkey) const
+    {
+        return p_impl->rbracketing(tkey);
+    }
+    gtensor_ref expand(lkey_type lkey) const { return p_impl->expand(lkey); }
+
+    template <
+            typename Coefficients,
+            template <typename, typename> class VectorType,
+            template <typename> class StorageModel>
+    free_tensor<Coefficients, VectorType, StorageModel>
+    lie_to_tensor(const lie<Coefficients, VectorType, StorageModel>& arg) const
+    {
+        using scalar_type =
+                typename coefficient_trait<Coefficients>::scalar_type;
+        if (arg.basis().width() != p_lie_basis->width()) {
+            throw std::invalid_argument("mismatched width");
+        }
+
+        auto max_deg = p_lie_basis->depth();
+        free_tensor<Coefficients, VectorType, StorageModel> result(
+                p_tensor_basis
+        );
+        if (arg.basis().depth() <= max_deg) {
+            for (auto outer : arg) {
+                auto val = outer.value();
+                for (auto inner : expand(outer.key())) {
+                    assert(inner.first.degree() == outer.key().degree());
+                    result.add_scal_prod(
+                            inner.first, scalar_type(inner.second) * val
+                    );
+                }
+            }
+        } else {
+            for (auto outer : arg) {
+                auto key = outer.key();
+                auto val = outer.value();
+                if (p_lie_basis->degree(key) <= max_deg) {
+                    for (auto inner : expand(key)) {
+                        assert(outer.key().degree() == inner.first.degree());
+                        result.add_scal_prod(
+                                inner.first, scalar_type(inner.second) * val
+                        );
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    template <
+            typename Coefficients,
+            template <typename, typename> class VectorType,
+            template <typename> class StorageModel>
+    lie<Coefficients, VectorType, StorageModel>
+    tensor_to_lie(const free_tensor<Coefficients, VectorType, StorageModel>& arg
+    ) const
+    {
+        using scalar_type = typename Coefficients::scalar_type;
+        using rational_type = typename Coefficients::rational_type;
+
+        if (arg.basis().width() != p_tensor_basis->width()) {
+            throw std::invalid_argument("mismatched width");
+        }
+        auto max_deg = p_tensor_basis->depth();
+
+        lie<Coefficients, VectorType, StorageModel> result(p_lie_basis);
+
+        if (arg.basis().depth() <= max_deg) {
+            for (auto&& outer : arg) {
+                auto key = outer.key();
+                auto deg = key.degree();
+                if (deg > 0) {
+                    auto val = outer.value() / rational_type(deg);
+                    for (auto inner : rbracketing(key)) {
+                        assert(inner.first.degree() == deg);
+                        result.add_scal_prod(
+                                inner.first, scalar_type(inner.second) * val
+                        );
+                    }
+                }
+            }
+        } else {
+            for (auto outer : arg) {
+                auto key = outer.key();
+                auto deg = static_cast<deg_t>(key.degree());
+                if (deg > 0) {
+                    auto val = outer.value() / deg;
+                    if (deg <= max_deg) {
+                        for (auto inner : rbracketing(key)) {
+                            assert(inner.first.degree()
+                                   == static_cast<dimn_t>(deg));
+                            result.add_scal_prod(
+                                    inner.first, scalar_type(inner.second) * val
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        return result;
+    }
+};
+
+}// namespace lal
+
+#endif// LIBALGEBRA_LITE_MAPS_H

--- a/vendored/libalgebra_lite/operators.h
+++ b/vendored/libalgebra_lite/operators.h
@@ -1,0 +1,294 @@
+//
+// Created by user on 06/02/23.
+//
+
+#ifndef LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_OPERATORS_H
+#define LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_OPERATORS_H
+
+#include "implementation_types.h"
+
+#include <utility>
+#include <type_traits>
+#include <tuple>
+
+#include "vector.h"
+
+namespace lal {
+
+namespace dtl {
+template <typename T> struct is_vector;
+}
+
+namespace operators {
+
+#define LAL_LO_DECLRESULT(IMPL) \
+    decltype(std::declval<IMPL>()(std::declval<const ArgumentType&>()))
+
+namespace dtl {
+
+template <typename Impl1, typename Impl2>
+class sum_operator;
+
+
+template <typename Impl, typename Multiplier>
+class scalar_multiply_operator;
+
+template <typename Scalar>
+class left_scalar_multiply;
+
+template <typename Scalar>
+class right_scalar_multiply;
+
+
+template <typename... Impl>
+class composition_operator;
+
+template <typename Operator>
+struct operator_traits;
+
+
+} // namespace dtl
+
+
+template <typename Impl>
+class linear_operator : protected Impl
+{
+    using traits = dtl::operator_traits<Impl>;
+public:
+    using scalar_type = typename traits::scalar_type;
+
+protected:
+    using implementation_type = Impl;
+
+public:
+
+    template <typename... Args>
+    explicit linear_operator(Args&&... args) : Impl(std::forward<Args>(args)...)
+    {}
+
+    using implementation_type::operator();
+
+
+    template <typename Impl2>
+    friend linear_operator<dtl::sum_operator<Impl, Impl2>>
+    operator+(const linear_operator& left,
+              const linear_operator<Impl2>& right)
+    {
+        // Sum passes on the implementation to the sum operator
+        return { static_cast<const Impl&>(left), static_cast<const Impl2&>(right) };
+    }
+
+    template <typename Scalar>
+    friend linear_operator<dtl::scalar_multiply_operator<Impl, dtl::left_scalar_multiply<scalar_type>>>
+    operator*(const Scalar& scalar, const linear_operator& op)
+    {
+        return { static_cast<const Impl&>(op), scalar_type(scalar) };
+    }
+
+    template <typename Scalar>
+    friend linear_operator<dtl::scalar_multiply_operator<Impl, dtl::right_scalar_multiply<scalar_type>>>
+    operator*(const linear_operator& op, const Scalar& scalar)
+    {
+        return { static_cast<const Impl&>(op), scalar_type(scalar) };
+    }
+
+
+    template <typename... Impls>
+    std::enable_if_t<(sizeof...(Impls) > 1), linear_operator<dtl::composition_operator<Impls...>>>
+    compose(const linear_operator<Impls>&... operators)
+    {
+        return { static_cast<Impls>(operators)... };
+    }
+
+};
+
+
+
+
+namespace dtl {
+
+template <typename Impl1, typename Impl2>
+class sum_operator
+{
+    Impl1 m_left;
+    Impl2 m_right;
+
+    template <typename LeftType, typename RightType>
+    static LeftType add_results(LeftType&& left, RightType&& right) {
+        for (auto rit : right) {
+            left.add_scal_prod(rit.key(), rit.value());
+        }
+        return left;
+    }
+
+    template <typename Type>
+    static Type add_results(Type&& left, Type&& right) {
+        left += right;
+        return left;
+    }
+
+public:
+
+    sum_operator(const Impl1& left, const Impl2& right)
+        : m_left(left), m_right(right)
+    {}
+
+    sum_operator(Impl1&& left, Impl2&& right)
+        : m_left(std::move(left)), m_right(std::move(right))
+    {}
+
+    template <typename Argument>
+    auto operator()(const Argument &arg) const -> decltype(add_results(m_left(arg), m_right(arg)))
+    {
+        return add_results(m_left(arg), m_right(arg));
+    }
+
+};
+
+template <typename Scalar>
+class left_scalar_multiply {
+    Scalar m_scalar;
+
+public:
+
+    using scalar_type = Scalar;
+
+    explicit left_scalar_multiply(Scalar&& scal) : m_scalar(std::move(scal))
+    {}
+
+    template <typename Vector>
+    Vector multiply(Vector&& arg) const
+    {
+        return m_scalar * arg;
+    }
+
+};
+
+
+template <typename Scalar>
+class right_scalar_multiply {
+    Scalar m_scalar;
+
+public:
+
+    using scalar_type = Scalar;
+
+    explicit right_scalar_multiply(Scalar&& scal) : m_scalar(std::move(scal))
+    {}
+
+    template <typename Vector>
+    Vector multiply(Vector&& arg) const
+    {
+        arg *= m_scalar;
+        return arg;
+    }
+
+};
+
+
+template <typename Impl, typename Multiplier>
+class scalar_multiply_operator : private Multiplier
+{
+    Impl m_operator;
+
+public:
+
+    explicit scalar_multiply_operator(const Impl& op, const typename Multiplier::scalar_type& s)
+        : Multiplier(s), m_operator(op)
+    {}
+
+    explicit scalar_multiply_operator(Impl&& op, typename Multiplier::scalar_type&& s)
+        : Multiplier(std::move(s)), m_operator(std::move(op))
+    {}
+
+    template <typename Argument>
+    auto operator()(const Argument& arg) const -> decltype(m_operator(arg))
+    {
+        return Multiplier::multiply(m_operator(arg));
+    }
+
+};
+
+template <std::size_t I, typename Argument, typename... Impl>
+static constexpr auto eval_recursive(const Argument &arg, const std::tuple<Impl...>& ops)
+        -> decltype(std::get<I>(ops)(arg)) {
+    return eval_recursive<I+1>(std::get<I>(ops)(arg), ops);
+}
+
+
+template <typename Argument, typename... Impl>
+static constexpr auto eval_recursive<sizeof...(Impl)-1, Argument, Impl...>(
+    const Argument &arg, const std::tuple<Impl...>& ops)
+        -> decltype(std::get<sizeof...(Impl)-1>(ops)(arg)) {
+    return std::get<sizeof...(Impl)-1>(ops)(arg), ops);
+}
+
+
+
+template <typename... Impl>
+class composition_operator
+{
+    static_assert(sizeof...(Impl) > 1, "composition of a single operator is not allowed");
+
+    using operator_tuple = std::tuple<Impl...>;
+    std::tuple<Impl...> m_operators;
+
+    template <std::size_t I>
+    struct eval_recursive
+    {
+        using next = eval_recursive<I+1>;
+
+        template <typename Arg>
+        constexpr auto eval(const Arg& arg, const operator_tuple& ops)
+            -> decltype(std::get<I>(ops)(next::eval(arg, ops)))
+        {
+            return std::get<I>(ops)(next::eval(arg, ops));
+        }
+    };
+
+    template <>
+    struct eval_recursive<sizeof...(Impl)>
+    {
+        template <typename Arg>
+        constexpr const Arg& eval(const Arg& arg, const operator_tuple& ops)
+        {
+            return arg;
+        }
+    };
+
+    using evaluator = eval_recursive<0>;
+
+
+public:
+
+    composition_operator(const Impl&... impls) : m_operators(impls...)
+    {}
+
+    composition_operator(Impl&&... impls) : m_operators(std::forward<Impl>(impls)...)
+    {}
+
+    template <typename Argument>
+    auto operator()(const Argument& arg) const -> decltype(evaluator::eval(arg, m_operators))
+    {
+        return evaluator::eval(arg, m_operators);
+    }
+
+};
+
+
+
+
+} // namespace dtl
+
+
+#undef LAL_LO_DECLRESULT
+
+
+
+
+
+} // namespace operators
+} // namespace lal
+
+
+#endif //LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_OPERATORS_H

--- a/vendored/libalgebra_lite/packed_integer.h
+++ b/vendored/libalgebra_lite/packed_integer.h
@@ -1,0 +1,266 @@
+//
+// Created by user on 13/08/22.
+//
+
+#ifndef LIBALGEBRA_LITE_PACKED_INTEGER_H
+#define LIBALGEBRA_LITE_PACKED_INTEGER_H
+
+#include <limits>
+#include <type_traits>
+#include <ostream>
+
+namespace lal {
+namespace dtl {
+
+
+template <typename PacktedInt, typename RefType>
+class packed_integer_ref;
+
+
+
+template<typename Int, typename Packed>
+class packed_integer
+{
+    static_assert(sizeof(Int) > sizeof(Packed),
+            "Integral type must contain more bits than packed type");
+
+    Int m_data;
+
+    static constexpr int remaining_bits = 8*(sizeof(Int)-sizeof(Packed));
+    static constexpr Int integral_mask = (Int(1) << remaining_bits) - Int(1);
+    static constexpr Int packed_mask = ~integral_mask;
+
+    friend class packed_integer_ref<packed_integer, Int>;
+    friend class packed_integer_ref<packed_integer, const Int>;
+    friend class packed_integer_ref<packed_integer, Packed>;
+    friend class packed_integer_ref<packed_integer, const Packed>;
+
+
+    using integer_ref = packed_integer_ref<packed_integer, Int>;
+    using const_integer_ref = packed_integer_ref<packed_integer, const Int>;
+    using packed_ref = packed_integer_ref<packed_integer, Packed>;
+    using const_packed_ref = packed_integer_ref<packed_integer, const Packed>;
+
+#ifdef LAL_TESTING
+    friend struct packed_integer_access;
+#endif
+
+public:
+
+    using integral_type = Int;
+    using packed_type = Packed;
+
+    explicit constexpr packed_integer(Int val) : m_data(val & integral_mask)
+    {}
+
+    explicit constexpr packed_integer(Packed packed)
+        : m_data(static_cast<Int>(packed)<<remaining_bits)
+    {}
+
+    constexpr packed_integer(Packed packed, Int val)
+        : m_data((static_cast<Int>(packed)<<remaining_bits) + (val & integral_mask))
+    {}
+
+    constexpr explicit operator Int() const noexcept
+    {
+        return m_data & integral_mask;
+    }
+    constexpr explicit operator Packed() const noexcept
+    {
+        return (m_data & packed_mask) >> remaining_bits;
+    }
+
+    operator integer_ref() noexcept // NOLINT(google-explicit-constructor)
+    {
+        return integer_ref(m_data);
+    }
+
+    operator packed_ref() noexcept // NOLINT(google-explicit-constructor)
+    {
+        return packed_ref(m_data);
+    }
+
+    constexpr bool operator==(const packed_integer& arg) const noexcept
+    { return m_data == arg.m_data; }
+    constexpr bool operator!=(const packed_integer& arg) const noexcept
+    { return m_data != arg.m_data; }
+    constexpr bool operator<(const packed_integer& arg) const noexcept
+    { return m_data < arg.m_data; }
+    constexpr bool operator<=(const packed_integer& arg) const noexcept
+    { return m_data <= arg.m_data; }
+    constexpr bool operator>(const packed_integer& arg) const noexcept
+    { return m_data > arg.m_data; }
+    constexpr bool operator>=(const packed_integer& arg) const noexcept
+    { return m_data >= arg.m_data; }
+
+    friend std::size_t hash_value(const packed_integer& value) noexcept {
+        std::hash<Int> hasher;
+        return hasher(value.m_data);
+    }
+
+};
+
+
+template <typename Int, typename Packed>
+std::ostream& operator<<(std::ostream& os, const packed_integer<Int, Packed>& arg) noexcept
+{
+    return os << Packed(arg) << Int(arg);
+}
+
+
+template <typename S, typename T>
+struct copy_constness
+{
+    using type = T;
+};
+
+template <typename S, typename T>
+struct copy_constness<const S, T>
+{
+    using type = const T;
+};
+
+template <typename S, typename T>
+using copy_constness_t = typename copy_constness<S, T>::type;
+
+
+#define LAL_ASSERT_NOT_CONST   \
+    static_assert(!std::is_const<RefType>::value, \
+        "Reference type must not be const")
+
+template <typename PackedInteger, typename RefType>
+class packed_integer_ref {
+
+    using main_ref_t = copy_constness_t<RefType, typename PackedInteger::integral_type>&;
+    main_ref_t m_ref;
+    RefType m_dummy;
+
+    static constexpr RefType make_dummy(main_ref_t ref) noexcept
+    {
+        return (std::is_same<
+                std::remove_cv_t<RefType>,
+                typename PackedInteger::packed_type
+        >::value)
+               ? RefType((ref & PackedInteger::packed_mask) >> PackedInteger::remaining_bits)
+               : RefType(ref & PackedInteger::integral_mask);
+
+    }
+
+    bool updated_referenced(std::add_lvalue_reference_t<std::add_const_t<RefType>> arg)
+    {
+        using trait = std::is_same<std::remove_cv_t<RefType>,
+                typename PackedInteger::packed_type>;
+        auto old = make_dummy(m_ref);
+        auto change = arg - old;
+        m_ref += ((trait::value) ? (change << PackedInteger::remaining_bits)
+                                 : change);
+        return change != 0;
+    }
+
+public:
+
+    explicit packed_integer_ref(main_ref_t data)
+            :m_ref(data), m_dummy(make_dummy(data)) { }
+
+    operator std::add_lvalue_reference_t<std::add_const_t<RefType>>() const noexcept
+    {
+        return m_dummy;
+    }
+
+    packed_integer_ref& operator=(std::add_lvalue_reference_t<std::add_const_t<RefType>> arg) noexcept
+    {
+        LAL_ASSERT_NOT_CONST;
+        if (updated_referenced(arg)) {
+            m_dummy = arg;
+        }
+        return *this;
+    }
+
+    packed_integer_ref& operator=(std::add_rvalue_reference_t<std::remove_cv_t<RefType>> arg) noexcept
+    {
+        LAL_ASSERT_NOT_CONST;
+        if (updated_referenced(arg)) {
+            m_dummy = arg;
+        }
+        return *this;
+    }
+
+    template <typename Int>
+    packed_integer_ref& operator=(Int arg) noexcept
+    {
+        LAL_ASSERT_NOT_CONST;
+        if (updated_referenced(RefType(arg))) {
+            m_dummy = arg;
+        }
+        return *this;
+    }
+
+    packed_integer_ref& operator++() noexcept
+    {
+        LAL_ASSERT_NOT_CONST;
+        if (updated_referenced(m_dummy+1)) {
+            ++m_dummy;
+        }
+        return *this;
+    }
+
+    packed_integer_ref& operator--() noexcept
+    {
+        LAL_ASSERT_NOT_CONST;
+        if (updated_referenced(m_dummy-1)) {
+            --m_dummy;
+        }
+        return *this;
+    }
+
+    template <typename Int>
+    packed_integer_ref& operator+=(Int arg) noexcept
+    {
+        LAL_ASSERT_NOT_CONST;
+        if (updated_referenced(m_dummy+arg)) {
+            m_dummy += arg;
+        }
+        return *this;
+    }
+
+    template <typename Int>
+    packed_integer_ref& operator-=(Int arg) noexcept
+    {
+        LAL_ASSERT_NOT_CONST;
+        if (updated_referenced(m_dummy-arg)) {
+            m_dummy -= arg;
+        }
+        return *this;
+    }
+
+    template <typename Int>
+    packed_integer_ref& operator*=(Int arg) noexcept
+    {
+        LAL_ASSERT_NOT_CONST;
+        if (updated_referenced(m_dummy*arg)) {
+            m_dummy *= arg;
+        }
+        return *this;
+    }
+
+
+    template <typename Int>
+    packed_integer_ref& operator/=(Int arg) noexcept
+    {
+        LAL_ASSERT_NOT_CONST;
+        if (updated_referenced(m_dummy/arg)) {
+            m_dummy /= arg;
+        }
+        return *this;
+    }
+
+};
+
+#undef LAL_ASSERT_NOT_CONST
+
+
+} // namespace dtl
+} // namespace alg
+
+
+#endif //LIBALGEBRA_LITE_PACKED_INTEGER_H

--- a/vendored/libalgebra_lite/polynomial.h
+++ b/vendored/libalgebra_lite/polynomial.h
@@ -1,0 +1,160 @@
+//
+// Created by user on 30/08/22.
+//
+
+#ifndef LIBALGEBRA_LITE_POLYNOMIAL_H
+#define LIBALGEBRA_LITE_POLYNOMIAL_H
+
+#include "implementation_types.h"
+#include "libalgebra_lite_export.h"
+
+#include <boost/container/small_vector.hpp>
+
+#include "algebra.h"
+#include "coefficients.h"
+#include "polynomial_basis.h"
+#include "registry.h"
+#include "sparse_vector.h"
+
+namespace lal {
+
+class LIBALGEBRA_LITE_EXPORT polynomial_multiplier
+{
+    using letter_type = typename polynomial_basis::letter_type;
+    using key_type = typename polynomial_basis::key_type;
+
+    using product_type
+            = boost::container::small_vector<std::pair<key_type, int>, 1>;
+
+public:
+    using basis_type = polynomial_basis;
+
+    product_type operator()(
+            const polynomial_basis& basis, const key_type& lhs,
+            const key_type& rhs
+    ) const;
+};
+
+template <>
+class LIBALGEBRA_LITE_EXPORT
+        multiplication_registry<base_multiplication<polynomial_multiplier>>
+{
+    using multiplication = base_multiplication<polynomial_multiplier>;
+
+public:
+    static std::shared_ptr<const multiplication> get();
+    template <typename Basis>
+    static std::shared_ptr<const multiplication> get(const Basis&)
+    {
+        return get();
+    }
+};
+
+template <typename Coefficients>
+class polynomial : public algebra<
+                           polynomial_basis, Coefficients,
+                           base_multiplication<polynomial_multiplier>,
+                           sparse_vector, dtl::standard_storage>
+{
+    using base = algebra<
+            polynomial_basis, Coefficients,
+            base_multiplication<polynomial_multiplier>, sparse_vector,
+            dtl::standard_storage>;
+
+public:
+    using multiplication_type = base_multiplication<polynomial_multiplier>;
+    using base::base;
+
+    polynomial() : base(basis_registry<polynomial_basis>::get()) {}
+
+    template <typename Scalar>
+    explicit polynomial(Scalar s)
+        : base(basis_registry<polynomial_basis>::get(),
+               multiplication_registry<multiplication_type>::get(), monomial(),
+               typename base::scalar_type(s))
+    {}
+
+    template <typename Key, typename Scalar>
+    explicit polynomial(Key k, Scalar s)
+        : base(basis_registry<polynomial_basis>::get(),
+               multiplication_registry<multiplication_type>::get())
+    {
+        (*this)[typename base::key_type(k)] = typename base::scalar_type(s);
+    }
+
+    template <typename IndeterminateMap>
+    typename polynomial::scalar_type operator()(const IndeterminateMap& arg
+    ) const noexcept
+    {
+        using ring = typename polynomial::coefficient_ring;
+        auto ans = ring::zero();
+        for (const auto& item : *this) {
+            auto key_result = item.first.template eval<ring>(arg);
+            ring::add_inplace(ans, ring::mul(item.second, key_result));
+        }
+        return ans;
+    }
+};
+
+LAL_EXPORT_TEMPLATE_CLASS(polynomial, double_field)
+LAL_EXPORT_TEMPLATE_CLASS(polynomial, float_field)
+using double_poly = polynomial<double_field>;
+using float_poly = polynomial<float_field>;
+
+#ifdef LAL_ENABLE_RATIONAL_COEFFS
+LAL_EXPORT_TEMPLATE_CLASS(polynomial, rational_field)
+using rational_poly = polynomial<rational_field>;
+#endif
+
+
+
+
+template <typename Field>
+struct coefficient_ring<polynomial<Field>, typename Field::rational_type>
+{
+    using scalar_type = polynomial<Field>;
+    using rational_type = typename Field::rational_type;
+
+    static const scalar_type& zero() noexcept
+    {
+        static const scalar_type zero;
+        return zero;
+    }
+    static const scalar_type& one() noexcept
+    {
+        static const scalar_type one(1);
+        return one;
+    }
+    static const scalar_type& mone() noexcept
+    {
+        static const scalar_type mone(-1);
+        return mone;
+    }
+
+    static inline bool is_invertible(const scalar_type& arg) {
+        return arg.size() == 1
+                && arg.degree() == 0
+                && Field::is_invertible(arg.begin()->value());
+    }
+    static constexpr const rational_type& as_rational(const scalar_type& arg)
+            noexcept {
+        return Field::as_rational(arg.begin()->value());
+    }
+
+};
+
+LAL_EXPORT_TEMPLATE_STRUCT(coefficient_ring, double_poly, double)
+LAL_EXPORT_TEMPLATE_STRUCT(coefficient_ring, float_poly, float)
+
+#ifdef LAL_ENABLE_RATIONAL_COEFFS
+LAL_EXPORT_TEMPLATE_STRUCT(
+        coefficient_ring, rational_poly, typename rational_field::scalar_type
+)
+
+using polynomial_ring = coefficient_ring<
+        polynomial<rational_field>, typename rational_field::scalar_type>;
+#endif
+
+}// namespace lal
+
+#endif// LIBALGEBRA_LITE_POLYNOMIAL_H

--- a/vendored/libalgebra_lite/polynomial_basis.h
+++ b/vendored/libalgebra_lite/polynomial_basis.h
@@ -1,0 +1,154 @@
+//
+// Created by user on 28/08/22.
+//
+
+#ifndef LIBALGEBRA_LITE_POLYNOMIAL_BASIS_H
+#define LIBALGEBRA_LITE_POLYNOMIAL_BASIS_H
+
+#include "implementation_types.h"
+
+#include <functional>
+#include <numeric>
+#include <iosfwd>
+
+#include <boost/container/small_vector.hpp>
+#include <boost/container/flat_map.hpp>
+#include <boost/container_hash/hash.hpp>
+
+#include "libalgebra_lite_export.h"
+#include "packed_integer.h"
+#include "registry.h"
+
+namespace lal {
+
+
+class LIBALGEBRA_LITE_EXPORT monomial
+{
+public:
+    using letter_type = dtl::packed_integer<dimn_t, char>;
+
+private:
+    using small_vec = boost::container::small_vector<std::pair<letter_type, deg_t>, 1>;
+    using map_type = boost::container::flat_map<letter_type, deg_t, std::less<>, small_vec>;
+//    using map_type = std::map<letter_type, deg_t>;
+
+    map_type m_data;
+
+    template <typename Coeff>
+    static typename Coeff::scalar_type
+    power(typename Coeff::scalar_type arg, deg_t exponent) noexcept
+    {
+        if (exponent == 0) {
+            return Coeff::one();
+        }
+        if (exponent == 1) {
+            return arg;
+        }
+        auto result1 = power<Coeff>(arg, exponent/2);
+        auto result2 = Coeff::mul(result1, result1);
+        return (exponent % 2==0) ? result2 : Coeff::mul(arg, result2);
+    }
+
+public:
+
+    using iterator = typename map_type::iterator;
+    using const_iterator = typename map_type::const_iterator;
+
+    monomial() : m_data() {}
+
+    explicit monomial(letter_type let, deg_t power=1)
+    {
+        assert(power > 0);
+        m_data[let] = power;
+    }
+
+    template <typename MapType>
+    explicit monomial(const MapType& arg) : m_data(arg.begin(), arg.end())
+    {}
+
+    template <typename InputIt>
+    explicit monomial(InputIt begin, InputIt end) : m_data(begin, end)
+    {}
+
+    deg_t degree() const noexcept;
+    deg_t type() const noexcept { return m_data.size(); }
+
+    deg_t operator[](letter_type let) const noexcept;
+    deg_t& operator[](letter_type let) noexcept { return m_data[let]; }
+
+    iterator begin() noexcept { return m_data.begin(); }
+    iterator end() noexcept { return m_data.end(); }
+    const_iterator begin() const noexcept { return m_data.begin(); }
+    const_iterator end() const noexcept { return m_data.end(); }
+
+    template <typename Coefficients, typename MapType>
+    typename Coefficients::scalar_type eval(const MapType& arg) const noexcept
+    {
+        auto result = Coefficients::zero();
+
+        for (const auto& item : m_data) {
+            Coefficients::add_inplace(result,
+                    power<Coefficients>(arg[item.first], item.second));
+        }
+        return result;
+    }
+
+    bool operator==(const monomial& other) const noexcept
+    {
+        return degree() == other.degree() && m_data == other.m_data;
+    }
+
+    bool operator<(const monomial& other) const noexcept
+    {
+        auto ldegree = degree();
+        auto rdegree = other.degree();
+        return (ldegree < rdegree) || (ldegree == rdegree && (m_data < other.m_data));
+    }
+
+    monomial& operator*=(const monomial& rhs);
+
+    friend std::size_t hash_value(const monomial& mon) noexcept
+    {
+        boost::hash<map_type> hasher;
+        return hasher(mon.m_data);
+    }
+
+};
+
+LIBALGEBRA_LITE_EXPORT std::ostream& operator<<(std::ostream& os, const monomial& arg);
+
+LIBALGEBRA_LITE_EXPORT monomial operator*(const monomial& lhs, const monomial& rhs);
+
+struct LIBALGEBRA_LITE_EXPORT polynomial_basis
+{
+    using letter_type = dtl::packed_integer<dimn_t, char>;
+    using key_type = monomial;
+
+    static key_type key_of_letter(letter_type letter)
+    {
+        return key_type(letter);
+    }
+
+    static deg_t degree(const key_type& key)
+    {
+        return key.degree();
+    }
+
+    std::ostream& print_key(std::ostream& os, const key_type& key) const;
+
+};
+
+
+template <>
+class LIBALGEBRA_LITE_EXPORT basis_registry<polynomial_basis>
+{
+public:
+
+    static basis_pointer<polynomial_basis> get();
+    static basis_pointer<polynomial_basis> get(const polynomial_basis&) { return get(); }
+
+};
+
+} // namespace lal
+
+#endif //LIBALGEBRA_LITE_POLYNOMIAL_BASIS_H

--- a/vendored/libalgebra_lite/registry.h
+++ b/vendored/libalgebra_lite/registry.h
@@ -1,0 +1,104 @@
+//
+// Created by user on 05/09/22.
+//
+
+#ifndef LIBALGEBRA_LITE_REGISTRY_H
+#define LIBALGEBRA_LITE_REGISTRY_H
+
+#include "implementation_types.h"
+#include "libalgebra_lite_export.h"
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+
+#include <boost/functional/hash.hpp>
+
+#include "basis.h"
+
+namespace lal {
+
+template <typename Basis>
+class basis_registry {
+    using basis_pointer = lal::basis_pointer<Basis>;
+    static std::mutex m_lock;
+    static std::unordered_map<std::pair<deg_t, deg_t>,
+                              std::unique_ptr<const Basis>, boost::hash<std::pair<deg_t, deg_t>>> m_cache;
+
+public:
+
+    /*
+     * Most of the basis types require a width and depth pair
+     */
+
+    static basis_pointer get(deg_t width, deg_t depth);
+
+};
+
+template <typename Basis>
+std::mutex basis_registry<Basis>::m_lock;
+
+template <typename Basis>
+std::unordered_map<std::pair<deg_t, deg_t>, std::unique_ptr<const Basis>,
+                   boost::hash<std::pair<deg_t, deg_t>>>
+    basis_registry<Basis>::m_cache;
+
+template <typename Multiplication>
+class multiplication_registry {
+    static std::mutex m_lock;
+    static std::unordered_map<deg_t, std::shared_ptr<const Multiplication>> m_cache;
+
+public:
+
+    /*
+     * Most of the multiplication classes take width as their only
+     * parameter, which is really only there to help validate the
+     * bases of the vector arguments.
+     */
+    static std::shared_ptr<const Multiplication> get(deg_t width);
+
+    template <typename Basis>
+    static std::shared_ptr<const Multiplication> get(const Basis &basis) {
+        return get(basis.width());
+    }
+
+};
+
+template <typename Multiplication>
+std::mutex multiplication_registry<Multiplication>::m_lock;
+
+template <typename Multiplication>
+std::unordered_map<deg_t, std::shared_ptr<const Multiplication>>
+    multiplication_registry<Multiplication>::m_cache;
+
+template <typename Basis>
+typename basis_registry<Basis>::basis_pointer basis_registry<Basis>::get(deg_t width, deg_t depth) {
+
+    std::lock_guard<std::mutex> access(m_lock);
+
+    auto &found = m_cache[{width, depth}];
+    if (!found) {
+        found = std::make_unique<const Basis>(width, depth);
+    }
+
+    return basis_pointer(found);
+}
+
+template <typename Multiplication>
+std::shared_ptr<const Multiplication> multiplication_registry<Multiplication>::get(deg_t width) {
+
+    std::lock_guard<std::mutex> access(m_lock);
+
+    auto &found = m_cache[width];
+    if (found) {
+        return found;
+    }
+
+    return found = std::make_shared<const Multiplication>(width);
+
+}
+
+}
+
+#endif //LIBALGEBRA_LITE_REGISTRY_H

--- a/vendored/libalgebra_lite/shuffle_tensor.h
+++ b/vendored/libalgebra_lite/shuffle_tensor.h
@@ -1,0 +1,468 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Created by user on 31/01/23.
+//
+
+#ifndef LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_SHUFFLE_TENSOR_H
+#define LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_SHUFFLE_TENSOR_H
+
+#include "implementation_types.h"
+#include "libalgebra_lite_export.h"
+
+#include "algebra.h"
+#include "basis_traits.h"
+#include "coefficients.h"
+#include "free_tensor.h"
+#include "tensor_basis.h"
+
+namespace lal {
+
+class left_half_shuffle_tensor_multiplier;
+
+class right_half_shuffle_tensor_multiplier;
+
+LAL_EXPORT_TEMPLATE_CLASS(
+        base_multiplier, left_half_shuffle_tensor_multiplier, tensor_basis
+)
+LAL_EXPORT_TEMPLATE_CLASS(
+        base_multiplier, right_half_shuffle_tensor_multiplier, tensor_basis
+)
+
+#if 0
+class free_tensor_multiplication
+{
+
+
+
+    template <typename Coefficients, typename Fn>
+    void fma_dense_giles(dtl::dense_multiplication_helper<Coefficients>& helper,
+            Fn fn, deg_t out_degree) noexcept
+    {
+        using key_type = tensor_basis::key_type;
+
+        auto lhs_deg = helper.lhs_degree();
+        auto rhs_deg = helper.rhs_degree();
+
+        auto* tile = helper.write_tile();
+        const auto* left_rtile = helper.left_tile();
+        const auto* right_rtile = helper.right_tile();
+
+        for (deg_t out_deg=out_degree; out_deg > 2*helper.tile_letters; --out_deg) {
+            const auto stride = helper.stride(out_deg);
+            const auto adj_deg = out_deg - 2*helper.tile_letters;
+
+            // end is not actually a valid key, but it serves as a marker.
+            key_type start{adj_deg, 0}, end{adj_deg, helper.range_size(adj_deg)};
+
+            for (auto k = start; k<end; ++k) {
+                auto k_reverse = helper.reverse(k);
+
+                helper.write_tile_in(k, k_reverse);
+
+                {
+                    const auto& lhs_unit = helper.lhs_unit();
+                    const auto* rhs_ptr = helper.right_fwd_read(k);
+
+                    for (dimn_t i=0; i<helper.tile_width; ++i) {
+                        for (dimn_t j=0; j<helper.tile_width; ++j) {
+                            tile[i*helper.tile_width+j] += fn(lhs_unit*rhs_ptr[i*stride+j]);
+                        }
+                    }
+                }
+
+                {
+                    const auto* lhs_ptr = helper.lhs_fwd_read(k);
+                    const auto& rhs_unit = helper.rhs_unit();
+                    for (dimn_t i = 0; i<helper.tile_width; ++i) {
+                        for (dimn_t j = 0; j<helper.tile_width; ++j) {
+                            tile[i*helper.tile_width+j] += fn(lhs_ptr[i*stride+j]*rhs_unit);
+                        }
+                    }
+                }
+
+                for (deg_t lh_deg=1; lh_deg < helper.tile_letters; ++lh_deg) {
+                    auto rh_deg = adj_deg - lh_deg;
+                    for (dimn_t i=0; i<helper.tile_width; ++i) {
+                        const auto split = helper.split_key(k);
+                        const auto& lhs_val = *helper.left_fwd_read(split.first);
+                        helper.read_right_tile(helper.combine(key_type(helper.tile_letters-lh_deg, split.first), k));
+                        for (dimn_t j=0; j<helper.tile_width; ++j) {
+                            tile[i*helper.tile_width+j] += fn(lhs_val*right_rtile[j]);
+                        }
+                    }
+                }
+
+                for (deg_t lh_deg=0; lh_deg<adj_deg; ++lh_deg) {
+                    const auto rh_deg = adj_deg - lh_deg;
+                    auto split = helper.split_key(rh_deg, k);
+                    helper.read_left_tile(helper.reverse(split.first));
+                    helper.read_right_tile(split.second);
+
+                    for (dimn_t i=0; i<helper.tile_width; ++i) {
+                        for (dimn_t j=0; j<helper.tile_width; ++j) {
+                            tile[i*helper.tile_width+j] += fn(left_rtile[i]*right_rtile[j]);
+                        }
+                    }
+                }
+
+                for (deg_t rh_deg=1; rh_deg<helper.tile_letters; ++rh_deg) {
+                    const auto lh_deg = adj_deg - rh_deg;
+                    for (dimn_t j=0; j<helper.tile_width; ++j) {
+                        const auto split = helper.split_key(key_type(rh_deg, j));
+                        const auto& rhs_val = *helper.right_fwd_read(helper.combine(k_reverse, helper.reverse(split.first)));
+                        helper.read_left_tile(split.second);
+
+                        for (dimn_t i=0; i<helper.tile_width; ++i) {
+                            tile[i*helper.tile_width+j] += fn(left_rtile[i]*rhs_val);
+                        }
+                    }
+                }
+
+                helper.write_tile_out(k, k_reverse);
+            }
+
+        }
+
+        fma_dense_traditional(helper, fn, 2*helper.tile_letters);
+    }
+
+    template <typename Coefficients, typename Alloc, typename Fn>
+    void fma_dense(
+            free_tensor<Coefficients, dense_vector>& result,
+            const free_tensor<Coefficients, dense_vector>& lhs,
+            const free_tensor<Coefficients, dense_vector>& rhs,
+            Fn fn,
+            deg_t max_deg
+            )
+    {
+        using key_type = typename tensor_basis::key_type;
+        if (max_deg>result.depth()) {
+            max_deg = result.depth();
+        }
+
+        auto lhs_deg = lhs.degree();
+        auto rhs_deg = rhs.degree();
+
+        deg_t out_degree = std::min(max_deg, lhs_deg+rhs_deg);
+        const tensor_basis* basis = &result.basis();
+        result.resize(basis->size(out_degree));
+
+        dtl::dense_multiplication_helper<Coefficients> helper(result, lhs, rhs);
+        if (out_degree > 2*helper.tile_letters) {
+            fma_dense_giles(helper, fn, out_degree);
+        } else {
+            fma_dense_traditional(helper, fn, out_degree);
+        }
+
+    }
+
+
+public:
+
+    using compatible_bases = boost::mpl::vector<tensor_basis>;
+
+    template <typename Result, typename Vector1, typename Vector2, typename Fn>
+    LAL_TENSOR_COMPAT_RVV(Result, Vector1, Vector2)
+    multiply_and_add(Result& result, const Vector1& lhs, const Vector2& rhs, Fn op)
+    {
+
+       using key_type = tensor_basis::key_type;
+
+        auto lhs_deg = helper.lhs_degree();
+        auto rhs_deg = helper.rhs_degree();
+
+        auto* tile = helper.write_tile();
+        const auto* left_rtile = helper.left_tile();
+        const auto* right_rtile = helper.right_tile();
+
+        for (deg_t out_deg=out_degree; out_deg > 2*helper.tile_letters; --out_deg) {
+            const auto stride = helper.stride(out_deg);
+            const auto adj_deg = out_deg - 2*helper.tile_letters;
+
+            // end is not actually a valid key, but it serves as a marker.
+            key_type start{adj_deg, 0}, end{adj_deg, helper.range_size(adj_deg)};
+
+            for (auto k = start; k<end; ++k) {
+                auto k_reverse = helper.reverse(k);
+
+                helper.write_tile_in(k, k_reverse);
+
+                {
+                    const auto& lhs_unit = helper.lhs_unit();
+                    const auto* rhs_ptr = helper.right_fwd_read(k);
+
+                    for (dimn_t i=0; i<helper.tile_width; ++i) {
+                        for (dimn_t j=0; j<helper.tile_width; ++j) {
+                            tile[i*helper.tile_width+j] += fn(lhs_unit*rhs_ptr[i*stride+j]);
+                        }
+                    }
+                }
+
+                {
+                    const auto* lhs_ptr = helper.lhs_fwd_read(k);
+                    const auto& rhs_unit = helper.rhs_unit();
+                    for (dimn_t i = 0; i<helper.tile_width; ++i) {
+                        for (dimn_t j = 0; j<helper.tile_width; ++j) {
+                            tile[i*helper.tile_width+j] += fn(lhs_ptr[i*stride+j]*rhs_unit);
+                        }
+                    }
+                }
+
+                for (deg_t lh_deg=1; lh_deg < helper.tile_letters; ++lh_deg) {
+                    auto rh_deg = adj_deg - lh_deg;
+                    for (dimn_t i=0; i<helper.tile_width; ++i) {
+                        const auto split = helper.split_key(k);
+                        const auto& lhs_val = *helper.left_fwd_read(split.first);
+                        helper.read_right_tile(helper.combine(key_type(helper.tile_letters-lh_deg, split.first), k));
+                        for (dimn_t j=0; j<helper.tile_width; ++j) {
+                            tile[i*helper.tile_width+j] += fn(lhs_val*right_rtile[j]);
+                        }
+                    }
+                }
+
+                for (deg_t lh_deg=0; lh_deg<adj_deg; ++lh_deg) {
+                    const auto rh_deg = adj_deg - lh_deg;
+                    auto split = helper.split_key(rh_deg, k);
+                    helper.read_left_tile(helper.reverse(split.first));
+                    helper.read_right_tile(split.second);
+
+                    for (dimn_t i=0; i<helper.tile_width; ++i) {
+                        for (dimn_t j=0; j<helper.tile_width; ++j) {
+                            tile[i*helper.tile_width+j] += fn(left_rtile[i]*right_rtile[j]);
+                        }
+                    }
+                }
+
+                for (deg_t rh_deg=1; rh_deg<helper.tile_letters; ++rh_deg) {
+                    const auto lh_deg = adj_deg - rh_deg;
+                    for (dimn_t j=0; j<helper.tile_width; ++j) {
+                        const auto split = helper.split_key(key_type(rh_deg, j));
+                        const auto& rhs_val = *helper.right_fwd_read(helper.combine(k_reverse, helper.reverse(split.first)));
+                        helper.read_left_tile(split.second);
+
+                        for (dimn_t i=0; i<helper.tile_width; ++i) {
+                            tile[i*helper.tile_width+j] += fn(left_rtile[i]*rhs_val);
+                        }
+                    }
+                }
+
+                helper.write_tile_out(k, k_reverse);
+            }
+
+        }
+
+        fma_dense_traditional(helper, fn, 2*helper.tile_letters);}
+
+    template <typename Coefficients, typename Alloc, typename Fn>
+    void multiply_inplace(
+            dense_vector_view<tensor_basis, Coefficients, Alloc>& lhs,
+            const dense_vector_view<tensor_basis, Coefficients, Alloc>& rhs,
+            Fn op) noexcept
+    {
+
+    }
+
+};
+#endif
+
+class LIBALGEBRA_LITE_EXPORT left_half_shuffle_tensor_multiplier
+    : public base_multiplier<left_half_shuffle_tensor_multiplier, tensor_basis>
+{
+    using base_type = base_multiplier<
+            left_half_shuffle_tensor_multiplier, tensor_basis>;
+
+    using typename base_type::key_type;
+    using typename base_type::product_type;
+    using typename base_type::reference;
+
+    using parent_type = std::pair<key_type, key_type>;
+
+    mutable std::unordered_map<
+            parent_type, product_type, boost::hash<parent_type>>
+            m_cache;
+    mutable std::recursive_mutex m_lock;
+
+    product_type
+    key_prod_impl(const tensor_basis& basis, key_type lhs, key_type rhs) const;
+
+
+protected:
+    product_type
+    shuffle(const tensor_basis& basis, key_type lhs, key_type rhs) const;
+
+public:
+    using basis_type = tensor_basis;
+
+    explicit left_half_shuffle_tensor_multiplier(deg_t width)
+    {}
+
+    reference
+    operator()(const tensor_basis& basis, key_type lhs, key_type rhs) const;
+};
+
+class LIBALGEBRA_LITE_EXPORT right_half_shuffle_tensor_multiplier
+    : public base_multiplier<right_half_shuffle_tensor_multiplier, tensor_basis>
+{
+    using base_type = base_multiplier<
+            right_half_shuffle_tensor_multiplier, tensor_basis>;
+
+    using typename base_type::key_type;
+    using typename base_type::product_type;
+    using typename base_type::reference;
+
+    using parent_type = std::pair<key_type, key_type>;
+
+    mutable std::unordered_map<
+            parent_type, product_type, boost::hash<parent_type>>
+            m_cache;
+    mutable std::recursive_mutex m_lock;
+
+    product_type
+    key_prod_impl(const tensor_basis& basis, key_type lhs, key_type rhs) const;
+
+    parent_type
+    split_at_right(const tensor_basis& basis, key_type key) const noexcept;
+
+
+protected:
+    product_type
+    shuffle(const tensor_basis& basis, key_type lhs, key_type rhs) const;
+
+public:
+    using basis_type = tensor_basis;
+
+    explicit right_half_shuffle_tensor_multiplier(deg_t width)
+    {}
+
+    reference
+    operator()(const tensor_basis& basis, key_type lhs, key_type rhs) const;
+};
+
+using half_shuffle_tensor_multiplier LAL_UNUSED
+        = left_half_shuffle_tensor_multiplier;
+
+class LIBALGEBRA_LITE_EXPORT shuffle_tensor_multiplier
+    : protected left_half_shuffle_tensor_multiplier
+{
+    using base_type = base_multiplier<
+            left_half_shuffle_tensor_multiplier, tensor_basis>;
+    using half_type = left_half_shuffle_tensor_multiplier;
+
+public:
+    using basis_type = tensor_basis;
+
+    using half_type::half_type;
+
+    typename base_type::product_type operator()(
+            const tensor_basis& basis, typename base_type::key_type lhs,
+            typename base_type::key_type rhs
+    ) const;
+};
+
+using left_half_shuffle_multiplication
+        = base_multiplication<left_half_shuffle_tensor_multiplier>;
+using half_shuffle_multiplication LAL_UNUSED = left_half_shuffle_multiplication;
+using right_half_shuffle_multiplication
+        = base_multiplication<right_half_shuffle_tensor_multiplier>;
+using shuffle_tensor_multiplication
+        = base_multiplication<shuffle_tensor_multiplier>;
+
+LAL_EXPORT_TEMPLATE_CLASS(
+        multiplication_registry, left_half_shuffle_multiplication
+)
+LAL_EXPORT_TEMPLATE_CLASS(
+        multiplication_registry, right_half_shuffle_multiplication
+)
+LAL_EXPORT_TEMPLATE_CLASS(
+        multiplication_registry, shuffle_tensor_multiplication
+)
+
+template <
+        typename Coefficients, template <typename, typename> class VectorType,
+        template <typename> class StorageModel>
+class shuffle_tensor
+    : public unital_algebra<
+              tensor_basis, Coefficients, shuffle_tensor_multiplication,
+              VectorType, StorageModel>
+{
+    using algebra_type = unital_algebra<
+            tensor_basis, Coefficients, shuffle_tensor_multiplication,
+            VectorType, StorageModel>;
+
+public:
+    using algebra_type::algebra_type;
+
+    shuffle_tensor create_alike() const {
+        return shuffle_tensor(this->get_basis(), this->multiplication());
+    }
+};
+
+template <typename LTensor, typename RTensor>
+inline LTensor
+left_half_shuffle_multiply(const LTensor& left, const RTensor& right)
+{
+
+    const auto lhsm
+            = multiplication_registry<left_half_shuffle_multiplication>::get(
+                    left.basis()
+            );
+    return multiply(*lhsm, left, right);
+}
+
+template <typename LTensor, typename RTensor>
+inline LTensor
+right_half_shuffle_multiply(const LTensor& left, const RTensor& right)
+{
+    auto rhsm = multiplication_registry<right_half_shuffle_multiplication>::get(
+            left.basis()
+    );
+    return multiply(*rhsm, left, right);
+}
+
+template <typename LTensor, typename RTensor>
+inline LTensor half_shuffle_multiply(const LTensor& left, const RTensor& right)
+{
+    const auto hsm = multiplication_registry<half_shuffle_multiplication>::get(
+            left.basis()
+            );
+    return multiply(*hsm, left, right);
+}
+
+template <typename LTensor, typename RTensor>
+inline LTensor shuffle_multiply(const LTensor& left, const RTensor& right)
+{
+    const auto sm = multiplication_registry<shuffle_tensor_multiplication>::get(
+            left.basis()
+    );
+    return multiply(*sm, left, right);
+}
+
+}// namespace lal
+
+#endif// LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_SHUFFLE_TENSOR_H

--- a/vendored/libalgebra_lite/sparse_vector.h
+++ b/vendored/libalgebra_lite/sparse_vector.h
@@ -1,0 +1,503 @@
+// Copyright (c) 2023 the RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Created by user on 26/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_SPARSE_VECTOR_H
+#define LIBALGEBRA_LITE_SPARSE_VECTOR_H
+
+#include "implementation_types.h"
+
+#include <iterator>
+#include <map>
+#include <type_traits>
+#include <utility>
+
+#include "basis_traits.h"
+#include "coefficients.h"
+#include "vector_base.h"
+
+namespace lal {
+namespace dtl {
+
+#define LAL_MUTABLE_REF_iOP(OP)                                                \
+    template <typename Scalar>                                                 \
+    Self& operator OP(Scalar arg) noexcept(noexcept(m_tmp OP arg))             \
+    {                                                                          \
+        m_tmp OP arg;                                                          \
+        return *this;                                                          \
+    }
+
+#define LAL_MUTABLE_REF_COMPARE(OP)                                            \
+    template <typename Scalar>                                                 \
+    bool operator OP(Scalar arg) noexcept(noexcept(m_tmp OP arg))              \
+    {                                                                          \
+        return m_tmp OP arg;                                                   \
+    }
+
+template <typename Vector>
+class sparse_mutable_reference
+{
+    using map_type = typename Vector::map_type;
+    using iterator_type = typename map_type::iterator;
+
+    Vector& m_vector;
+    iterator_type m_it;
+    typename Vector::key_type m_key;
+    typename Vector::scalar_type m_tmp;
+
+    using Self = sparse_mutable_reference;
+
+public:
+    using key_type = typename Vector::key_type;
+    using scalar_type = typename Vector::scalar_type;
+
+    sparse_mutable_reference(Vector& vect, iterator_type it)
+        : m_vector(vect), m_it(it), m_key(it->first), m_tmp(it->second)
+    {
+        assert(it != m_vector.m_data.end());
+    }
+
+    sparse_mutable_reference(Vector& vect, const key_type& key)
+        : m_vector(vect), m_it(vect.m_data.find(key)), m_key(key), m_tmp(0)
+    {
+        if (m_it != m_vector.m_data.end()) { m_tmp = m_it->second; }
+    }
+
+    ~sparse_mutable_reference()
+    {
+        if (m_tmp != scalar_type(0)) {
+            if (m_it != m_vector.m_data.end()) {
+                m_it->second = m_tmp;
+            } else {
+                m_vector.insert_new_value(m_key, m_tmp);
+            }
+        } else if (m_it != m_vector.m_data.end()) {
+            m_vector.m_data.erase(m_it);
+        }
+    }
+
+    operator const scalar_type&(
+    ) const noexcept// NOLINT(google-explicit-constructor)
+    {
+        return m_tmp;
+    }
+    //
+    //    template <typename S>
+    //    std::enable_if_t<std::is_constructible<scalar_type, S>::value,
+    //    sparse_mutable_reference&> operator=(S val) {
+    //       m_tmp = scalar_type(val);
+    //        return *this;
+    //    }
+
+    LAL_MUTABLE_REF_iOP(=) LAL_MUTABLE_REF_iOP(+=) LAL_MUTABLE_REF_iOP(
+            -=
+    ) LAL_MUTABLE_REF_iOP(*=) LAL_MUTABLE_REF_iOP(/=) LAL_MUTABLE_REF_iOP(<<=)
+            LAL_MUTABLE_REF_iOP(>>=) LAL_MUTABLE_REF_iOP(|=) LAL_MUTABLE_REF_iOP(
+                    &=
+            ) LAL_MUTABLE_REF_iOP(^=) LAL_MUTABLE_REF_iOP(%=)
+
+                    LAL_MUTABLE_REF_COMPARE(==) LAL_MUTABLE_REF_COMPARE(
+                            !=
+                    ) LAL_MUTABLE_REF_COMPARE(<) LAL_MUTABLE_REF_COMPARE(<=)
+                            LAL_MUTABLE_REF_COMPARE(>) LAL_MUTABLE_REF_COMPARE(
+                                    >=
+                            )
+
+                                    friend constexpr bool
+                                    operator==(
+                                            const scalar_type lhs,
+                                            const sparse_mutable_reference& rhs
+                                    ) noexcept
+    {
+        return lhs == rhs.m_tmp;
+    }
+};
+
+#undef LAL_MUTABLE_REF_COMPARE
+#undef LAL_MUTABLE_REF_iOP
+
+template <typename Vector, typename Iterator, typename Parent>
+class sparse_iterator_base
+{
+protected:
+    Vector* p_vector = nullptr;
+    Iterator m_it;
+
+    using traits = std::iterator_traits<Iterator>;
+
+    using key_type = typename traits::value_type::first_type;
+    using scalar_type = typename traits::value_type::second_type;
+
+public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = Parent;
+    using reference = Parent&;
+    using const_reference = const Parent&;
+    using pointer = Parent*;
+    using const_pointer = const Parent*;
+    using iterator_category = std::forward_iterator_tag;
+
+    sparse_iterator_base() : p_vector(nullptr), m_it() {}
+
+    sparse_iterator_base(Vector* vector, Iterator it)
+        : p_vector(vector), m_it(it)
+    {
+        assert(vector != nullptr);
+    }
+
+    sparse_iterator_base(Vector& vector, Iterator it)
+        : p_vector(&vector), m_it(it)
+    {}
+
+    Parent& operator++() noexcept
+    {
+        ++m_it;
+        return static_cast<Parent&>(*this);
+    }
+    const Parent operator++(int) noexcept
+    {
+        Parent result(p_vector, m_it);
+        ++m_it;
+        return result;
+    }
+
+    const Parent& operator*() const noexcept
+    {
+        return static_cast<const Parent&>(*this);
+    }
+    const Parent* operator->() const noexcept
+    {
+        return static_cast<const Parent*>(this);
+    }
+
+    bool operator==(const sparse_iterator_base& other) const noexcept
+    {
+        return m_it == other.m_it;
+    }
+    bool operator!=(const sparse_iterator_base& other) const noexcept
+    {
+        return m_it != other.m_it;
+    }
+};
+
+template <typename Vector, typename Iterator>
+class sparse_iterator;
+
+template <typename Vector>
+class sparse_iterator<Vector, typename Vector::map_type::iterator>
+    : public sparse_iterator_base<
+              Vector, typename Vector::map_type::iterator,
+              sparse_iterator<Vector, typename Vector::map_type::iterator>>
+{
+    using base = sparse_iterator_base<
+            Vector, typename Vector::map_type::iterator,
+            sparse_iterator<Vector, typename Vector::map_type::iterator>>;
+    using base_iterator = typename Vector::map_type::iterator;
+
+public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = sparse_iterator;
+    using reference = sparse_iterator&;
+    using pointer = sparse_iterator*;
+    using iterator_category = std::forward_iterator_tag;
+
+    using value_reference = sparse_mutable_reference<Vector>;
+
+    using base::base;
+
+    const typename base::key_type& key() const noexcept
+    {
+        assert(base::p_vector != nullptr);
+        return base::m_it->first;
+    }
+
+    value_reference value() const noexcept
+    {
+        assert(base::p_vector != nullptr);
+        return value_reference(*base::p_vector, base::m_it);
+    }
+};
+
+template <typename Vector>
+class sparse_iterator<Vector, typename Vector::map_type::const_iterator>
+    : public sparse_iterator_base<
+              Vector, typename Vector::map_type::const_iterator,
+              sparse_iterator<
+                      Vector, typename Vector::map_type::const_iterator>>
+{
+    using base = sparse_iterator_base<
+            Vector, typename Vector::map_type::const_iterator,
+            sparse_iterator<Vector, typename Vector::map_type::const_iterator>>;
+    using base_iterator = typename Vector::map_type::const_iterator;
+
+public:
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = sparse_iterator;
+    using reference = sparse_iterator&;
+    using pointer = sparse_iterator*;
+
+    using base::base;
+
+    const typename base::key_type& key() const noexcept
+    {
+        return base::m_it->first;
+    }
+    const typename base::scalar_type& value() const noexcept
+    {
+        return base::m_it->second;
+    }
+};
+
+}// namespace dtl
+
+template <typename Basis, typename Coefficients>
+class sparse_vector : public vectors::vector_base<Basis, Coefficients>
+{
+    using vec_base = vectors::vector_base<Basis, Coefficients>;
+    using typename vec_base::basis_traits;
+    using typename vec_base::coeff_traits;
+
+    friend class dtl::sparse_mutable_reference<sparse_vector>;
+
+public:
+    using typename vec_base::basis_pointer;
+    using typename vec_base::basis_type;
+    using typename vec_base::coefficient_ring;
+    using typename vec_base::key_type;
+    using typename vec_base::rational_type;
+    using typename vec_base::scalar_type;
+    using map_type = std::map<key_type, scalar_type>;
+
+private:
+    map_type m_data;
+    deg_t m_degree = 0;
+    using vec_base::p_basis;
+
+    friend class dtl::sparse_iterator<
+            sparse_vector, typename map_type::iterator>;
+    friend class dtl::sparse_iterator<
+            const sparse_vector, typename map_type::const_iterator>;
+
+protected:
+    sparse_vector(basis_pointer basis, map_type&& arg)
+        : vec_base(basis), m_data(arg)
+    {}
+
+public:
+    using reference = dtl::sparse_mutable_reference<sparse_vector>;
+    using const_reference = const scalar_type&;
+
+    using iterator
+            = dtl::sparse_iterator<sparse_vector, typename map_type::iterator>;
+    using const_iterator = dtl::sparse_iterator<
+            const sparse_vector, typename map_type::const_iterator>;
+
+    template <typename Scalar>
+    explicit sparse_vector(
+            basis_pointer basis, std::initializer_list<Scalar> args
+    )
+        : vec_base(basis)
+    {
+        assert(args.size() == 1);
+        m_data[key_type()] = scalar_type(*args.begin());
+    }
+
+    template <typename Key, typename Scalar>
+    explicit sparse_vector(basis_pointer basis, Key k, Scalar s)
+        : vec_base(basis)
+    {
+        scalar_type tmp(s);
+        if (tmp != coefficient_ring::zero()) {
+            m_data.insert(std::make_pair(key_type(k), tmp));
+            update_degree_for_key(k);
+        }
+    }
+
+    explicit sparse_vector(basis_pointer basis) : vec_base(basis) {}
+
+    void swap(sparse_vector& right) {
+        std::swap(m_data, right.m_data);
+        std::swap(m_degree, right.m_degree);
+        vec_base::swap(right);
+    }
+
+    constexpr dimn_t size() const noexcept { return m_data.size(); }
+    constexpr bool empty() const noexcept { return m_data.empty(); }
+    constexpr dimn_t dimension() const noexcept { return size(); }
+    deg_t degree() const noexcept
+    {
+        deg_t result = 0;
+        for (const auto& item : m_data) {
+            auto d = p_basis->degree(item.first);
+            if (d > result) { result = d; }
+        }
+        return result;
+    }
+    dimn_t capacity() const noexcept
+    {
+        return basis_traits::max_dimension(*p_basis);
+    }
+
+    void update_degree(deg_t degree) noexcept { m_degree = degree; }
+
+    iterator begin() noexcept { return {*this, m_data.begin()}; }
+    iterator end() noexcept { return {*this, m_data.end()}; }
+    const_iterator begin() const noexcept { return {*this, m_data.begin()}; }
+    const_iterator end() const noexcept { return {*this, m_data.end()}; }
+
+    const_iterator cbegin() const noexcept { return begin(); }
+    const_iterator cend() const noexcept { return end(); }
+
+    const_reference operator[](const key_type& key) const noexcept
+    {
+        auto val = m_data.find(key);
+        if (val != m_data.end()) { return val->second; }
+        return coefficient_ring::zero();
+    }
+
+    reference operator[](const key_type& key) noexcept
+    {
+        return reference(*this, key);
+    }
+
+private:
+    template <typename Tag = typename basis_traits::degree_tag>
+    std::enable_if_t<std::is_same<Tag, with_degree_tag>::value>
+    update_degree_for_key(const key_type& key)
+    {
+        auto degree = p_basis->degree(key);
+        if (m_degree < degree && degree < basis_traits::max_degree(*p_basis)) {
+            m_degree = degree;
+        }
+    }
+
+    template <typename Tag = typename basis_traits::degree_tag>
+    std::enable_if_t<std::is_same<Tag, without_degree_tag>::value>
+    update_degree_for_key(const key_type&)
+    {
+        // Do Nothing
+    }
+
+public:
+    void insert_new_value(const key_type& key, const scalar_type& value)
+    {
+        m_data[key] = value;
+        update_degree_for_key(key);
+    }
+
+    void clear() noexcept { m_data.clear(); }
+
+    template <typename UnaryOp>
+    sparse_vector unary_op(UnaryOp op) const
+    {
+        map_type data;
+        //        data.reserve(m_data.size());
+        const auto& zero = Coefficients::zero();
+        for (const auto& item : m_data) {
+            auto tmp = op(item.second);
+            if (tmp != zero) { data.emplace(item.first, std::move(tmp)); }
+        }
+        return {p_basis, std::move(data)};
+    }
+    template <typename UnaryOp>
+    sparse_vector& inplace_unary_op(UnaryOp&& op)
+    {
+        auto tmp = this->unary_op(
+            [op = std::forward<UnaryOp>(op)](const scalar_type& arg) {
+            auto tmp = arg;
+            op(tmp);
+            return tmp;
+        });
+        std::swap(m_data, tmp.m_data);
+        return *this;
+    }
+
+    template <typename BinOp>
+    sparse_vector binary_op(const sparse_vector& rhs, BinOp&& op) const
+    {
+        sparse_vector tmp(*this);
+        tmp.inplace_binary_op(rhs, [op=std::forward<BinOp>(op)](scalar_type& l,
+                                                             const
+                                                scalar_type& r) {
+            l = op(l, r);
+        });
+
+        return tmp;
+    }
+
+    template <typename BinOp>
+    sparse_vector& inplace_binary_op(const sparse_vector& rhs, BinOp op)
+    {
+        const auto lend = m_data.end();
+        auto rit = rhs.m_data.begin();
+        const auto rend = rhs.m_data.end();
+
+        const auto& zero = coefficient_ring::zero();
+
+        for (; rit != rend; ++rit) {
+            auto it = m_data.find(rit->first);
+            if (it != lend) {
+                op(it->second, rit->second);
+                if (it->second == zero) {
+                    m_data.erase(it);
+                } else {
+                    update_degree_for_key(it->first);
+                }
+            } else {
+                assert(rit->second != zero);
+                scalar_type new_val = zero;
+                op(new_val, rit->second);
+                insert_new_value(rit->first, new_val);
+            }
+        }
+
+        return *this;
+    }
+
+    bool operator==(const sparse_vector& rhs) const noexcept
+    {
+
+        if (m_data.size() != rhs.m_data.size()) { return false; }
+
+        for (auto&& ritem : rhs.m_data) {
+            auto found = m_data.find(ritem.first);
+            if (found == m_data.end() || found->second != ritem.second) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+};
+
+}// namespace lal
+
+#endif// LIBALGEBRA_LITE_SPARSE_VECTOR_H

--- a/vendored/libalgebra_lite/tensor_basis.h
+++ b/vendored/libalgebra_lite/tensor_basis.h
@@ -1,0 +1,139 @@
+//
+// Created by user on 25/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_TENSOR_BASIS_H
+#define LIBALGEBRA_LITE_TENSOR_BASIS_H
+
+#include "implementation_types.h"
+#include "libalgebra_lite_export.h"
+
+#include <cassert>
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+#include "basis_traits.h"
+#include "index_key.h"
+#include "registry.h"
+
+namespace lal {
+
+class LIBALGEBRA_LITE_EXPORT tensor_basis
+{
+    deg_t m_width;
+    deg_t m_depth;
+
+    std::vector<dimn_t> m_powers;
+    std::vector<dimn_t> m_sizes;
+
+public:
+    using key_type = index_key<>;
+    using degree_tag LAL_UNUSED = with_degree_tag;
+
+    tensor_basis(deg_t width, deg_t depth);
+
+    deg_t width() const noexcept { return m_width; }
+    deg_t depth() const noexcept { return m_depth; }
+
+    static constexpr deg_t degree(const key_type& arg) noexcept
+    {
+        return deg_t(arg.degree());
+    }
+
+    key_type lparent(const key_type& arg) const noexcept
+    {
+        auto degree = arg.degree();
+        if (degree == 0) { return key_type(0, 0); }
+        return key_type(1, arg.index() / m_powers[degree - 1]);
+    }
+    key_type rparent(const key_type& arg) const noexcept
+    {
+        auto degree = arg.degree();
+        if (degree == 0) { return key_type(0, 0); }
+        return key_type(degree - 1, arg.index() % m_powers[degree - 1]);
+    }
+
+    pair<key_type, key_type> parents(const key_type& arg) const noexcept
+    {
+        auto degree = arg.degree();
+        if (degree == 0) { return {key_type(0, 0), key_type(0, 0)}; }
+        auto tmp = arg.index();
+        auto letter = tmp / m_powers[degree - 1];
+        return {key_type(1, letter),
+                key_type(degree - 1, tmp - letter * m_width)};
+    }
+
+    std::string key_to_string(const key_type&) const;
+    std::ostream& print_key(std::ostream&, const key_type&) const;
+
+    static key_type key_of_letter(let_t letter) noexcept
+    {
+        return key_type(1, letter - 1);
+    }
+    let_t first_letter(const key_type& arg) const noexcept
+    {
+        return let_t(lparent(arg).index() + 1);
+    }
+    let_t to_letter(const key_type& arg) const noexcept {
+        assert(arg.degree() == 1);
+        return let_t(arg.index() + 1);
+    }
+    static bool letter(const key_type& arg) noexcept
+    {
+        return arg.degree() == 1;
+    }
+
+    dimn_t start_of_degree(deg_t deg) const noexcept
+    {
+        if (deg == 0) {
+            return 0;
+        } else {
+            return m_sizes[deg - 1];
+        }
+    }
+    dimn_t size_of_degree(deg_t deg) const noexcept;
+    dimn_t size(int i) const noexcept
+    {
+        if (i >= 0) {
+            return m_sizes[i];
+        } else {
+            return m_sizes[m_depth];
+        }
+    }
+
+    const std::vector<dimn_t>& sizes() const noexcept { return m_sizes; }
+
+    const std::vector<dimn_t>& powers() const noexcept { return m_powers; }
+
+    dimn_t key_to_index(key_type arg) const noexcept;
+    key_type index_to_key(dimn_t arg) const noexcept;
+
+    void advance_key(key_type& key) const noexcept;
+
+    dimn_t reverse_idx(deg_t degree, dimn_t idx) const noexcept
+    {
+        dimn_t result = 0;
+        for (deg_t i = 0; i < degree; ++i) {
+            result *= m_width;
+            auto tmp = idx;
+            idx /= m_width;
+            result += tmp - idx * m_width;
+        }
+        return result;
+    }
+
+    key_type reverse_key(key_type arg) const noexcept
+    {
+        auto degree = arg.degree();
+        auto idx = arg.index();
+        auto result_idx = reverse_idx(degree, idx);
+        return key_type{degree, result_idx};
+    }
+};
+
+LAL_EXPORT_TEMPLATE_CLASS(basis_registry, tensor_basis)
+
+}// namespace lal
+
+#endif// LIBALGEBRA_LITE_TENSOR_BASIS_H

--- a/vendored/libalgebra_lite/unpacked_tensor_word.h
+++ b/vendored/libalgebra_lite/unpacked_tensor_word.h
@@ -1,0 +1,100 @@
+//
+// Created by user on 25/01/23.
+//
+
+#ifndef LIBALGEBRA_LITE_UNPACKED_TENSOR_WORD_H
+#define LIBALGEBRA_LITE_UNPACKED_TENSOR_WORD_H
+
+#include "implementation_types.h"
+
+
+#include <boost/container/small_vector.hpp>
+
+#include "tensor_basis.h"
+
+namespace lal {
+
+class LIBALGEBRA_LITE_EXPORT unpacked_tensor_word {
+    using letter_type = unsigned short;
+    using vec_type = boost::container::small_vector<letter_type, 1>;
+
+    using index_type = typename tensor_basis::key_type::index_type;
+
+    vec_type m_data;
+    deg_t m_width;
+
+public:
+
+    template <typename I>
+    unpacked_tensor_word(deg_t width, std::initializer_list<I> args)
+        : m_data(), m_width(width)
+    {
+        m_data.reserve(args.size());
+        for (auto arg : args) {
+            assert(letter_type(arg) < letter_type(m_width));
+            m_data.emplace_back(arg);
+        }
+        std::reverse(m_data.begin(), m_data.end());
+    }
+
+    unpacked_tensor_word(deg_t width, const std::vector<letter_type>& data);
+    unpacked_tensor_word(deg_t width, vec_type&& data) noexcept;
+    unpacked_tensor_word(deg_t width, typename tensor_basis::key_type key);
+    explicit unpacked_tensor_word(deg_t width, deg_t depth=0);
+
+public:
+
+    inline deg_t degree() const noexcept { return static_cast<deg_t>(m_data.size()); }
+    inline deg_t width() const noexcept { return m_width; }
+
+    template <typename I>
+    letter_type operator[](I index) const noexcept {
+        assert(dimn_t(index) < m_data.size());
+        return m_data[m_data.size() - 1 - index];
+    }
+
+
+private:
+
+    void advance(deg_t number);
+
+public:
+
+    unpacked_tensor_word& operator++();
+    const unpacked_tensor_word operator++(int);
+
+    template <typename I>
+    unpacked_tensor_word& operator+=(I number) {
+        assert(number > 0);
+        advance(deg_t(number));
+        return *this;
+    }
+
+    index_type pack_with_base(deg_t base, letter_type offset=0) const noexcept;
+    index_type to_index() const noexcept;
+    index_type to_reverse_index() const noexcept;
+
+    typename tensor_basis::key_type pack() const noexcept;
+
+
+    unpacked_tensor_word& reverse() noexcept;
+
+    unpacked_tensor_word split_left(deg_t left_degree);
+    std::pair<unpacked_tensor_word, unpacked_tensor_word> split(deg_t left_letters) const;
+
+    unpacked_tensor_word operator*(const unpacked_tensor_word& other) const;
+
+    bool operator==(const unpacked_tensor_word& other) const noexcept;
+    bool operator!=(const unpacked_tensor_word& other) const noexcept;
+    bool operator<(const unpacked_tensor_word& other) const noexcept;
+    bool operator<=(const unpacked_tensor_word& other) const noexcept;
+    bool operator>(const unpacked_tensor_word& other) const noexcept;
+    bool operator>=(const unpacked_tensor_word& other) const noexcept;
+
+};
+
+LIBALGEBRA_LITE_EXPORT std::ostream& operator<<(std::ostream& os, const unpacked_tensor_word& word);
+
+} // lal
+
+#endif //LIBALGEBRA_LITE_UNPACKED_TENSOR_WORD_H

--- a/vendored/libalgebra_lite/vector.h
+++ b/vendored/libalgebra_lite/vector.h
@@ -1,0 +1,677 @@
+//
+// Created by user on 08/08/22.
+//
+
+#ifndef LIBALGEBRA_LITE_VECTOR_H
+#define LIBALGEBRA_LITE_VECTOR_H
+
+#include "implementation_types.h"
+
+#include <ostream>
+#include <memory>
+
+#include "basis.h"
+#include "vector_traits.h"
+#include "coefficients.h"
+#include "basis_traits.h"
+#include "registry.h"
+#include "vector_base.h"
+
+namespace lal {
+
+namespace dtl {
+
+template <typename VectorType>
+struct storage_base {
+    using vector_type = VectorType;
+    using vect_traits = vector_traits<VectorType>;
+
+    using basis_type = typename vect_traits::basis_type;
+    using registry = basis_registry<basis_type>;
+    using coefficient_ring = typename vect_traits::coefficient_ring;
+
+    using basis_traits = basis_trait<basis_type>;
+    using coeff_traits = coefficient_trait<coefficient_ring>;
+
+    using basis_pointer = lal::basis_pointer<basis_type>;
+    using key_type = typename basis_traits::key_type;
+    using scalar_type = typename coeff_traits::scalar_type;
+    using rational_type = typename coeff_traits::rational_type;
+
+    using iterator = typename vector_type::iterator;
+    using const_iterator = typename vector_type::const_iterator;
+    using reference = typename vector_type::reference;
+    using const_reference = typename vector_type::const_reference;
+
+    static_assert(std::is_base_of<lal::vectors::vector_base<basis_type, coefficient_ring>, VectorType>::value,
+                  "vector type must derive from the vector_base class");
+
+};
+
+template <typename VectorType>
+class standard_storage : public storage_base<VectorType> {
+public:
+    using base = storage_base<VectorType>;
+
+    using typename base::vector_type;
+
+    using typename base::vect_traits;
+    using typename base::basis_traits;
+    using typename base::coeff_traits;
+    using typename base::registry;
+    using typename base::basis_type;
+    using typename base::key_type;
+    using typename base::coefficient_ring;
+    using typename base::scalar_type;
+    using typename base::rational_type;
+    using typename base::iterator;
+    using typename base::const_iterator;
+    using typename base::reference;
+    using typename base::const_reference;
+
+    using typename base::basis_pointer;
+
+
+private:
+    vector_type m_instance;
+
+protected:
+    const vector_type &instance() const noexcept { return m_instance; }
+    vector_type &instance() noexcept { return m_instance; }
+
+public:
+
+    standard_storage() : m_instance(registry::get()) {}
+
+    standard_storage(const standard_storage& other)
+        : m_instance(other.m_instance)
+    {}
+
+    standard_storage(standard_storage&& other) noexcept
+        : m_instance(std::move(other.m_instance))
+    {}
+
+    explicit standard_storage(basis_pointer basis) : m_instance(basis) {}
+
+    explicit standard_storage(vector_type &&data)
+        :  m_instance(std::move(data)) {
+    }
+
+    template <typename... VArgs>
+    explicit standard_storage(basis_pointer basis, VArgs&&... args)
+        : m_instance(basis, std::forward<VArgs>(args)...)
+    {}
+
+    standard_storage& operator=(const standard_storage& other)
+    {
+        if (&other != this) {
+            m_instance = other.m_instance;
+        }
+        return *this;
+    }
+
+    standard_storage& operator=(standard_storage&& other) noexcept {
+        if (&other != this) {
+            m_instance = std::move(other.m_instance);
+        }
+        return *this;
+    }
+
+
+};
+
+} // namespace dtl
+
+#define LAL_VECTYPE_AND_STORAGE_TEMPLATE_ARGS(VT, SM, EA) \
+    template <typename, typename> class VT, template <typename> class SM
+#define LAL_VECTOR_TEMPLATE_ARGS(B, C, VT, SM, EA) \
+    typename B, typename C, LAL_VECTYPE_AND_STORAGE_TEMPLATE_ARGS((SM), (EA))
+
+template <typename Basis,
+    typename Coefficients,
+    template <typename, typename> class VectorType,
+    template <typename> class StorageModel=dtl::standard_storage>
+class vector : protected StorageModel<VectorType<Basis, Coefficients>> {
+    using base_type = StorageModel<VectorType<Basis, Coefficients>>;
+
+public:
+    using typename base_type::vector_type;
+    using typename base_type::basis_type;
+    using typename base_type::basis_pointer;
+    using typename base_type::key_type;
+    using typename base_type::coefficient_ring;
+    using typename base_type::scalar_type;
+    using typename base_type::rational_type;
+
+    using typename base_type::registry;
+    using typename base_type::iterator;
+    using typename base_type::const_iterator;
+    using typename base_type::reference;
+    using typename base_type::const_reference;
+
+protected:
+
+    vector(vector_type &&arg)
+        : base_type(std::move(arg)) {}
+
+public:
+
+    vector() : base_type() {}
+
+    vector(const vector& other) : base_type(other)
+    {
+    }
+
+    vector(vector&& other) noexcept : base_type(std::move(other))
+    {}
+
+    template <typename Scalar>
+    explicit vector(key_type k, Scalar s) : base_type(k, s)
+    {}
+
+//    template <typename Key, typename Scalar>
+//    explicit vector(Key k, Scalar s) : base_type(p_basis,
+//                                                 key_type(k),
+//                                                 scalar_type(s)) {
+//    }
+
+    template <typename Key, typename Scalar>
+    explicit vector(basis_pointer basis, Key key, Scalar s)
+        : base_type(std::move(basis), key_type(key), scalar_type(s)) {}
+
+    explicit vector(basis_pointer basis) : base_type(std::move(basis)) {}
+
+    vector(basis_pointer basis, std::initializer_list<scalar_type> args)
+        : base_type(vector_type(basis, args)) {}
+
+    explicit vector(const vector_type &arg)
+        : base_type(vector_type(arg)) {
+    }
+
+
+    vector& operator=(const vector&) = default;
+    vector& operator=(vector&&) noexcept = default;
+
+
+    vector clone() const {
+        return vector(*this);
+    }
+
+    vector create_alike() const { return vector(get_basis()); }
+
+    vector_type &base_vector() noexcept { return base_type::instance(); }
+    const vector_type &base_vector() const noexcept { return base_type::instance(); }
+
+    dimn_t size() const noexcept {
+        return base_type::instance().size();
+    }
+
+    dimn_t dimension() const noexcept {
+        return base_type::instance().dimension();
+    }
+
+    deg_t degree() const noexcept { return base_type::instance().degree(); }
+    bool empty() const noexcept {
+        return base_type::instance().empty();
+    }
+
+    const basis_type& basis() const noexcept { return base_type::instance().basis(); }
+    basis_pointer get_basis() const noexcept { return base_type::instance().get_basis(); }
+
+    template <typename KeyType>
+    const_reference operator[](const KeyType &key) const {
+        return base_type::instance()[key_type(key)];
+    }
+
+    template <typename KeyType>
+    reference operator[](const KeyType &key) {
+        return base_type::instance()[key_type(key)];
+    }
+
+    void clear() {
+        base_type::instance().clear();
+    }
+
+    iterator begin() noexcept {
+        return base_type::instance().begin();
+    }
+
+    iterator end() noexcept {
+        return base_type::instance().end();
+    }
+    const_iterator begin() const noexcept {
+        return base_type::instance().cbegin();
+    }
+    const_iterator end() const noexcept {
+        return base_type::instance().cend();
+    }
+
+private:
+
+    template <typename, typename, typename, typename=void>
+    struct has_iterator_inplace_binop : std::false_type {};
+
+    template <typename V, typename F, typename I>
+    struct has_iterator_inplace_binop<V, F, I, std::void_t<
+        decltype(V::template inplace_binop(
+            std::declval<I>(),
+            std::declval<I>(),
+            std::declval<F>()
+        ))>>
+        : std::true_type {
+    };
+
+public:
+
+//    template <typename Iter, typename C>
+//    std::enable_if_t<
+//        has_iterator_inplace_binop<
+//            vector_type,
+//            decltype(coefficient_ring::template add_inplace<>),
+//            Iter
+//        >::value,
+//        vector &>
+//    add_inplace(Iter begin, Iter end) {
+//        return base_type::instance()
+//            .inplace_binop(begin, end, coefficient_ring::add_inplace);
+//    }
+//
+//    template <typename Iter>
+//    std::enable_if_t<
+//        has_iterator_inplace_binop<
+//            vector_type,
+//            decltype(coefficient_ring::template add_inplace<>),
+//            Iter>::value,
+//        vector &>
+//    sub_inplace(Iter begin, Iter end) {
+//        return base_type::instance()
+//            .inplace_binop(begin, end, coefficient_ring::sub_inplace);
+//    }
+
+    template <typename Iter>
+//    std::enable_if_t<
+//        !has_iterator_inplace_binop<
+//            vector_type,
+//            decltype(coefficient_ring::template add_inplace<>),
+//            Iter>::value,
+//        vector &>
+    vector&
+    add_inplace(Iter begin, Iter end) {
+        const auto &self = base_type::instance();
+        for (auto it = begin; it != end; ++it) {
+            self[it->first] += it->second;
+        }
+        return *this;
+    }
+
+    template <typename Iter>
+//    std::enable_if_t<
+//        !has_iterator_inplace_binop<
+//            vector_type,
+//            decltype(coefficient_ring::template sub_inplace<>),
+//            Iter>::value,
+//        vector &>
+    vector&
+    sub_inplace(Iter begin, Iter end) {
+        const auto &self = base_type::instance();
+        for (auto it = begin; it != end; ++it) {
+            self[it->first] -= it->second;
+        }
+    }
+
+    template <typename Key, typename Scal>
+    std::enable_if_t<std::is_constructible<key_type, const Key&>::value, vector&>
+    add_scal_prod(const Key &key, const Scal &scal)
+    {
+        base_type::instance()[key_type(key)] += scalar_type(scal);
+        return *this;
+    }
+    template <typename Key, typename Rat>
+    std::enable_if_t<!std::is_base_of<vector, Key>::value, vector&>
+    add_scal_div(const Key &key, const Rat &scal)
+    {
+        base_type::instance()[key_type(key)] +=
+            coefficient_ring::one() / rational_type(scal);
+        return *this;
+    }
+    template <typename Key, typename Scal>
+    std::enable_if_t<std::is_constructible<key_type, const Key&>::value, vector&>
+    sub_scal_prod(const Key &key, const Scal &scal)
+    {
+        base_type::instance()[key_type(key)] -= scalar_type(scal);
+        return *this;
+    }
+    template <typename Key, typename Rat>
+    std::enable_if_t<!std::is_base_of<vector, Key>::value, vector &>
+    sub_scal_div(const Key &key, const Rat &scal)
+    {
+        base_type::instance()[key_type(key)] -=
+            coefficient_ring::one() / rational_type(scal);
+        return *this;
+    }
+
+    template <typename Scal>
+    vector &add_scal_prod(const vector &rhs, const Scal &scal)
+    {
+        auto &self = base_vector();
+        scalar_type m(scal);
+        self.inplace_binary_op(rhs.base_vector(), [m](scalar_type &ls, const scalar_type &rs) { ls += rs * m; });
+        return *this;
+    }
+    template <typename Rat>
+    vector &add_scal_div(const vector &rhs, const Rat &scal)
+    {
+        auto &self = base_vector();
+        rational_type m(scal);
+        self.inplace_binary_op(rhs.base_vector(), [m](scalar_type &ls, const scalar_type &rs) { ls += rs / m; });
+        return *this;
+    }
+    template <typename Scal>
+    vector &sub_scal_prod(const vector &rhs, const Scal &scal)
+    {
+        auto &self = base_vector();
+        scalar_type m(scal);
+        self.inplace_binary_op(rhs.base_vector(), [m](scalar_type &ls, const scalar_type &rs) { ls -= rs * m; });
+        return *this;
+    }
+    template <typename Rat>
+    vector &sub_scal_div(const vector &rhs, const Rat &scal)
+    {
+        auto &self = base_vector();
+        rational_type m(scal);
+        self.inplace_binary_op(rhs.base_vector(), [m](scalar_type &ls, const scalar_type &rs) { ls -= rs / m; });
+        return *this;
+    }
+
+    template <template <typename, typename> class AltVecType,
+        template <typename> class AltStorageModel,
+        typename Scal>
+    vector &add_scal_prod(
+        const vector<Basis, Coefficients, AltVecType, AltStorageModel> &rhs,
+        const Scal &scal
+    )
+    {
+        const auto &self = this->instance();
+        const scalar_type m(scal);
+        for (auto term : rhs.instance()) {
+            self[term.key()] += term.value() * m;
+        }
+        return *this;
+    }
+    template <template <typename, typename> class AltVecType,
+        template <typename> class AltStorageModel,
+        typename Rat>
+    vector &add_scal_div(
+        const vector<Basis, Coefficients, AltVecType, AltStorageModel> &rhs,
+        const Rat &scal
+    )
+    {
+        const auto &self = this->instance();
+        const rational_type m(scal);
+        for (auto term : rhs.instance()) {
+            self[term.key()] += term.value() / m;
+        }
+        return *this;
+    }
+    template <template <typename, typename> class AltVecType,
+        template <typename> class AltStorageModel,
+        typename Scal>
+    vector &sub_scal_prod(
+        const vector<Basis, Coefficients, AltVecType, AltStorageModel> &rhs,
+        const Scal &scal
+    )
+    {
+        const auto& self = this->instance();
+        const scalar_type m(scal);
+        for (auto term : rhs.instance()) {
+            self[term.key()] -= term.value()*m;
+        }
+        return *this;
+    }
+    template <template <typename, typename> class AltVecType,
+        template <typename> class AltStorageModel,
+        typename Rat>
+    vector &sub_scal_div(
+        const vector<Basis, Coefficients, AltVecType, AltStorageModel> &rhs,
+        const Rat &scal
+    )
+    {
+        const auto &self = this->instance();
+        const rational_type m(scal);
+        for (auto term : rhs.instance()) {
+            self[term.key()] -= term.value() / m;
+        }
+        return *this;
+    }
+
+/*    template <
+        typename AltBasis,
+        typename AltCoeffs,
+        template <typename, typename> class AltVecType,
+        template <typename> class AltStorageModel,
+        typename Scal>
+    vector &add_scal_prod(
+        const vector<AltBasis, AltCoeffs, AltVecType, AltStorageModel> &rhs,
+        const Scal &scal
+    )
+    {
+        return *this;
+    }
+    template <
+        typename AltBasis,
+        typename AltCoeffs,
+        template <typename, typename> class AltVecType,
+        template <typename> class AltStorageModel,
+        typename Rat>
+    vector &add_scal_div(
+        const vector<AltBasis, AltCoeffs, AltVecType, AltStorageModel> &rhs,
+        const Rat &scal
+    )
+    {
+        return *this;
+    }
+    template <
+        typename AltBasis,
+        typename AltCoeffs,
+        template <typename, typename> class AltVecType,
+        template <typename> class AltStorageModel,
+        typename Scal>
+    vector &sub_scal_prod(
+        const vector<AltBasis, AltCoeffs, AltVecType, AltStorageModel> &rhs,
+        const Scal &scal
+    )
+    {
+        return *this;
+    }
+    template <
+        typename AltBasis,
+        typename AltCoeffs,
+        template <typename, typename> class AltVecType,
+        template <typename> class AltStorageModel,
+        typename Rat>
+    vector &sub_scal_div(
+        const vector<AltBasis, AltCoeffs, AltVecType, AltStorageModel> &rhs,
+        const Rat &scal
+    )
+    {
+        return *this;
+    }*/
+
+    template <typename Vector>
+    friend std::enable_if_t<std::is_base_of<vector, Vector>::value, Vector>
+    operator-(const Vector &arg) {
+        vector result_inner(arg.instance()
+                                .unary_op([](const scalar_type &s) { return -s; }));
+        return Vector(std::move(result_inner));
+    }
+
+    template <typename Vector, typename Scal>
+    friend std::enable_if_t<std::is_base_of<vector, Vector>::value && (
+        std::is_same<Scal, scalar_type>::value || std::is_constructible<scalar_type, const Scal&>::value),
+                            Vector>
+    operator*(const Vector &arg, const Scal &scalar) {
+        scalar_type m(scalar);
+        vector result_inner(arg.instance()
+                                .unary_op([m](const scalar_type &s) {
+                                    return s * m;
+                                }));
+        return Vector(std::move(result_inner));
+    }
+
+    template <typename Vector, typename Scal>
+    friend std::enable_if_t<std::is_base_of<vector, Vector>::value &&
+        (std::is_same<Scal, scalar_type>::value || std::is_constructible<scalar_type, const Scal &>::value),
+    Vector>
+    operator*(const Scal &scalar, const Vector &arg) {
+        scalar_type m(scalar);
+        vector result_inner(arg.instance()
+                                .unary_op([m](const scalar_type &s) {
+                                    return m * s;
+                                }));
+        return Vector(std::move(result_inner));
+    }
+
+    template <typename Vector, typename Rat>
+    friend std::enable_if_t<std::is_base_of<vector, Vector>::value, Vector>
+    operator/(const Vector &arg, const Rat &scalar) {
+        rational_type m(scalar);
+        vector result_inner(arg.instance()
+            .unary_op([m](const scalar_type &s) { return s / m; }));
+        return Vector(std::move(result_inner));
+    }
+
+    template <typename LVector>
+    friend std::enable_if_t<std::is_base_of<vector, LVector>::value, LVector>
+    operator+(const LVector &lhs, const vector &rhs) {
+        vector result_inner(lhs.instance().binary_op(rhs.instance(),
+                                                                         [](const scalar_type &ls,
+                                                                            const scalar_type &rs) {
+                                                                             return
+                                                                                 ls + rs;
+                                                                         }));
+        return LVector(std::move(result_inner));
+    }
+
+    template <typename LVector>
+    friend std::enable_if_t<std::is_base_of<vector, LVector>::value, LVector>
+    operator-(const LVector &lhs, const vector &rhs) {
+        vector result_inner(lhs.instance().binary_op(rhs.instance(),
+                                                     [](const scalar_type &ls, const scalar_type & rs)
+                                                        { return ls - rs; }));
+        return LVector(std::move(result_inner));
+    }
+//
+//    template <typename LVector,
+//        typename RCoefficients,
+//        template <typename, typename> class RVecType,
+//        template <typename> class RStorageModel>
+//    friend std::enable_if_t<
+//        std::is_base_of<vector, LVector>::value,
+//        LVector
+//    >
+//    operator+(const LVector &lhs,
+//              const vector<Basis, RCoefficients, RVecType, RStorageModel> &rhs) {
+//        using rscalar_type = typename coefficient_trait<RCoefficients>::scalar_type;
+//
+//        return LVector(lhs.p_basis);
+//
+//    }
+
+    template <typename LVector, typename Scal>
+    friend std::enable_if_t<std::is_base_of<vector, LVector>::value, LVector &>
+    operator*=(LVector &lhs, const Scal &scal) {
+        scalar_type m(scal);
+        lhs.instance().inplace_unary_op([m] (scalar_type& s) {  s *= m; });
+        return lhs;
+    }
+
+    template <typename LVector, typename Rat>
+    friend std::enable_if_t<std::is_base_of<vector, LVector>::value, LVector &>
+    operator/=(LVector &lhs, const Rat &scal) {
+        rational_type m(scal);
+        lhs.instance().inplace_unary_op([m](scalar_type &s) { s /= m; });
+        return lhs;
+    }
+
+    template <typename LVector>
+    friend std::enable_if_t<std::is_base_of<vector, LVector>::value, LVector &>
+    operator+=(LVector &lhs, const vector &rhs) {
+        lhs.instance().inplace_binary_op(rhs.instance(), [](scalar_type& ls, const scalar_type& rs)
+        { ls += rs; });
+        return lhs;
+    }
+
+    template <typename LVector>
+    friend std::enable_if_t<std::is_base_of<vector, LVector>::value, LVector &>
+    operator-=(LVector &lhs, const vector &rhs) {
+        lhs.instance()
+            .inplace_binary_op(rhs.instance(), [](scalar_type &ls, const scalar_type &rs) { ls -= rs; });
+        return lhs;
+    }
+
+    template <typename Vector>
+    static Vector new_like(const Vector &arg) {
+        return Vector(arg.get_basis());
+    }
+
+
+    friend std::ostream& operator<<(std::ostream& os, const vector& arg) {
+        const auto &basis = arg.basis();
+        const auto &zero = coefficient_ring::zero();
+        os << "{ ";
+        for (auto item : arg) {
+            auto val = item.value();
+            if (val != zero) {
+                os << val << '(';
+                basis.print_key(os, item.key());
+                os << ") ";
+            }
+        }
+        os << '}';
+        return os;
+    }
+
+};
+
+template <typename B, typename C, template <typename, typename> class VT,
+    template <typename> class SM>
+bool operator==(const vector<B, C, VT, SM> &lhs,
+                const vector<B, C, VT, SM> &rhs) noexcept {
+    return lhs.base_vector() == rhs.base_vector();
+}
+template <typename B, typename C, template <typename, typename> class VT,
+    template <typename> class SM>
+bool operator!=(const vector<B, C, VT, SM> &lhs,
+                const vector<B, C, VT, SM> &rhs) noexcept {
+    return !(lhs == rhs);
+}
+//
+//template <typename Basis, typename Coeff,
+//    template <typename, typename> class VectorType,
+//    template <typename> class StorageModel>
+//std::ostream &operator<<(std::ostream &os,
+//                         const vector<Basis,
+//                                      Coeff,
+//                                      VectorType,
+//                                      StorageModel> &vect) {
+//    const auto &basis = vect.basis();
+//    const auto &zero = coefficient_trait<coeff>::coefficient_ring::zero();
+//    os << "{ ";
+//    for (auto item : vect) {
+//        auto val = item.value();
+//        if (item.value() != zero) {
+//            os << item.value() << '(';
+//            basis.print_key(os, item.key());
+//            os << ") ";
+//        }
+//    }
+//    os << '}';
+//    return os;
+//}
+//
+
+
+} // namespace alg
+
+
+#endif //LIBALGEBRA_LITE_VECTOR_H

--- a/vendored/libalgebra_lite/vector.h
+++ b/vendored/libalgebra_lite/vector.h
@@ -253,7 +253,7 @@ private:
 
     template <typename V, typename F, typename I>
     struct has_iterator_inplace_binop<V, F, I, std::void_t<
-        decltype(V::template inplace_binop(
+        decltype(V::inplace_binop(
             std::declval<I>(),
             std::declval<I>(),
             std::declval<F>()

--- a/vendored/libalgebra_lite/vector_base.h
+++ b/vendored/libalgebra_lite/vector_base.h
@@ -1,0 +1,54 @@
+//
+// Created by user on 07/02/23.
+//
+
+#ifndef LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_VECTOR_BASE_H
+#define LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_VECTOR_BASE_H
+
+#include "implementation_types.h"
+
+
+
+#include "basis.h"
+#include "coefficients.h"
+#include "basis_traits.h"
+
+
+namespace lal {
+namespace vectors {
+
+template <typename Basis, typename Coefficients>
+class vector_base
+{
+protected:
+    using coeff_traits = coefficient_trait<Coefficients>;
+    using basis_traits = basis_trait<Basis>;
+
+    using basis_pointer = lal::basis_pointer<Basis>;
+    basis_pointer p_basis;
+
+    explicit vector_base(basis_pointer basis) : p_basis(basis) {}
+public:
+
+    using basis_type            = Basis;
+    using key_type              = typename basis_traits::key_type;
+    using coefficient_ring      = typename coeff_traits::coefficient_ring;
+    using scalar_type           = typename coeff_traits::scalar_type;
+    using rational_type         = typename coeff_traits::rational_type;
+
+    basis_pointer get_basis() const noexcept { return p_basis; }
+    const Basis& basis() const noexcept { return *p_basis; }
+
+    void swap(vector_base& other) {
+        std::swap(p_basis, other.p_basis);
+    }
+
+};
+
+
+} // namespace vectors
+} // namespace lal
+
+
+
+#endif //LIBALGEBRA_LITE_INCLUDE_LIBALGEBRA_LITE_VECTOR_BASE_H

--- a/vendored/libalgebra_lite/vector_bundle.h
+++ b/vendored/libalgebra_lite/vector_bundle.h
@@ -1,0 +1,75 @@
+//
+// Created by user on 24/08/22.
+//
+
+#ifndef LIBALGEBRA_LITE_VECTOR_BUNDLE_H
+#define LIBALGEBRA_LITE_VECTOR_BUNDLE_H
+
+#include <utility>
+
+namespace lal {
+
+template <typename Vector, typename Fibre=Vector>
+class vector_bundle : public Vector
+{
+    Fibre m_fibre;
+
+public:
+    using vector_type = Vector;
+    using fibre_type = Fibre;
+
+    using fibre_basis_type = typename Fibre::basis_type;
+    using fibre_key_type = typename Fibre::key_type;
+    using fibre_coeffificient_ring = typename Fibre::coefficient_ring;
+    using fibre_scalar_type = typename Fibre::scalar_type;
+    using fibre_rational_type = typename Fibre::rational_type;
+    using fibre_iterator = typename Fibre::iterator;
+    using fibre_const_iterator = typename Fibre::const_iterator;
+    using fibre_reference = typename Fibre::reference;
+    using fibre_const_reference = typename Fibre::const_reference;
+
+
+private:
+
+    using vector_basis_pointer = const typename vector_bundle::basis_type*;
+    using fibre_basis_pointer = const typename vector_bundle::fibre_basis_type*;
+
+    vector_bundle(
+            vector_basis_pointer vbasis,
+            typename Vector::vector_type&& varg,
+            fibre_basis_pointer fbasis,
+            typename Fibre::vector_type&& farg
+            )
+        : Vector(vbasis, std::move(varg)), m_fibre(fbasis, farg)
+    {}
+
+public:
+
+    explicit vector_bundle(vector_type&& arg)
+        : Vector(std::move(arg)), m_fibre()
+    {}
+
+    explicit vector_bundle(const vector_type& varg)
+        : Vector(varg), m_fibre()
+    {}
+
+    vector_bundle(vector_type&& varg, fibre_type&& farg)
+        : Vector(std::move(varg)), m_fibre(std::move(farg))
+    {}
+
+
+
+
+
+
+
+};
+
+
+
+
+} // namespace alg
+
+
+
+#endif //LIBALGEBRA_LITE_VECTOR_BUNDLE_H

--- a/vendored/libalgebra_lite/vector_traits.h
+++ b/vendored/libalgebra_lite/vector_traits.h
@@ -1,0 +1,23 @@
+//
+// Created by user on 27/07/22.
+//
+
+#ifndef LIBALGEBRA_LITE_VECTOR_TRAITS_H
+#define LIBALGEBRA_LITE_VECTOR_TRAITS_H
+
+namespace lal {
+namespace dtl {
+
+template<typename Vector>
+struct vector_traits {
+    using basis_type = typename Vector::basis_type;
+
+    using coefficient_ring = typename Vector::coefficient_ring;
+    using scalar_type = typename Vector::scalar_type;
+    using rational_type = typename Vector::rational_type;
+};
+
+} // namespace dtl
+} // namespace lal
+
+#endif //LIBALGEBRA_LITE_VECTOR_TRAITS_H


### PR DESCRIPTION
Libalgebra lite has been imported as a submodule for a long time, which has caused no end of problems. The medium-term plan is to completely rebuild the algebra module of RoughPy and replace it with a far more flexible framework that will accommodate the device support that we want to introduce. To aid this transition, I've moved all the code from the LibalgebraLite repository into the RoughPy main repository under the `vendored` directory. This allows us to make changes that would break LibalgebraLite if backported into the main repo.

I've already fixed a few errors that appeared in the build system, which might warrant backports, but that isn't the priority for now.