### PR TITLE
Feature small objects

### DIFF
--- a/platform/include/roughpy/platform/alloc.h
+++ b/platform/include/roughpy/platform/alloc.h
@@ -11,12 +11,32 @@
 #include "roughpy/platform/roughpy_platform_export.h"
 
 namespace rpy::mem {
-RPY_NO_DISCARD ROUGHPY_PLATFORM_EXPORT void* aligned_alloc(size_t alignment, size_t size);
-
-ROUGHPY_PLATFORM_EXPORT void aligned_free(void* ptr);
 
 
+// 4K is a typical page size most operating systems
+inline constexpr size_t small_chunk_size = 4096;
+inline constexpr size_t small_block_size = 64;
+inline constexpr size_t small_blocks_per_chunk = small_chunk_size / small_block_size;
 
-}
+RPY_NO_DISCARD ROUGHPY_PLATFORM_EXPORT void*
+aligned_alloc(size_t alignment, size_t size) noexcept;
 
-#endif //ALLOC_H
+ROUGHPY_PLATFORM_EXPORT void aligned_free(void* ptr, size_t size=0) noexcept;
+
+RPY_NO_DISCARD ROUGHPY_PLATFORM_EXPORT
+void* small_object_alloc(size_t size);
+
+ROUGHPY_PLATFORM_EXPORT
+void small_object_free(void* ptr, size_t size);
+
+
+class ROUGHPY_PLATFORM_EXPORT SmallObjectBase
+{
+public:
+    void* operator new(size_t size);
+    void operator delete(void* object, size_t size);
+};
+
+}// namespace rpy::mem
+
+#endif// ALLOC_H

--- a/platform/include/roughpy/platform/alloc.h
+++ b/platform/include/roughpy/platform/alloc.h
@@ -5,7 +5,9 @@
 #ifndef ALLOC_H
 #define ALLOC_H
 
+#include "roughpy/core/debug_assertion.h"
 #include "roughpy/core/macros.h"
+#include "roughpy/core/traits.h"
 #include "roughpy/core/types.h"
 
 #include "roughpy/platform/roughpy_platform_export.h"
@@ -18,24 +20,109 @@ inline constexpr size_t small_chunk_size = 4096;
 inline constexpr size_t small_block_size = 64;
 inline constexpr size_t small_blocks_per_chunk = small_chunk_size / small_block_size;
 
+/**
+ * @brief Allocates a block of aligned memory.
+ *
+ * This function allocates a block of memory of the specified size with the
+ * specified alignment. The alignment must be a power of two, and the size must
+ * be a multiple of the alignment.
+ *
+ * @param alignment The required alignment of the allocated memory block.
+ * @param size The size of the memory block to allocate, in bytes.
+ * @return A pointer to the allocated memory block, or nullptr if the allocation
+ * fails.
+ */
 RPY_NO_DISCARD ROUGHPY_PLATFORM_EXPORT void*
 aligned_alloc(size_t alignment, size_t size) noexcept;
 
+/**
+ * @brief Frees a block of memory that was aligned and allocated.
+ *
+ * This function releases a block of memory that was previously allocated
+ * with an alignment requirement. It ensures that the memory is properly
+ * deallocated and the alignment constraints are respected.
+ *
+ * @param ptr A pointer to the memory block to be freed.
+ */
 ROUGHPY_PLATFORM_EXPORT void aligned_free(void* ptr, size_t size=0) noexcept;
 
+/**
+ * @brief Allocates memory for a small object.
+ *
+ * This function allocates a block of memory of the specified size
+ * using a synchronized pool resource to optimize allocation for small objects.
+ *
+ * @param size The size of the memory block to allocate, in bytes.
+ * @return A pointer to the allocated memory block.
+ */
 RPY_NO_DISCARD ROUGHPY_PLATFORM_EXPORT
 void* small_object_alloc(size_t size);
 
+/**
+ * @brief Frees memory allocated for a small object.
+ *
+ * This function is responsible for deallocating memory that was previously
+ * allocated for a small object. Ensures that resources used by the object
+ * are properly released.
+ *
+ * @param ptr The pointer to the small object to be freed.
+ */
 ROUGHPY_PLATFORM_EXPORT
 void small_object_free(void* ptr, size_t size);
 
