### PR TITLE
Added RPY_NO_RETURN attribute to throw_exception

### DIFF
--- a/core/include/roughpy/core/check.h
+++ b/core/include/roughpy/core/check.h
@@ -26,7 +26,7 @@
 namespace rpy::errors {
 
 template <typename E>
-RPY_LOCAL
+RPY_NO_RETURN
 void throw_exception(
         std::string_view user_msg,
         const char* filename,

--- a/platform/src/errors.cpp
+++ b/platform/src/errors.cpp
@@ -10,33 +10,34 @@
 namespace rpy::errors {
 
 
-template
-ROUGHPY_PLATFORM_EXPORT void throw_exception<std::runtime_error>(std::string_view user_msg,
-  const char* filename,
-  int lineno,
-  const char* func
-);
-
-template ROUGHPY_PLATFORM_EXPORT void throw_exception<std::logic_error>(std::string_view user_msg,
-  const char* filename,
-  int lineno,
-  const char* func);
-
-template ROUGHPY_PLATFORM_EXPORT void throw_exception<std::invalid_argument>(std::string_view user_msg,
-  const char* filename,
-  int lineno,
-  const char* func);
-
-template ROUGHPY_PLATFORM_EXPORT void throw_exception<std::domain_error>(std::string_view user_msg,
-  const char* filename,
-  int lineno,
-  const char* func);
-
-template ROUGHPY_PLATFORM_EXPORT void throw_exception<std::out_of_range>(std::string_view user_msg,
-  const char* filename,
-  int lineno,
-  const char* func);
-
+// template
+// RPY_NO_RETURN  void throw_exception<std::runtime_error>(std::string_view user_msg,
+//   const char* filename,
+//   int lineno,
+//   const char* func
+// );
+//
+// template
+// RPY_NO_RETURN void throw_exception<std::logic_error>(std::string_view user_msg,
+//   const char* filename,
+//   int lineno,
+//   const char* func) ;
+//
+// template RPY_NO_RETURN void throw_exception<std::invalid_argument>(std::string_view user_msg,
+//   const char* filename,
+//   int lineno,
+//   const char* func);
+//
+// template RPY_NO_RETURN void throw_exception<std::domain_error>(std::string_view user_msg,
+//   const char* filename,
+//   int lineno,
+//   const char* func);
+//
+// template RPY_NO_RETURN void throw_exception<std::out_of_range>(std::string_view user_msg,
+//   const char* filename,
+//   int lineno,
+//   const char* func);
+//
 
 
 }


### PR DESCRIPTION
The throw_exception function had its [[noreturn]] attribute removed, which lead to a number of compiler warnings about non-returning functions after a throw.