### PR TITLE
Fix ub in basis stack

### DIFF
--- a/algebra/include/roughpy/algebra/algebra_fwd.h
+++ b/algebra/include/roughpy/algebra/algebra_fwd.h
@@ -92,12 +92,15 @@ using RawUnspecifiedAlgebraType = dtl::AlgebraInterfaceBase*;
 using ConstRawUnspecifiedAlgebraType = const dtl::AlgebraInterfaceBase*;
 using UnspecifiedAlgebraType = std::unique_ptr<dtl::AlgebraInterfaceBase>;
 
-class TensorBasisInterface;
-class LieBasisInterface;
+
+template <typename KeyType>
+class BasisInterface;
 
 using TensorKey = key_type;
+using TensorBasisInterface = BasisInterface<TensorKey>;
 using TensorBasis = Basis<TensorBasisInterface>;
 using LieKey = key_type;
+using LieBasisInterface = BasisInterface<LieKey>;
 using LieBasis = Basis<LieBasisInterface>;
 
 class FreeTensorInterface;

--- a/algebra/include/roughpy/algebra/basis_impl.h
+++ b/algebra/include/roughpy/algebra/basis_impl.h
@@ -44,55 +44,32 @@ namespace dtl {
  * @tparam T Impementation Basis type
  * @tparam Interfaces interfaces that must be implemented
  */
-template <typename T, typename PrimaryInterface>
-class BasisImplementation : public PrimaryInterface
+template <typename T, typename Interface>
+class BasisImplementation : public Interface
 {
 protected:
-    using basis_traits = BasisInfo<Basis<PrimaryInterface>, T>;
+    using basis_traits = BasisInfo<Basis<Interface>, T>;
     using basis_storage_t = typename basis_traits::storage_t;
 
     basis_storage_t m_impl;
 
 public:
-    using typename PrimaryInterface::key_type;
+    using typename Interface::key_type;
 
     template <typename... Args>
     explicit BasisImplementation(Args&&... args)
         : m_impl(basis_traits::construct(std::forward<Args>(args)...))
     {}
 
-    string key_to_string(const typename PrimaryInterface::key_type& key
+    string key_to_string(const typename Interface::key_type& key
     ) const override;
     dimn_t dimension() const noexcept override;
 
-    bool are_same(const typename PrimaryInterface::base_interface_t &other) const noexcept override;
-};
+    bool are_same(const typename Interface::base_interface_t &other) const noexcept override;
 
-template <typename T, typename Derived, typename Base>
-class OrderedBasisImplementationMixin : public Base
-{
-protected:
-    using Base::m_impl;
-    using typename Base::basis_traits;
-
-public:
-    using Base::Base;
-    using key_type = typename Derived::key_type;
 
     key_type index_to_key(dimn_t index) const override;
     dimn_t key_to_index(const key_type& key) const override;
-};
-
-template <typename T, typename Derived, typename Base>
-class WordLikeBasisImplementationMixin : public Base
-{
-protected:
-    using Base::m_impl;
-    using typename Base::basis_traits;
-
-public:
-    using Base::Base;
-    using key_type = typename Derived::key_type;
 
     deg_t width() const noexcept override;
     deg_t depth() const noexcept override;
@@ -108,112 +85,110 @@ public:
     bool letter(const key_type& key) const override;
 };
 
-template <typename T, typename PrimaryInterface>
-string BasisImplementation<T, PrimaryInterface>::key_to_string(
-        const typename PrimaryInterface::key_type& key
+
+
+template <typename T, typename Interface>
+string BasisImplementation<T, Interface>::key_to_string(
+        const typename Interface::key_type& key
 ) const
 {
     return basis_traits::key_to_string(m_impl, key);
 }
-template <typename T, typename PrimaryInterface>
-dimn_t BasisImplementation<T, PrimaryInterface>::dimension() const noexcept
+template <typename T, typename Interface >
+dimn_t BasisImplementation<T, Interface>::dimension() const noexcept
 {
     return basis_traits::dimension(m_impl);
 }
 
-template <typename T, typename PrimaryInterface>
-bool BasisImplementation<T,
-                         PrimaryInterface>::are_same(const typename PrimaryInterface::base_interface_t &other) const noexcept {
-    const auto *pother = dynamic_cast<const BasisImplementation *>(&other);
+template <typename T, typename Interface>
+bool BasisImplementation<T, Interface>::are_same(
+        const typename Interface::base_interface_t& other
+) const noexcept
+{
+    const auto* pother = dynamic_cast<const BasisImplementation*>(&other);
     if (pother == nullptr) { return false; }
 
     return basis_traits::are_same(m_impl, pother->m_impl);
 }
 
-template <typename T, typename Derived, typename Base>
-typename Derived::key_type
-OrderedBasisImplementationMixin<T, Derived, Base>::index_to_key(dimn_t index
-) const
+template <typename T, typename Interface>
+typename Interface::key_type
+BasisImplementation<T, Interface>::index_to_key(dimn_t index) const
 {
     return basis_traits::index_to_key(m_impl, index);
 }
-template <typename T, typename Derived, typename Base>
-dimn_t OrderedBasisImplementationMixin<T, Derived, Base>::key_to_index(
-        const key_type& key
+template <typename T, typename Interface>
+dimn_t BasisImplementation<T, Interface>::key_to_index(const key_type& key
 ) const
 {
     return basis_traits::key_to_index(m_impl, key);
 }
-
-template <typename T, typename Derived, typename Base>
-deg_t WordLikeBasisImplementationMixin<T, Derived, Base>::width() const noexcept
+template <typename T, typename Interface>
+deg_t BasisImplementation<T, Interface>::width() const noexcept
 {
     return basis_traits::width(m_impl);
 }
-template <typename T, typename Derived, typename Base>
-deg_t WordLikeBasisImplementationMixin<T, Derived, Base>::depth() const noexcept
+template <typename T, typename Interface>
+deg_t BasisImplementation<T, Interface>::depth() const noexcept
 {
     return basis_traits::depth(m_impl);
 }
-template <typename T, typename Derived, typename Base>
-deg_t WordLikeBasisImplementationMixin<T, Derived, Base>::degree(
-        const key_type& key
+template <typename T, typename Interface>
+deg_t BasisImplementation<T, Interface>::degree(const key_type& key
 ) const noexcept
 {
     return basis_traits::degree(m_impl, key);
 }
-template <typename T, typename Derived, typename Base>
-deg_t WordLikeBasisImplementationMixin<T, Derived, Base>::size(deg_t degree
-) const noexcept
+template <typename T, typename Interface>
+deg_t BasisImplementation<T, Interface>::size(deg_t degree) const noexcept
 {
     return basis_traits::size(m_impl, degree);
 }
-template <typename T, typename Derived, typename Base>
-let_t WordLikeBasisImplementationMixin<T, Derived, Base>::first_letter(
-        const key_type& key
+template <typename T, typename Interface>
+let_t BasisImplementation<T, Interface>::first_letter(const key_type& key
 ) const noexcept
 {
     return basis_traits::first_letter(m_impl, key);
 }
-template <typename T, typename Derived, typename Base>
-let_t WordLikeBasisImplementationMixin<T, Derived, Base>::to_letter(const key_type& key) const noexcept
+template <typename T, typename Interface>
+let_t BasisImplementation<T, Interface>::to_letter(const key_type& key
+) const noexcept
 {
     return basis_traits::to_letter(m_impl, key);
 }
-template <typename T, typename Derived, typename Base>
-dimn_t
-WordLikeBasisImplementationMixin<T, Derived, Base>::start_of_degree(deg_t degree
+template <typename T, typename Interface>
+dimn_t BasisImplementation<T, Interface>::start_of_degree(deg_t degree
 ) const noexcept
 {
     return basis_traits::start_of_degree(m_impl, degree);
 }
-template <typename T, typename Derived, typename Base>
-pair<optional<typename Derived::key_type>, optional<typename Derived::key_type>>
-WordLikeBasisImplementationMixin<T, Derived, Base>::parents(const key_type& key
-) const
+template <typename T, typename Interface>
+pair<optional<typename Interface::key_type>, optional<typename Interface::key_type>>
+BasisImplementation<T, Interface>::parents(const key_type& key) const
 {
     return basis_traits::parents(m_impl, key);
 }
-
-template <typename T, typename Derived, typename Base>
-optional<typename Derived::key_type> WordLikeBasisImplementationMixin<T, Derived, Base>::child(const key_type& lparent, const key_type& rparent) const {
+template <typename T, typename Interface>
+optional<typename Interface::key_type> BasisImplementation<T, Interface>::child(
+        const key_type& lparent,
+        const key_type& rparent
+) const
+{
     return basis_traits::child(m_impl, lparent, rparent);
 }
-
-template <typename T, typename Derived, typename Base>
-typename Derived::key_type
-WordLikeBasisImplementationMixin<T, Derived, Base>::key_of_letter(let_t letter
-) const noexcept
+template <typename T, typename Interface>
+typename Interface::key_type
+BasisImplementation<T, Interface>::key_of_letter(let_t letter) const noexcept
 {
     return basis_traits::key_of_letter(m_impl, letter);
 }
-template <typename T, typename Derived, typename Base>
-bool WordLikeBasisImplementationMixin<T, Derived, Base>::letter(
-        const key_type& key
-) const
+template <typename T, typename Interface>
+bool BasisImplementation<T, Interface>::letter(const key_type& key) const
 {
     return basis_traits::letter(m_impl, key);
 }
+
+
 
 }// namespace dtl
 }// namespace algebra

--- a/algebra/include/roughpy/algebra/basis_impl.h
+++ b/algebra/include/roughpy/algebra/basis_impl.h
@@ -54,7 +54,8 @@ protected:
     basis_storage_t m_impl;
 
 public:
-    using typename Interface::key_type;
+    // using typename Interface::key_type;
+    using key_type = typename Interface::key_type;
 
     template <typename... Args>
     explicit BasisImplementation(Args&&... args)
@@ -81,7 +82,8 @@ public:
     pair<optional<key_type>, optional<key_type>> parents(const key_type& key
     ) const override;
     optional<key_type> child(const key_type& lparent, const key_type& rparent) const override;
-    key_type key_of_letter(let_t letter) const noexcept override;
+    typename Interface::key_type
+    key_of_letter(let_t letter) const noexcept override;
     bool letter(const key_type& key) const override;
 };
 

--- a/algebra/include/roughpy/algebra/interfaces/algebra_interface.h
+++ b/algebra/include/roughpy/algebra/interfaces/algebra_interface.h
@@ -66,8 +66,13 @@ protected:
             AlgebraType alg_type
     );
 
+
+
+
 public:
     virtual ~AlgebraInterfaceBase();
+
+
 
     RPY_NO_DISCARD const context_pointer& context() const noexcept
     {

--- a/algebra/include/roughpy/algebra/lie_basis.h
+++ b/algebra/include/roughpy/algebra/lie_basis.h
@@ -29,31 +29,8 @@
 #ifndef ROUGHPY_ALGEBRA_LIE_BASIS_H_
 #define ROUGHPY_ALGEBRA_LIE_BASIS_H_
 
+#include "algebra_fwd.h"
 #include "basis.h"
 
-namespace rpy {
-namespace algebra {
-
-class ROUGHPY_ALGEBRA_EXPORT LieBasisInterface
-    : public make_basis_interface<
-              LieBasisInterface, rpy::key_type, OrderedBasisInterface,
-              WordLikeBasisInterface>
-{
-};
-
-#ifdef RPY_PLATFORM_WINDOWS
-#  ifdef RPY_COMPILING_DLL
-extern template class Basis<LieBasisInterface>;
-#  else
-template class RPY_DLL_IMPORT Basis<LieBasisInterface>;
-#  endif
-#else
-extern template class ROUGHPY_ALGEBRA_EXPORT Basis<LieBasisInterface>;
-#endif
-
-        using LieBasis = Basis<LieBasisInterface>;
-
-}// namespace algebra
-}// namespace rpy
 
 #endif// ROUGHPY_ALGEBRA_LIE_BASIS_H_

--- a/algebra/include/roughpy/algebra/tensor_basis.h
+++ b/algebra/include/roughpy/algebra/tensor_basis.h
@@ -36,26 +36,7 @@
 namespace rpy {
 namespace algebra {
 
-class ROUGHPY_ALGEBRA_EXPORT TensorBasisInterface
-    : public make_basis_interface<
-              TensorBasisInterface, rpy::key_type, OrderedBasisInterface,
-              WordLikeBasisInterface>
-{
-public:
-    ~TensorBasisInterface() override;
-};
 
-#ifdef RPY_PLATFORM_WINDOWS
-#  ifdef RPY_COMPILING_DLL
-extern template class Basis<TensorBasisInterface>;
-#  else
-template class RPY_DLL_IMPORT Basis<TensorBasisInterface>;
-#  endif
-#else
-extern template class ROUGHPY_ALGEBRA_EXPORT Basis<TensorBasisInterface>;
-#endif
-
-        using TensorBasis = Basis<TensorBasisInterface>;
 
 }// namespace algebra
 }// namespace rpy

--- a/algebra/src/lie_basis.cpp
+++ b/algebra/src/lie_basis.cpp
@@ -35,10 +35,3 @@
 using namespace rpy;
 using namespace rpy::algebra;
 
-namespace rpy {
-namespace algebra {
-
-template class RPY_DLL_EXPORT Basis<LieBasisInterface>;
-
-}
-}// namespace rpy

--- a/algebra/src/tensor_basis.cpp
+++ b/algebra/src/tensor_basis.cpp
@@ -35,10 +35,3 @@
 using namespace rpy;
 using namespace rpy::algebra;
 
-namespace rpy {
-namespace algebra {
-template class RPY_DLL_EXPORT Basis<TensorBasisInterface>;
-}
-}// namespace rpy
-
-TensorBasisInterface::~TensorBasisInterface() = default;

--- a/core/include/roughpy/core/macros.h
+++ b/core/include/roughpy/core/macros.h
@@ -275,7 +275,7 @@
 #endif
 
 // Sanitizer supports
-#ifdef RPY_CLANG
+#if defined(RPY_CLANG) || defined(RPY_GCC)
 #  define RPY_NO_UBSAN __attribute__((no_sanitize("undefined")))
 #else
 #  define RPY_NO_UBSAN


### PR DESCRIPTION
Simplified the composition of the basis class and interface, fixing one instance of undefined behaviour. Also fixed another instance of UB (though probably fine, downcasting to a guaranteed intermediate interface should be OK) by moving the access interface to be a base of the storage model class and performing a side cast instead. 