### PR TITLE
Feature parse value from string

### DIFF
--- a/platform/include/roughpy/generics/type.h
+++ b/platform/include/roughpy/generics/type.h
@@ -233,7 +233,7 @@ protected:
 
 public:
 
-    virtual bool parse_from_string(void* data, string_view str) const noexcept = 0;
+    virtual bool parse_from_string(void* data, string_view str) const noexcept;
 
     /**
      * @brief Abstract function for copying or moving a block of memory.

--- a/platform/include/roughpy/generics/type.h
+++ b/platform/include/roughpy/generics/type.h
@@ -232,6 +232,9 @@ protected:
     virtual void free_object(void*) const = 0;
 
 public:
+
+    virtual bool parse_from_string(void* data, string_view str) const noexcept = 0;
+
     /**
      * @brief Abstract function for copying or moving a block of memory.
      *

--- a/platform/include/roughpy/generics/values.h
+++ b/platform/include/roughpy/generics/values.h
@@ -338,6 +338,8 @@ public:
                     && !is_same_v<decay_t<T>, const Type*>>>
     explicit Value(T&& value);
 
+    static Value from_string(TypePtr type, string_view data);
+
     ~Value();
 
     // The semantics of copy assignment are different depending on whether the

--- a/platform/include/roughpy/generics/values.h
+++ b/platform/include/roughpy/generics/values.h
@@ -325,6 +325,8 @@ public:
     // Construct a zero object if this is valid
     explicit Value(TypePtr type, const void* data = nullptr);
 
+    explicit Value(TypePtr type, string_view data);
+
     // Copy a value from an existing reference
     explicit Value(ConstRef other);
 

--- a/platform/src/generics/builtin_types/builtin_type.h
+++ b/platform/src/generics/builtin_types/builtin_type.h
@@ -60,6 +60,7 @@ protected:
 public:
     RPY_NO_DISCARD string_view id() const noexcept override;
 
+    bool parse_from_string(void* data, string_view str) const noexcept override;
     void copy_or_move(void* dst, const void* src, size_t count, bool move)
             const noexcept override;
     RPY_NO_DISCARD std::unique_ptr<const ConversionTrait>

--- a/platform/src/generics/builtin_types/builtin_type_methods.h
+++ b/platform/src/generics/builtin_types/builtin_type_methods.h
@@ -8,6 +8,7 @@
 #include "builtin_type.h"
 
 #include <algorithm>
+#include <charconv>
 
 
 #include "roughpy/core/check.h"
@@ -45,6 +46,35 @@ bool BuiltinTypeBase<T>::dec_ref() const noexcept
     // return false so it is never destroyed
     return false;
 }
+
+
+template <typename T>
+bool BuiltinTypeBase<T>::parse_from_string(
+        void* data,
+        string_view str
+) const noexcept
+{
+    RPY_DBG_ASSERT_NE(data, nullptr);
+
+    T value;
+
+    const auto* begin = str.data();
+    const auto* end = str.data() + str.size();
+
+    auto result = std::from_chars(begin, end, value);
+
+    if (result.ec == std::errc::invalid_argument) {
+        return false;
+    }
+
+    if (result.ptr != end) {
+        return false;
+    }
+
+    *static_cast<T*>(data) = std::move(value);
+    return true;
+}
+
 
 template <typename T>
 void* BuiltinTypeBase<T>::allocate_object() const

--- a/platform/src/generics/builtin_types/test_double_type.cpp
+++ b/platform/src/generics/builtin_types/test_double_type.cpp
@@ -44,7 +44,30 @@ TEST(TestDoubleType, TestHash)
     for (double val : {1., -2., 3.141592653589793, -2.7182818284598}) {
         EXPECT_EQ(type->hash_of(&val), hasher(val));
     }
+}
 
+TEST(TestDoubleType, TestParseFromStringValidString)
+{
+    const auto type = get_type<double>();
+
+    string_view str = "3.141592653589793";
+    double value;
+    auto result = type->parse_from_string(&value, str);
+
+    ASSERT_TRUE(result);
+    EXPECT_EQ(value, 3.141592653589793);
+
+}
+
+TEST(TestDoubleType, TestParseFromStringInvalidString)
+{
+    const auto type = get_type<double>();
+    double value;
+
+    string_view str = "bad value";
+    auto result = type->parse_from_string(&value, str);
+
+    EXPECT_FALSE(result);
 }
 
 /******************************************************************************

--- a/platform/src/generics/builtin_types/test_float_type.cpp
+++ b/platform/src/generics/builtin_types/test_float_type.cpp
@@ -42,6 +42,29 @@ TEST(TestFloatType, TestHash)
         EXPECT_EQ(type->hash_of(&val), hasher(val));
     }
 }
+TEST(TestFloatType, ParseFromStringValidString)
+{
+    const auto type = get_type<float>();
+
+    string_view str = "3.141592653589793";
+    float value;
+    auto result = type->parse_from_string(&value, str);
+
+    ASSERT_TRUE(result);
+    EXPECT_EQ(value, 3.141592653589793f);
+
+}
+
+TEST(TestFloatType, TestParseFromStringInvalidString)
+{
+    const auto type = get_type<float>();
+    float value;
+
+    string_view str = "bad value";
+    auto result = type->parse_from_string(&value, str);
+
+    EXPECT_FALSE(result);
+}
 
 /******************************************************************************
  *                                Comparison                                  *

--- a/platform/src/generics/test_value.cpp
+++ b/platform/src/generics/test_value.cpp
@@ -14,6 +14,12 @@ using namespace rpy;
 using namespace rpy::generics;
 
 
+TEST(TestValue, TestConstructFromString)
+{
+    Value v(get_type<double>(), string_view("3.1415"));
+
+    EXPECT_EQ(v, Value(3.1415));
+}
 
 
 TEST(TestValue, TestAddInplace)

--- a/platform/src/generics/type.cpp
+++ b/platform/src/generics/type.cpp
@@ -30,6 +30,10 @@ intptr_t Type::ref_count() const noexcept
     return this->m_rc.load(std::memory_order_acquire);
 }
 
+bool Type::parse_from_string(void* data, string_view str) const noexcept
+{
+    return false;
+}
 std::unique_ptr<const ConversionTrait> Type::convert_to(const Type& type
 ) const noexcept
 {

--- a/platform/src/generics/value.cpp
+++ b/platform/src/generics/value.cpp
@@ -203,3 +203,7 @@ Value& Value::operator=(ConstRef other)
     return *this;
 }
 
+Value Value::from_string(TypePtr type, string_view str)
+{
+    return Value(std::move(type), str);
+}

--- a/platform/src/generics/value.cpp
+++ b/platform/src/generics/value.cpp
@@ -107,6 +107,17 @@ Value::Value(TypePtr type, const void* data)
     }
 }
 
+Value::Value(TypePtr type, string_view str_data)
+    : p_type(std::move(type))
+{
+    RPY_DBG_ASSERT(p_type != nullptr);
+    ensure_constructed(type.get());
+    if (!p_type->parse_from_string(data(), str_data))
+    {
+        RPY_THROW(std::invalid_argument, "cannot parse string");
+    }
+}
+
 Value::Value(ConstRef other)
     : p_type(&other.type())
 {


### PR DESCRIPTION
As we shift to a "hidden implementation" model for the more complicated scalar types like rationals and a poly rationals, we need a robust means for users to actually construct and use these types. One of the easiest means will be to have a parser that can parse a string into a value (e.g. `"{ 1(x0) 1(x2) }"` would parse to a polynomial whose string representation is the given. 

This PR adds the interface to the Type class and to the Value type that allows for this.