### PR TITLE
Fix build time performance improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Setup msbuild on Windows
       if: runner.os == 'Windows'
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
 
     - name: Setup ninja on Windows
       if: runner.os == 'Windows'

--- a/algebra/CMakeLists.txt
+++ b/algebra/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(RoughPy_Algebra
         RoughPy::Platform
         RoughPy::Scalars
         PRIVATE
+        RoughPy::PrecompiledHeaders
         Libalgebra_lite::Libalgebra_lite
 )
 

--- a/intervals/CMakeLists.txt
+++ b/intervals/CMakeLists.txt
@@ -34,7 +34,11 @@ target_include_directories(RoughPy_Intervals PUBLIC
 
 set_target_properties(RoughPy_Intervals PROPERTIES ROUGHPY_COMPONENT Intervals)
 
-target_link_libraries(RoughPy_Intervals PUBLIC RoughPy::Platform)
+target_link_libraries(RoughPy_Intervals
+        PUBLIC
+            RoughPy::Platform
+        PRIVATE
+            RoughPy::PrecompiledHeaders)
 
 # TODO: This should be removed, it's not sensible
 target_compile_definitions(RoughPy_Intervals PRIVATE "RPY_COMPILING_INTERVALS")

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -2,7 +2,52 @@
 
 setup_roughpy_component(Platform)
 
-add_Library(RoughPy_Platform SHARED
+add_library(RoughPy_PrecompiledHeaders INTERFACE)
+add_library(RoughPy::PrecompiledHeaders ALIAS RoughPy_PrecompiledHeaders)
+
+target_link_libraries(RoughPy_PrecompiledHeaders INTERFACE
+        Boost::headers
+        cereal::cereal
+        GMP::GMP
+        Libalgebra_lite::Libalgebra_lite
+)
+
+# Cereal is our current serialization library, and it's dreadful.
+# Parsing these headers and instantiating all the templates therein is
+# easily the biggest contribution to the build type for RoughPy. For this
+# reason, we precompile all the headers for cereal. Ideally, I want a less
+# intensive solution like protobufs or flatbufs, or literally anything else.
+if (NOT ROUGHPY_ENABLE_IWYU)
+target_precompile_headers(RoughPy_PrecompiledHeaders INTERFACE
+        <boost/multiprecision/gmp.hpp>
+        <cereal/cereal.hpp>
+        <cereal/access.hpp>
+        <cereal/specialize.hpp>
+        <cereal/types/base_class.hpp>
+        <cereal/types/optional.hpp>
+        <cereal/types/polymorphic.hpp>
+        <cereal/types/string.hpp>
+        <cereal/types/utility.hpp>
+        <cereal/types/vector.hpp>
+        <cereal/archives/binary.hpp>
+        <cereal/archives/json.hpp>
+        <cereal/archives/portable_binary.hpp>
+        <cereal/archives/xml.hpp>
+        <libalgebra_lite/dense_vector.h>
+        <libalgebra_lite/sparse_vector.h>
+        <libalgebra_lite/basis.h>
+        <libalgebra_lite/algebra.h>
+        <libalgebra_lite/free_tensor.h>
+        <libalgebra_lite/lie.h>
+        <libalgebra_lite/shuffle_tensor.h>
+        <libalgebra_lite/maps.h>
+        <libalgebra_lite/polynomial.h>
+)
+endif()
+
+
+
+add_library(RoughPy_Platform SHARED
         src/configuration.cpp
         #        src/threading/openmp_threading.cpp
         src/errors.cpp
@@ -33,11 +78,10 @@ target_link_libraries(RoughPy_Platform PUBLIC
         RoughPy::Core
         Boost::system
         Boost::url
-        cereal::cereal
         Eigen3::Eigen
-        GMP::GMP
         Libalgebra_lite::Libalgebra_lite
         PRIVATE
+        RoughPy::PrecompiledHeaders
         OpenCL::OpenCL
 )
 
@@ -62,29 +106,7 @@ generate_export_header(RoughPy_Platform
 add_subdirectory(src)
 
 
-# Cereal is our current serialization library, and it's dreadful.
-# Parsing these headers and instantiating all the templates therein is
-# easily the biggest contribution to the build type for RoughPy. For this
-# reason, we precompile all the headers for cereal. Ideally, I want a less
-# intensive solution like protobufs or flatbufs, or literally anything else.
-if (NOT ROUGHPY_ENABLE_IWYU)
-target_precompile_headers(RoughPy_Platform PUBLIC
-        <boost/multiprecision/gmp.hpp>
-        <cereal/cereal.hpp>
-        <cereal/access.hpp>
-        <cereal/specialize.hpp>
-        <cereal/types/base_class.hpp>
-        <cereal/types/optional.hpp>
-        <cereal/types/polymorphic.hpp>
-        <cereal/types/string.hpp>
-        <cereal/types/utility.hpp>
-        <cereal/types/vector.hpp>
-        <cereal/archives/binary.hpp>
-        <cereal/archives/json.hpp>
-        <cereal/archives/portable_binary.hpp>
-        <cereal/archives/xml.hpp>
-)
-endif()
+
 
 
 #

--- a/roughpy/CMakeLists.txt
+++ b/roughpy/CMakeLists.txt
@@ -145,6 +145,8 @@ target_link_libraries(RoughPy_PyModule PRIVATE
         RoughPy::Intervals
         RoughPy::Algebra
         RoughPy::Streams
+        RoughPy::PrecompiledHeaders
+
         #        $<LINK_LIBRARY:WHOLE_ARCHIVE,RoughPy::Streams>
         #        recombine::recombine
 )

--- a/scalars/CMakeLists.txt
+++ b/scalars/CMakeLists.txt
@@ -85,6 +85,7 @@ target_include_directories(RoughPy_Scalars PUBLIC
 target_link_libraries(RoughPy_Scalars PUBLIC
         RoughPy::Platform
         PRIVATE
+        RoughPy::PrecompiledHeaders
         PCGRandom::pcg_random
 )
 

--- a/streams/CMakeLists.txt
+++ b/streams/CMakeLists.txt
@@ -45,6 +45,8 @@ target_link_libraries(RoughPy_Streams PUBLIC
         RoughPy::Algebra
         RoughPy::Intervals
         Boost::url
+        PRIVATE
+            RoughPy::PrecompiledHeaders
 )
 
 set_target_properties(RoughPy_Streams PROPERTIES ROUGHPY_COMPONENT Streams)

--- a/streams/src/schema.cpp
+++ b/streams/src/schema.cpp
@@ -36,7 +36,6 @@
 #include <roughpy/core/macros.h>
 #include <roughpy/core/types.h>      // for basic_string, pair, move
 
-#include <cereal/types/vector.hpp>
 #include <roughpy/streams/schema.h>
 
 using namespace rpy;


### PR DESCRIPTION
The build performance of RougPy is somewhat lacking, especially on Windows where we have to use MSVC (by far the slowest compiler of the three). To combat this, we define a new PrecompiledHeaders target that we can link to that contains all the private headers that we need all over the place in RoughPy that take a lot of time to process. This mainly consists of cereal, which ultimately we want to remove because it is so expensive to instantiate, and a pain to integrate across API boundaries. (Removing this is somewhat down the line.)