### PR TITLE
Add missing return statement in main.cpp

### DIFF
--- a/testing/src/main.cpp
+++ b/testing/src/main.cpp
@@ -55,4 +55,5 @@ int main(int argc, char** argv)
     _CrtSetReportMode(_CRT_ERROR, error_mode);
     _CrtSetReportMode(_CRT_ASSERT, assert_mode);
 #endif
+    return result;
 }


### PR DESCRIPTION
The function was missing a return statement, which could lead to undefined behavior. This change ensures the function returns the intended result consistently.