-
+/**
+ * @brief Base class for small object optimization.
+ *
+ * This class provides foundational functionalities for small objects,
+ * including memory management optimizations to reduce heap allocations.
+ * Objects inheriting from this class may benefit from improved performance
+ * for scenarios involving frequent creation and destruction of small objects.
+ */
 class ROUGHPY_PLATFORM_EXPORT SmallObjectBase
 {
 public:
     void* operator new(size_t size);
     void operator delete(void* object, size_t size);
 };
+
+
+/**
+ * @brief Checks if a given value is a valid alignment.
+ *
+ * This function determines whether the specified alignment value is valid.
+ * An alignment value is considered valid if it is a positive integer
+ * and a power of two.
+ *
+ * @param align The alignment value to check.
+ * @tparam I Integral type of the alignment value.
+ * @return True if the alignment value is valid, false otherwise.
+ */
+template <typename I>
+constexpr enable_if_t<is_integral_v<I>, bool> is_alignment(I align)
+{
+    return align > 0 && (align & (align - 1)) == 0;
+}
+
+/**
+ * @brief Checks if a given pointer is aligned to a specified boundary.
+ *
+ * This function determines whether the specified pointer address is aligned
+ * to the given boundary. The boundary must be a power of two.
+ *
+ * @param ptr The pointer to check.
+ * @param alignment The alignment boundary to check against. Must be a power of
+ * two.
+ * @return True if the pointer is aligned to the specified boundary, false
+ * otherwise.
+ */
+inline bool is_pointer_aligned(const volatile void* ptr, std::size_t alignment)
+{
+    // TODO: This function should be constexpr, we need to make use of constexpr
+    //       bit cast or something similar.
+    RPY_DBG_ASSERT(is_alignment(alignment));
+    return reinterpret_cast<std::uintptr_t>(ptr) % alignment == 0;
+}
+
 
 }// namespace rpy::mem
 

--- a/platform/src/CMakeLists.txt
+++ b/platform/src/CMakeLists.txt
@@ -6,3 +6,14 @@ add_subdirectory(devices)
 
 
 
+if (ROUGHPY_BUILD_TESTS)
+
+    add_executable(test_platform
+            test_alloc.cpp
+    )
+
+    target_link_libraries(test_platform PRIVATE RoughPy_Platform GTest::gtest)
+
+    setup_roughpy_cpp_tests(test_platform)
+
+endif()

--- a/platform/src/alloc.cpp
+++ b/platform/src/alloc.cpp
@@ -35,7 +35,7 @@ protected:
     void* do_allocate(size_t bytes, size_t alignment) override
     {
         ignore_unused(alignment);
-        void* ptr = std::aligned_alloc(small_chunk_size, bytes);
+        void* ptr = mem::aligned_alloc(small_chunk_size, bytes);
         if (!ptr) { throw std::bad_alloc(); }
         return ptr;
     }
