### PR TITLE
Fix compiler warnings from unncessary abs

### DIFF
--- a/platform/include/roughpy/generics/comparison_trait.h
+++ b/platform/include/roughpy/generics/comparison_trait.h
@@ -28,7 +28,7 @@ class ConstRef;
  */
 class ROUGHPY_PLATFORM_EXPORT ComparisonTrait : public BuiltinTrait
 {
-    const Type* p_type;
+    RPY_MAYBE_UNUSED const Type* p_type;
 
 protected:
     constexpr explicit ComparisonTrait(const Type* type)

--- a/platform/include/roughpy/generics/number_trait.h
+++ b/platform/include/roughpy/generics/number_trait.h
@@ -252,7 +252,7 @@ struct AbsFunc : NoSuchFunction {
 };
 
 template <typename T>
-struct AbsFunc<T, void_t<decltype(abs(declval<T>()))>> {
+struct AbsFunc<T, void_t<decltype(abs(declval<T>())), enable_if_t<is_signed_v<T>>>> {
     using result_t = decltype(abs(declval<T>()));
 
     static constexpr bool has_function = true;
@@ -262,6 +262,18 @@ struct AbsFunc<T, void_t<decltype(abs(declval<T>()))>> {
         return abs(val);
     }
 };
+
+template <typename T>
+struct AbsFunc<T, enable_if_t<is_unsigned_v<T>>>
+{
+    using result_t = T;
+    static constexpr bool has_function = true;
+    constexpr result_t operator()(const T& val) const
+    {
+        return val;
+    }
+};
+
 
 template <typename T, typename = void>
 struct SqrtFunc : NoSuchFunction {

--- a/roughpy/src/algebra/lie_key.cpp
+++ b/roughpy/src/algebra/lie_key.cpp
@@ -298,8 +298,8 @@ namespace {
 class ToLieKeyHelper
 {
     using container_type = typename python::PyLieKey::container_type;
-    dimn_t size;
-    dimn_t current;
+    RPY_MAYBE_UNUSED dimn_t size;
+    RPY_MAYBE_UNUSED dimn_t current;
     algebra::LieBasis basis;
     deg_t width;
     let_t max_letter = 0;


### PR DESCRIPTION
Clang threw some warnings about using abs on a non-signed type. Created a new specialisation of the implementation that does nothing to unsigned integral types.

Also added [[maybe_unused]] to a couple of private class members that are currently unused, but need to be there.
