### PR TITLE
Fix component include directory paths set by cmake function

### DIFF
--- a/cmake/component_setup.cmake
+++ b/cmake/component_setup.cmake
@@ -31,9 +31,9 @@ function(setup_roughpy_component _name)
     _do_set_variable(VERSION ${comp_VERSION} "The version of the component")
     _do_set_variable(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}"
             "Root directory of the ${_name} component")
-    _do_set_variable(INCLUDE_DIR "${ROUGHPY_${_upper_name}_ROOT_DIR}/include/roughpy/${_lower_name}"
+    _do_set_variable(INCLUDE_DIR "${ROUGHPY_${_upper_name}_ROOT_DIR}/include/roughpy/"
             "Include directory for the ${_name} component")
-    _do_set_variable(INCLUDE "${ROUGHPY_${_upper_name}_INCLUDE_DIR}"
+    _do_set_variable(INCLUDE "${ROUGHPY_${_upper_name}_INCLUDE_DIR}/${_lower_name}"
             "Include directory for the ${_name} component")
     _do_set_variable(SOURCE "${ROUGHPY_${_upper_name}_ROOT_DIR}/src"
             "Main source directory for the ${_name} component")

--- a/platform/src/devices/CMakeLists.txt
+++ b/platform/src/devices/CMakeLists.txt
@@ -24,18 +24,18 @@ target_sources(RoughPy_Platform PRIVATE
         queue.cpp
         queue_interface.cpp
         PUBLIC
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/buffer.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/core.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/device_handle.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/device_provider.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/event.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/host_device.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/kernel.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/kernel_arg.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/macros.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/memory_view.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/queue.h
-        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/devices/types.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/buffer.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/core.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/device_handle.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/device_provider.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/event.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/host_device.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/kernel.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/kernel_arg.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/macros.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/memory_view.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/queue.h
+        ${ROUGHPY_PLATFORM_INCLUDE_DIR}/platform/devices/types.h
 )
 
 add_subdirectory(host)

--- a/streams/src/channels/CMakeLists.txt
+++ b/streams/src/channels/CMakeLists.txt
@@ -9,11 +9,11 @@ target_sources(RoughPy_Streams PRIVATE
         lie_channel.cpp
         lead_laggable_channel.cpp
 
-        ${ROUGHPY_STREAMS_INCLUDE_DIR}/channels/stream_channel.h
-        ${ROUGHPY_STREAMS_INCLUDE_DIR}/channels/increment_channel.h
-        ${ROUGHPY_STREAMS_INCLUDE_DIR}/channels/value_channel.h
-        ${ROUGHPY_STREAMS_INCLUDE_DIR}/channels/categorical_channel.h
-        ${ROUGHPY_STREAMS_INCLUDE_DIR}/channels/lie_channel.h
-        ${ROUGHPY_STREAMS_INCLUDE_DIR}/channels/lead_laggable_channel.h
+        ${ROUGHPY_STREAMS_INCLUDE}/channels/stream_channel.h
+        ${ROUGHPY_STREAMS_INCLUDE}/channels/increment_channel.h
+        ${ROUGHPY_STREAMS_INCLUDE}/channels/value_channel.h
+        ${ROUGHPY_STREAMS_INCLUDE}/channels/categorical_channel.h
+        ${ROUGHPY_STREAMS_INCLUDE}/channels/lie_channel.h
+        ${ROUGHPY_STREAMS_INCLUDE}/channels/lead_laggable_channel.h
 )
 


### PR DESCRIPTION
Adjusted the include directory paths in `cmake/component_setup.cmake`, `platform/src/devices/CMakeLists.txt`, and `streams/src/channels/CMakeLists.txt` for consistency and correctness. This ensures that the correct directories are referenced during the build process.