@@ -43,7 +43,7 @@ protected:
     void do_deallocate(void* p, size_t bytes, size_t alignment) override
     {
         ignore_unused(alignment);
-        return aligned_free(p, bytes);
+        return mem::aligned_free(p, bytes);
     }
 
     bool do_is_equal(const std::pmr::memory_resource& other

--- a/platform/src/alloc.cpp
+++ b/platform/src/alloc.cpp
@@ -12,6 +12,8 @@
 
 using namespace rpy;
 using namespace rpy::mem;
+
+
 void* rpy::mem::aligned_alloc(size_t alignment, size_t size) noexcept
 {
     return boost::alignment::aligned_alloc(alignment, size);

--- a/platform/src/alloc.cpp
+++ b/platform/src/alloc.cpp
@@ -4,15 +4,80 @@
 
 #include "roughpy/platform/alloc.h"
 
-#include <boost/align/aligned_alloc.hpp>
+#include <new>
+#include <memory_resource>
 
+#include <boost/align/aligned_alloc.hpp>
+#include <roughpy/core/traits.h>
+
+using namespace rpy;
 using namespace rpy::mem;
-void* rpy::mem::aligned_alloc(size_t alignment, size_t size)
+void* rpy::mem::aligned_alloc(size_t alignment, size_t size) noexcept
 {
     return boost::alignment::aligned_alloc(alignment, size);
 }
 
-void rpy::mem::aligned_free(void* ptr)
+void rpy::mem::aligned_free(void* ptr, size_t size) noexcept
 {
+    ignore_unused(size);
     boost::alignment::aligned_free(ptr);
+}
+
+
+namespace {
+
+class PageAlignedMemoryResource : public std::pmr::memory_resource
+{
+
+protected:
+    void* do_allocate(size_t bytes, size_t alignment) override
+    {
+        ignore_unused(alignment);
+        void* ptr = std::aligned_alloc(small_chunk_size, bytes);
+        if (!ptr) { throw std::bad_alloc(); }
+        return ptr;
+    }
+
+    void do_deallocate(void* p, size_t bytes, size_t alignment) override
+    {
+        ignore_unused(alignment);
+        return aligned_free(p, bytes);
+    }
+
+    bool do_is_equal(const std::pmr::memory_resource& other
+    ) const noexcept override
+    {
+        return this == &other;
+    }
+
+public:
+    static PageAlignedMemoryResource* get() noexcept
+    {
+        static PageAlignedMemoryResource instance;
+        return &instance;
+    }
+};
+
+std::pmr::synchronized_pool_resource* get_pool() noexcept
+{
+    static std::pmr::synchronized_pool_resource pool (
+        std::pmr::pool_options{ small_blocks_per_chunk, small_block_size },
+        PageAlignedMemoryResource::get());
+    return &pool;
+}
+}
+
+void* rpy::mem::small_object_alloc(size_t size)
+{
+    return get_pool()->allocate(size);
+}
+void rpy::mem::small_object_free(void* ptr, size_t size)
+{
+    get_pool()->deallocate(ptr, size);
+}
+void* SmallObjectBase::operator new(size_t size) {
+    return small_object_alloc(size);
+}
+void SmallObjectBase::operator delete(void* object, size_t size) {
+    small_object_free(object, size);
 }

--- a/platform/src/generics/CMakeLists.txt
+++ b/platform/src/generics/CMakeLists.txt
@@ -35,7 +35,9 @@ target_link_libraries(RoughPy_Platform PRIVATE
 if (ROUGHPY_BUILD_TESTS)
 
 
-    add_executable(test_generics test_value.cpp)
+    add_executable(test_generics
+            test_value.cpp
+    )
 
     target_link_libraries(test_generics PRIVATE RoughPy::Platform GTest::gtest)
 

--- a/platform/src/test_alloc.cpp
+++ b/platform/src/test_alloc.cpp
@@ -1,0 +1,49 @@
+//
+// Created by sam on 19/11/24.
+//
+
+#include <gtest/gtest.h>
+
+
+#include "roughpy/platform/alloc.h"
+
+#include <boost/align/detail/is_alignment.hpp>
+
+using namespace rpy;
+
+
+TEST(TestAlignedAlloc, TestIsAlignmentCorrect)
+{
+    auto alignments[] = { 1, 2, 4, 8, 16, 32, 64,
+                          128, 256, 512, 1024, 2048, 4096};
+    for (size_t align : alignments) {
+        EXPECT_TRUE(mem::is_alignment(align));
+    }
+}
+
+TEST(TestAlignedAlloc, TestIsAlignment0False)
+{
+    EXPECT_FALSE(mem::is_alignment(0));
+}
+
+TEST(TestAlignmentAlloc, TestIsAlignmentNonPow2False)
+{
+    for (size_t nonalign : { 3, 7, 13, 17, 33}) {
+        EXPECT_FALSE(mem::is_alignment(nonalign));
+    }
+}
+
+
+TEST(TestAlignedAlloc, TestAllocCorrectAlignment)
+{
+    void* ptr;
+
+    for (size_t align : { 16, 32, 64, 128}) {
+        ptr = mem::aligned_alloc(align, 32);
+        ASSERT_NE(ptr, nullptr);
+
+        EXPECT_TRUE(mem::is_pointer_aligned(ptr, align));
+        mem::aligned_free(ptr, 32);
+    }
+}
+

--- a/platform/src/test_alloc.cpp
+++ b/platform/src/test_alloc.cpp
@@ -14,7 +14,7 @@ using namespace rpy;
 
 TEST(TestAlignedAlloc, TestIsAlignmentCorrect)
 {
-    auto alignments[] = { 1, 2, 4, 8, 16, 32, 64,
+    size_t alignments[] = { 1, 2, 4, 8, 16, 32, 64,
                           128, 256, 512, 1024, 2048, 4096};
     for (size_t align : alignments) {
         EXPECT_TRUE(mem::is_alignment(align));


### PR DESCRIPTION
Lots of RoughPy objects are small and allocated frequently. We add a pool allocator to the Platform to facilitate this.