### PR TITLE
Add test harness for Windows debug mode in gtest setup

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -15,8 +15,10 @@ set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST CACHE INTERNAL "")
 # TODO: Add a test runner similar to gtest_main that we can link into
 #       each of our test executables.
 
+add_library(RoughPy_test_harness STATIC src/main.cpp)
 
 
+target_link_libraries(RoughPy_test_harness PUBLIC GTest::gtest)
 
 
 
@@ -26,8 +28,7 @@ set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST CACHE INTERNAL "")
 
 function(setup_roughpy_cpp_tests _test_name)
 
-
-    target_link_libraries(${_test_name} PRIVATE GTest::gtest_main)
+    target_link_libraries(${_test_name} PRIVATE RoughPy_test_harness)
 
     if (WIN32)
 

--- a/testing/src/main.cpp
+++ b/testing/src/main.cpp
@@ -1,0 +1,58 @@
+//
+// Created by sammorley on 08/11/24.
+//
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+
+#if defined(_WIN32) && defined(_DEBUG) && !defined(RPY_NO_DEBUG_MODIFICATION)
+#  include <crtdbg.h>
+
+#define(RPY_SET_REPORT_FILE, TP, FL)                                           \
+    do {                                                                       \
+        err_code = _CrtSetReportMode((TP), (FL));                              \
+        if (err_code != 0) {                                                   \
+            return err_code;                                                   \
+        }                                                                      \
+    } while (0)
+
+#endif
+
+/*
+ * This is a slight modification of the main function found in the gtest_main.cc
+ * file of gtest library. This version adds calls to change the default handlers
+ * for debug assertions and errors. With this configuration, errors are dumped
+ * to stderr rather than using a debug popup, which for some reason is the
+ * default
+ */
+int main(int argc, char** argv)
+{
+
+#if defined(_WIN32) && defined(_DEBUG) && !defined(RPY_NO_DEBUG_MODIFICATION)
+    int err_code = 0;
+    int warn_mode = _CrtSetReportMode(_CRT_WARN,
+        _CRTDBG_MODE_DEBUG | _CRTDBG_MODE_FILE);
+    RPY_SET_REPORT_FILE(_CRT_WARN, stderr);
+    int err_mode = _CrtSetReportMode(_CRT_ERROR,
+        _CRTDBG_MODE_DEBUG | _CRTDBG_MODE_FILE);
+    RPY_SET_REPORT_FILE(_CRT_ERROR, stderr);
+    _CrtSetReportFile(_CRT_ERROR, stderr);
+    int assert_mode = _CrtSetReportMode(_CRT_ASSERT,
+        _CRTDBG_MODE_DEBUG | _CRTDBG_MODE_FILE);
+    RPY_SET_REPORT_FILE(_CRT_ASSERT, stderr);
+#endif
+
+    // make sure the output format is exactly as for the gtest_main function
+    printf("Running main() from file %s\n", __FILE__);
+    testing::InitGoogleTest(&argc, argv);
+    const auto result = RUN_ALL_TESTS();
+
+#if defined(_WIN32) && defined(_DEBUG) && !defined(RPY_NO_DEBUG_MODIFICATION)
+    // I don't know if resetting these modes is strictly necessary, but it
+    // probably doesn't hurt,
+    _CrtSetReportMode(_CRT_WARN, warn_mode);
+    _CrtSetReportMode(_CRT_ERROR, error_mode);
+    _CrtSetReportMode(_CRT_ASSERT, assert_mode);
+#endif
+}


### PR DESCRIPTION
Create a `RoughPy_test_harness` library to customize Google Test's main function. This includes redirecting debug output to stderr, which avoids using default debug popups. The `CMakeLists.txt` was updated to link this new library instead of the default gtest main.