### PR TITLE
Overhaul memory smart pointer

### DIFF
--- a/algebra/include/roughpy/algebra/basis.h
+++ b/algebra/include/roughpy/algebra/basis.h
@@ -31,9 +31,8 @@
 
 #include "algebra_fwd.h"
 
-#include <boost/smart_ptr/intrusive_ptr.hpp>
-#include <boost/smart_ptr/intrusive_ref_counter.hpp>
 #include <roughpy/core/hash.h>
+#include <roughpy/core/smart_ptr.h>
 
 #include <roughpy/core/traits.h>
 
@@ -165,7 +164,7 @@ class Basis : public PrimaryInterface::mixin_t
             "Primary template must be an instance of BasisInterface"
     );
 
-    boost::intrusive_ptr<const basis_interface> p_impl;
+    Rc<const basis_interface> p_impl;
 
 public:
     using key_type = typename basis_interface::key_type;

--- a/algebra/include/roughpy/algebra/basis.h
+++ b/algebra/include/roughpy/algebra/basis.h
@@ -46,7 +46,7 @@ class BasisImplementation;
 
 template <typename Derived, typename KeyType = rpy::key_type>
 class BasisInterface
-    : public boost::intrusive_ref_counter<BasisInterface<KeyType>>
+    : public mem::RcBase<BasisInterface<KeyType>>
 {
 public:
     using key_type = KeyType;

--- a/algebra/include/roughpy/algebra/context.h
+++ b/algebra/include/roughpy/algebra/context.h
@@ -68,7 +68,7 @@ struct VectorConstructionData {
     VectorType vector_type = VectorType::Sparse;
 };
 
-class ROUGHPY_ALGEBRA_EXPORT ContextBase : public boost::intrusive_ref_counter<ContextBase>
+class ROUGHPY_ALGEBRA_EXPORT ContextBase : public mem::RcBase<ContextBase>
 {
     deg_t m_width;
     deg_t m_depth;

--- a/algebra/include/roughpy/algebra/context_fwd.h
+++ b/algebra/include/roughpy/algebra/context_fwd.h
@@ -30,10 +30,9 @@
 
 #include "algebra_fwd.h"
 
-#include <boost/smart_ptr/intrusive_ptr.hpp>
-#include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 #include <roughpy/core/slice.h>
+#include <roughpy/core/smart_ptr.h>
 
 #include <roughpy/platform/serialization.h>
 
@@ -76,8 +75,8 @@ class ContextBase;
 
 class Context;
 
-using base_context_pointer = boost::intrusive_ptr<const ContextBase>;
-using context_pointer = boost::intrusive_ptr<const Context>;
+using base_context_pointer = Rc<const ContextBase>;
+using context_pointer = Rc<const Context>;
 
 struct BasicContextSpec {
     string stype_id;

--- a/algebra/include/roughpy/algebra/linear_operator.h
+++ b/algebra/include/roughpy/algebra/linear_operator.h
@@ -35,6 +35,7 @@
 
 #include <roughpy/core/macros.h>
 #include <roughpy/core/traits.h>
+#include <roughpy/core/smart_ptr.h>
 
 namespace rpy {
 namespace algebra {
@@ -56,7 +57,7 @@ template <typename Argument, typename Result>
 class LinearOperator
 {
     using interface_type = LinearOperatorInterface<Argument, Result>;
-    boost::intrusive_ptr<interface_type> p_impl;
+    Rc<interface_type> p_impl;
 
 public:
     Result operator()(const Argument& arg) const;

--- a/algebra/src/context.cpp
+++ b/algebra/src/context.cpp
@@ -372,25 +372,21 @@ UnspecifiedAlgebraType Context::adjoint_to_left_multiply_by(
 
 void rpy::algebra::intrusive_ptr_add_ref(const ContextBase* ptr) noexcept
 {
-    using counter_t = boost::
-            intrusive_ref_counter<ContextBase, boost::thread_safe_counter>;
+    using counter_t = mem::RcBase<ContextBase, boost::thread_safe_counter>;
     intrusive_ptr_add_ref(static_cast<const counter_t*>(ptr));
 }
 void rpy::algebra::intrusive_ptr_release(const ContextBase* ptr) noexcept
 {
-    using counter_t = boost::
-            intrusive_ref_counter<ContextBase, boost::thread_safe_counter>;
+    using counter_t = mem::RcBase<ContextBase, boost::thread_safe_counter>;
     intrusive_ptr_release(static_cast<const counter_t*>(ptr));
 }
 void rpy::algebra::intrusive_ptr_add_ref(const Context* ptr) noexcept
 {
-    using counter_t = boost::
-            intrusive_ref_counter<ContextBase, boost::thread_safe_counter>;
+    using counter_t = mem::RcBase<ContextBase, boost::thread_safe_counter>;
     intrusive_ptr_add_ref(static_cast<const counter_t*>(ptr));
 }
 void rpy::algebra::intrusive_ptr_release(const Context* ptr) noexcept
 {
-    using counter_t = boost::
-            intrusive_ref_counter<ContextBase, boost::thread_safe_counter>;
+    using counter_t = mem::RcBase<ContextBase, boost::thread_safe_counter>;
     intrusive_ptr_release(static_cast<const counter_t*>(ptr));
 }

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(RoughPy_Core INTERFACE
         include/roughpy/core/macros.h
         include/roughpy/core/helpers.h
         include/roughpy/core/slice.h
+        include/roughpy/core/smart_ptr.h
 )
 add_library(RoughPy::Core ALIAS RoughPy_Core)
 

--- a/core/include/roughpy/core/smart_ptr.h
+++ b/core/include/roughpy/core/smart_ptr.h
@@ -1,0 +1,32 @@
+//
+// Created by sammorley on 10/11/24.
+//
+
+#ifndef ROUGHPY_CORE_SMART_PTR_H
+#define ROUGHPY_CORE_SMART_PTR_H
+
+#include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
+namespace rpy {
+
+
+namespace mem {
+
+template <typename T>
+using Rc = boost::intrusive_ptr<T>;
+
+template <typename T, typename Policy=boost::thread_safe_counter>
+using RcBase = boost::intrusive_ref_counter<T, Policy>;
+
+
+
+}
+
+
+using mem::Rc;
+
+
+}
+
+#endif //ROUGHPY_CORE_SMART_PTR_H

--- a/platform/include/roughpy/platform/devices/core.h
+++ b/platform/include/roughpy/platform/devices/core.h
@@ -30,8 +30,10 @@
 #define ROUGHPY_DEVICE_CORE_H_
 
 #include <roughpy/core/macros.h>
+#include <roughpy/core/smart_ptr.h>
 #include <roughpy/core/traits.h>
 #include <roughpy/core/types.h>
+
 #include <roughpy/platform/serialization.h>
 #include <roughpy/platform/errors.h>
 
@@ -303,8 +305,8 @@ class MemoryView;
 class QueueInterface;
 class Queue;
 
-using Device = boost::intrusive_ptr<const DeviceHandle>;
-using HostDevice = boost::intrusive_ptr<const HostDeviceHandle>;
+using Device = Rc<const DeviceHandle>;
+using HostDevice = Rc<const HostDeviceHandle>;
 
 ROUGHPY_PLATFORM_EXPORT HostDevice get_host_device();
 ROUGHPY_PLATFORM_EXPORT Device get_default_device();

--- a/platform/include/roughpy/platform/devices/device_handle.h
+++ b/platform/include/roughpy/platform/devices/device_handle.h
@@ -63,7 +63,7 @@ struct ExtensionSourceAndOptions {
  *
  */
 class ROUGHPY_PLATFORM_EXPORT DeviceHandle
-    : public boost::intrusive_ref_counter<DeviceHandle>
+    : public mem::RcBase<DeviceHandle>
 {
     mutable std::recursive_mutex m_lock;
     mutable std::unordered_map<string, Kernel> m_kernel_cache;

--- a/platform/src/devices/device_handle.cpp
+++ b/platform/src/devices/device_handle.cpp
@@ -130,15 +130,13 @@ void rpy::devices::intrusive_ptr_add_ref(
         const rpy::devices::DeviceHandle* device
 ) noexcept
 {
-    using counter_t = boost::
-            intrusive_ref_counter<DeviceHandle, boost::thread_safe_counter>;
+    using counter_t = mem::RcBase<DeviceHandle, boost::thread_safe_counter>;
     intrusive_ptr_add_ref(static_cast<const counter_t*>(device));
 }
 void rpy::devices::intrusive_ptr_release(
         const rpy::devices::DeviceHandle* device
 ) noexcept
 {
-    using counter_t = boost::
-            intrusive_ref_counter<DeviceHandle, boost::thread_safe_counter>;
+    using counter_t = mem::RcBase<DeviceHandle, boost::thread_safe_counter>;
     intrusive_ptr_release(static_cast<const counter_t*>(device));
 }

--- a/platform/src/devices/host/host_decls.h
+++ b/platform/src/devices/host/host_decls.h
@@ -33,9 +33,10 @@
 #define ROUGHPY_DEVICE_SRC_CPU_CPU_DECLS_H_
 
 #include <roughpy/core/macros.h>
+#include <roughpy/core/smart_ptr.h>
 #include <roughpy/core/types.h>
 
-#include <boost/smart_ptr/intrusive_ptr.hpp>
+
 
 namespace rpy {
 namespace devices {
@@ -46,7 +47,7 @@ class CPUEvent;
 class CPUKernel;
 class CPUQueue;
 
-using CPUDevice = boost::intrusive_ptr<const CPUDeviceHandle>;
+using CPUDevice = Rc<const CPUDeviceHandle>;
 
 }// namespace device
 }// namespace rpy

--- a/platform/src/devices/host/host_device_impl.cpp
+++ b/platform/src/devices/host/host_device_impl.cpp
@@ -32,6 +32,7 @@
 #include "host_device_impl.h"
 
 #include <roughpy/core/alloc.h>
+#include <roughpy/core/smart_ptr.h>
 
 #include "devices/buffer.h"
 #include "devices/event.h"
@@ -190,7 +191,7 @@ CPUDeviceHandle::~CPUDeviceHandle() = default;
 
 CPUDevice CPUDeviceHandle::get()
 {
-    static boost::intrusive_ptr<CPUDeviceHandle> device(new CPUDeviceHandle);
+    static Rc<CPUDeviceHandle> device(new CPUDeviceHandle);
     return device;
 }
 

--- a/platform/src/devices/opencl/ocl_decls.h
+++ b/platform/src/devices/opencl/ocl_decls.h
@@ -33,9 +33,9 @@
 #define ROUGHPY_DEVICE_SRC_OPENCL_OCL_DECLS_H_
 
 #include <roughpy/core/macros.h>
+#include <roughpy/core/smart_ptr.h>
 #include <roughpy/core/types.h>
 
-#include <boost/smart_ptr/intrusive_ptr.hpp>
 
 namespace rpy {
 namespace devices {
@@ -46,7 +46,7 @@ class OCLEvent;
 class OCLKernel;
 class OCLQueue;
 
-using OCLDevice = boost::intrusive_ptr<const OCLDeviceHandle>;
+using OCLDevice = Rc<const OCLDeviceHandle>;
 
 }// namespace devices
 }// namespace rpy


### PR DESCRIPTION
Boost intrusive pointers might not be the way we want to keep smart pointers in the future, so we have made an alias for them. This should make it easier to replace it in the future if necessary