### PR TITLE
Overhaul polynomial type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,8 @@ find_package(PCGRandom REQUIRED)
 find_package(GMP REQUIRED)
 find_package(MPFR REQUIRED)
 find_package(range-v3 CONFIG REQUIRED)
+find_package(ctre CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
 
 message(STATUS "Target architecture ${RPY_ARCH}")
 

--- a/platform/include/roughpy/generics/type.h
+++ b/platform/include/roughpy/generics/type.h
@@ -30,18 +30,19 @@ namespace rpy::generics {
  * includes methods and attributes which can be leveraged to manage and
  * manipulate these properties efficiently and effectively.
  */
-struct BasicProperties {
-    bool standard_layout : 1;
-    bool trivially_copyable : 1;
-    bool trivially_constructible : 1;
-    bool trivially_default_constructible : 1;
-    bool trivially_copy_constructible : 1;
-    bool trivially_copy_assignable : 1;
-    bool trivially_destructible : 1;
-    bool polymorphic : 1;
-    bool is_signed : 1;
-    bool is_floating_point : 1;
-    bool is_integral : 1;
+struct BasicProperties
+{
+    bool standard_layout: 1;
+    bool trivially_copyable: 1;
+    bool trivially_constructible: 1;
+    bool trivially_default_constructible: 1;
+    bool trivially_copy_constructible: 1;
+    bool trivially_copy_assignable: 1;
+    bool trivially_destructible: 1;
+    bool polymorphic: 1;
+    bool is_signed: 1;
+    bool is_floating_point: 1;
+    bool is_integral: 1;
 };
 
 template <typename T>
@@ -60,6 +61,7 @@ constexpr BasicProperties basic_properties_of() noexcept;
 
 template <typename T>
 TypePtr get_type() noexcept;
+
 //{
 //    static_assert(false, "There is no Type associated with T");
 //    RPY_UNREACHABLE_RETURN(nullptr);
@@ -78,7 +80,6 @@ class ROUGHPY_PLATFORM_EXPORT Type : public mem::PolymorphicRefCounted
     friend class Value;
 
 public:
-
     /**
      * @brief Returns the type information of the current instance.
      *
@@ -164,7 +165,6 @@ protected:
     virtual void free_object(void* ptr) const = 0;
 
 public:
-
     virtual bool parse_from_string(void* data, string_view str) const noexcept;
 
     /**
@@ -183,7 +183,7 @@ public:
      */
     virtual void
     copy_or_move(void* dst, const void* src, size_t count, bool move) const
-            = 0;
+    = 0;
 
     virtual void
     destroy_range(void* data, size_t count) const = 0;
@@ -273,10 +273,7 @@ public:
      *
      * @return A TypePtr representing the specific type.
      */
-    static TypePtr of() noexcept
-    {
-        return get_type<decay_t<T>>();
-    }
+    static TypePtr of() noexcept { return get_type<decay_t<T> >(); }
 
 };
 
@@ -314,8 +311,8 @@ const BuiltinTypes& get_builtin_types() noexcept;
 class ROUGHPY_PLATFORM_EXPORT MultiPrecisionTypes
 {
     MultiPrecisionTypes();
-public:
 
+public:
     TypePtr integer_type;
     TypePtr rational_type;
 
@@ -326,6 +323,9 @@ public:
     static const MultiPrecisionTypes& get() noexcept;
 };
 
+RPY_NO_DISCARD
+ROUGHPY_PLATFORM_EXPORT
+TypePtr get_polynomial_type() noexcept;
 
 
 template <typename T>
@@ -338,18 +338,18 @@ constexpr BasicProperties basic_properties_of() noexcept
 {
     using base_t = remove_cvref_t<T>;
     return {
-        is_standard_layout_v<base_t>,
-        is_trivially_copyable_v<base_t>,
-        is_trivially_constructible_v<base_t>,
-        is_trivially_default_constructible_v<base_t>,
-        is_trivially_copy_constructible_v<base_t>,
-        is_trivially_copy_assignable_v<base_t>,
-        is_trivially_destructible_v<base_t>,
-        is_polymorphic_v<base_t>,
-        is_signed_v<base_t>,
-        is_floating_point_v<base_t>,
-        is_integral_v<base_t>,
-};
+            is_standard_layout_v<base_t>,
+            is_trivially_copyable_v<base_t>,
+            is_trivially_constructible_v<base_t>,
+            is_trivially_default_constructible_v<base_t>,
+            is_trivially_copy_constructible_v<base_t>,
+            is_trivially_copy_assignable_v<base_t>,
+            is_trivially_destructible_v<base_t>,
+            is_polymorphic_v<base_t>,
+            is_signed_v<base_t>,
+            is_floating_point_v<base_t>,
+            is_integral_v<base_t>,
+    };
 }
 
 /**
@@ -366,7 +366,9 @@ constexpr BasicProperties basic_properties_of() noexcept
  * @return The promoted type based on the provided `lhs` and `rhs` types.
  * If neither type can be promoted to the other, `nullptr` is returned.
  */
-RPY_NO_DISCARD TypePtr ROUGHPY_PLATFORM_EXPORT compute_promotion(const Type* lhs, const Type* rhs) noexcept;
+RPY_NO_DISCARD TypePtr ROUGHPY_PLATFORM_EXPORT compute_promotion(
+    const Type* lhs,
+    const Type* rhs) noexcept;
 
 /**
  * @brief Computes the hash value of a given Type object.
@@ -386,16 +388,10 @@ inline hash_t hash_value(const Type& value) noexcept
 }
 
 RPY_NO_DISCARD constexpr bool
-operator==(const Type& lhs, const Type& rhs) noexcept
-{
-    return &lhs == &rhs;
-}
+operator==(const Type& lhs, const Type& rhs) noexcept { return &lhs == &rhs; }
 
 RPY_NO_DISCARD constexpr bool
-operator!=(const Type& lhs, const Type& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
+operator!=(const Type& lhs, const Type& rhs) noexcept { return !(lhs == rhs); }
 
 /**
  * @brief Retrieves the size of an object of the specified type.
@@ -409,7 +405,6 @@ operator!=(const Type& lhs, const Type& rhs) noexcept
 inline size_t size_of(const Type& type) noexcept { return type.object_size(); }
 
 namespace concepts {
-
 
 
 /**
@@ -548,7 +543,6 @@ inline bool is_arithmetic(Type const& type)
 }
 
 }// namespace concepts
-
 
 
 template <>

--- a/platform/src/generics/CMakeLists.txt
+++ b/platform/src/generics/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(RoughPy_Platform PRIVATE
         conversion_trait.cpp
         multiprecision_types.cpp
         number_trait.cpp
+        polynomial_types.cpp
         type.cpp
         type_builtin.cpp
         type_promotion.cpp

--- a/platform/src/generics/CMakeLists.txt
+++ b/platform/src/generics/CMakeLists.txt
@@ -28,6 +28,8 @@ target_sources(RoughPy_Platform PRIVATE
 
 add_subdirectory(builtin_types)
 
+add_subdirectory(polynomial_type)
+
 target_link_libraries(RoughPy_Platform PRIVATE
         RoughPy_Generics_BuiltinType
 )

--- a/platform/src/generics/multiprecision_types/mpq_string_rep.h
+++ b/platform/src/generics/multiprecision_types/mpq_string_rep.h
@@ -1,0 +1,32 @@
+//
+// Created by sam on 26/11/24.
+//
+
+#ifndef ROUGHPY_GENERICS_INTERNAL_MPQ_STRING_REP_H
+#define ROUGHPY_GENERICS_INTERNAL_MPQ_STRING_REP_H
+
+
+#include <gmp.h>
+
+#include "roughpy/core/types.h"
+
+
+namespace rpy::generics {
+
+inline void mpq_display_rep(string& buffer, mpq_srcptr value) noexcept
+{
+    // The GMP docs describe the size of a mpq string representation in the
+    // documentation https://gmplib.org/manual/Rational-Conversions
+    auto num_size = mpz_sizeinbase(mpq_numref(value), 10);
+    auto denom_size = mpz_sizeinbase(mpq_denref(value), 10);
+    buffer.resize(num_size + denom_size + 3);
+
+    mpq_get_str(buffer.data(), 10, value);
+
+    // The buffer has at least one null byte at the end, cut these off
+    while (buffer.back() == '\0') { buffer.pop_back(); }
+}
+
+}
+
+#endif //ROUGHPY_GENERICS_INTERNAL_MPQ_STRING_REP_H

--- a/platform/src/generics/multiprecision_types/mpz_hash.h
+++ b/platform/src/generics/multiprecision_types/mpz_hash.h
@@ -24,6 +24,15 @@ inline hash_t mpz_hash(mpz_srcptr integer) noexcept
     return result;
 }
 
+inline hash_t mpq_hash(mpq_srcptr integer) noexcept
+{
+    auto num_hash = mpz_hash(mpq_numref(integer));
+    const auto denom_hash = mpz_hash(mpq_denref(integer));
+
+    hash_combine(num_hash, denom_hash);
+    return num_hash;
+}
+
 
 }
 

--- a/platform/src/generics/multiprecision_types/rational_type.cpp
+++ b/platform/src/generics/multiprecision_types/rational_type.cpp
@@ -11,6 +11,7 @@
 #include <roughpy/platform/alloc.h>
 
 #include "mpz_hash.h"
+#include "mpq_string_rep.h"
 
 using namespace rpy;
 using namespace rpy::generics;
@@ -145,18 +146,9 @@ RationalType::display(std::ostream& os, const void* value) const
 
     const auto* rat = static_cast<mpq_srcptr>(value);
 
-    // The GMP docs describe the size of a mpq string representation in the
-    // documentation https://gmplib.org/manual/Rational-Conversions
-    auto num_size = mpz_sizeinbase(mpq_numref(rat), 10);
-    auto denom_size = mpz_sizeinbase(mpq_denref(rat), 10);
-
     string buffer;
-    buffer.resize(num_size + denom_size + 3);
+    mpq_display_rep(buffer, rat);
 
-    mpq_get_str(buffer.data(), 10, rat);
-
-    // The buffer has at least one null byte at the end, cut these off
-    while (buffer.back() == '\0') { buffer.pop_back(); }
     return os << buffer;
 }
 
@@ -165,11 +157,7 @@ hash_t RationalType::hash_of(const void* value) const noexcept
     if (value == nullptr) { return 0; }
 
     auto* rat = static_cast<mpq_srcptr>(value);
-    auto num_hash = mpz_hash(mpq_numref(rat));
-    const auto denom_hash = mpz_hash(mpq_denref(rat));
-
-    hash_combine(num_hash, denom_hash);
-    return num_hash;
+    return mpq_hash(rat);
 }
 
 TypePtr RationalType::get() noexcept

--- a/platform/src/generics/polynomial_type/CMakeLists.txt
+++ b/platform/src/generics/polynomial_type/CMakeLists.txt
@@ -11,3 +11,31 @@ target_sources(RoughPy_Platform PRIVATE
         polynomial.h
 )
 
+
+if (ROUGHPY_BUILD_TESTS)
+
+    add_executable(test_polynomial
+        test_monomial.cpp
+        indeterminate.cpp
+        indeterminate.h
+        monomial.cpp
+        monomial.h
+        polynomial.cpp
+        polynomial.h
+    )
+
+    target_include_directories(test_polynomial PRIVATE
+            ${ROUGHPY_PLATFORM_SOURCE}
+    )
+
+    target_link_libraries(test_polynomial PRIVATE
+            RoughPy::Core
+            Boost::headers
+            GMP::GMP
+            GTest::gtest
+    )
+
+    setup_roughpy_cpp_tests(test_polynomial)
+
+
+endif()

--- a/platform/src/generics/polynomial_type/CMakeLists.txt
+++ b/platform/src/generics/polynomial_type/CMakeLists.txt
@@ -7,5 +7,7 @@ target_sources(RoughPy_Platform PRIVATE
     indeterminate.cpp
     monomial.cpp
     monomial.h
+        polynomial.cpp
+        polynomial.h
 )
 

--- a/platform/src/generics/polynomial_type/CMakeLists.txt
+++ b/platform/src/generics/polynomial_type/CMakeLists.txt
@@ -15,7 +15,9 @@ target_sources(RoughPy_Platform PRIVATE
 if (ROUGHPY_BUILD_TESTS)
 
     add_executable(test_polynomial
+        test_indeterminate.cpp
         test_monomial.cpp
+        test_polynomial.cpp
         indeterminate.cpp
         indeterminate.h
         monomial.cpp

--- a/platform/src/generics/polynomial_type/CMakeLists.txt
+++ b/platform/src/generics/polynomial_type/CMakeLists.txt
@@ -19,6 +19,8 @@ target_sources(RoughPy_Platform PRIVATE
         polynomial_type.h
 )
 
+target_link_libraries(RoughPy_Platform PRIVATE
+    ctre::ctre)
 
 if (ROUGHPY_BUILD_TESTS)
 

--- a/platform/src/generics/polynomial_type/CMakeLists.txt
+++ b/platform/src/generics/polynomial_type/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+
+
+
+target_sources(RoughPy_Platform PRIVATE
+    indeterminate.h
+    indeterminate.cpp
+    monomial.cpp
+    monomial.h
+)
+

--- a/platform/src/generics/polynomial_type/CMakeLists.txt
+++ b/platform/src/generics/polynomial_type/CMakeLists.txt
@@ -3,27 +3,35 @@
 
 
 target_sources(RoughPy_Platform PRIVATE
-    indeterminate.h
-    indeterminate.cpp
-    monomial.cpp
-    monomial.h
+        indeterminate.h
+        indeterminate.cpp
+        monomial.cpp
+        monomial.h
         polynomial.cpp
         polynomial.h
+        polynomial_arithmetic.cpp
+        polynomial_arithmetic.h
+        polynomial_comparison.cpp
+        polynomial_comparison.h
+        polynomial_number.cpp
+        polynomial_number.h
+        polynomial_type.cpp
+        polynomial_type.h
 )
 
 
 if (ROUGHPY_BUILD_TESTS)
 
     add_executable(test_polynomial
-        test_indeterminate.cpp
-        test_monomial.cpp
-        test_polynomial.cpp
-        indeterminate.cpp
-        indeterminate.h
-        monomial.cpp
-        monomial.h
-        polynomial.cpp
-        polynomial.h
+            test_indeterminate.cpp
+            test_monomial.cpp
+            test_polynomial.cpp
+            indeterminate.cpp
+            indeterminate.h
+            monomial.cpp
+            monomial.h
+            polynomial.cpp
+            polynomial.h
     )
 
     target_include_directories(test_polynomial PRIVATE
@@ -39,5 +47,12 @@ if (ROUGHPY_BUILD_TESTS)
 
     setup_roughpy_cpp_tests(test_polynomial)
 
+    add_executable(test_polynomial_type
+            test_polynomial_type.cpp
+    )
 
-endif()
+    target_link_libraries(test_polynomial_type PRIVATE RoughPy::Platform GTest::gtest)
+
+    setup_roughpy_cpp_tests(test_polynomial_type)
+
+endif ()

--- a/platform/src/generics/polynomial_type/indeterminate.cpp
+++ b/platform/src/generics/polynomial_type/indeterminate.cpp
@@ -10,6 +10,6 @@ using namespace rpy;
 using namespace rpy::generics;
 
 
-std::ostream& operator<<(std::ostream& os, const Indeterminate& value) {
+std::ostream& generics::operator<<(std::ostream& os, const Indeterminate& value) {
     return os << value.prefix() << value.index();
 }

--- a/platform/src/generics/polynomial_type/indeterminate.cpp
+++ b/platform/src/generics/polynomial_type/indeterminate.cpp
@@ -1,0 +1,15 @@
+//
+// Created by sam on 26/11/24.
+//
+
+#include "indeterminate.h"
+
+#include <ostream>
+
+using namespace rpy;
+using namespace rpy::generics;
+
+
+std::ostream& operator<<(std::ostream& os, const Indeterminate& value) {
+    return os << value.prefix() << value.index();
+}

--- a/platform/src/generics/polynomial_type/indeterminate.h
+++ b/platform/src/generics/polynomial_type/indeterminate.h
@@ -42,10 +42,14 @@ public:
     static constexpr base_type integer_mask
             = (static_cast<base_type>(1) << char_shift) - 1;
 
-    constexpr Indeterminate() noexcept : m_data(0) {}
+    static constexpr base_type default_value =
+        static_cast<base_type>('x') << char_shift;
+
+
+    constexpr Indeterminate() noexcept : m_data(default_value) {}
 
     explicit Indeterminate(base_type integer) noexcept
-        : m_data(integer & integer_mask)
+        : m_data(default_value | (integer & integer_mask))
     {
         RPY_DBG_ASSERT_LE(integer, integer_mask);
     }

--- a/platform/src/generics/polynomial_type/indeterminate.h
+++ b/platform/src/generics/polynomial_type/indeterminate.h
@@ -1,0 +1,140 @@
+//
+// Created by sam on 26/11/24.
+//
+
+#ifndef ROUGHPY_GENERICS_INTERNAL_INDETERMINATE_H
+#define ROUGHPY_GENERICS_INTERNAL_INDETERMINATE_H
+
+#include <cstring>
+#include <iosfwd>
+
+#include "roughpy/core/check.h"
+#include "roughpy/core/debug_assertion.h"
+#include "roughpy/core/hash.h"
+#include "roughpy/core/helpers.h"
+#include "roughpy/core/traits.h"
+#include "roughpy/core/types.h"
+
+#include "roughpy/platform/roughpy_platform_export.h"
+
+namespace rpy::generics {
+
+class Indeterminate
+{
+    using base_type = int64_t;
+    base_type m_data;
+
+public:
+    static constexpr size_t data_size = sizeof(base_type);
+    static constexpr size_t num_chars = 1;
+
+    static_assert(
+            num_chars >= 1,
+            "sanity check failed: at least one prefix character"
+    );
+    static_assert(
+            data_size > num_chars,
+            "sanity check failed, base type be large than num_chars bytes"
+    );
+
+    static constexpr int char_shift
+            = static_cast<int>(data_size - num_chars) * 8;
+
+    static constexpr base_type integer_mask
+            = (static_cast<base_type>(1) << char_shift) - 1;
+
+    constexpr Indeterminate() noexcept : m_data(0) {}
+
+    constexpr explicit Indeterminate(base_type integer) noexcept
+        : m_data(integer & integer_mask)
+    {
+        RPY_DBG_ASSERT_LE(integer, integer_mask);
+    }
+
+    constexpr explicit Indeterminate(char prefix, base_type integer) noexcept
+    {
+        RPY_DBG_ASSERT_LE(integer, integer_mask);
+
+        m_data = static_cast<base_type>(prefix) << char_shift;
+        m_data |= (integer & integer_mask);
+    }
+
+    template <size_t N, typename = enable_if_t<(N <= num_chars)>>
+    Indeterminate(char prefix[N], base_type base) noexcept
+    {
+        RPY_DBG_ASSERT_LE(base, integer_mask);
+
+        m_data = 0;
+        std::memcpy(&m_data, prefix, N);
+        m_data <<= char_shift;
+        m_data |= (base & integer_mask);
+    }
+
+    string prefix() const
+    {
+        // This will almost surely never throw because the number of characters
+        // should never exceed the size of the string internal storage
+        string result;
+
+        char tmp_array[num_chars];
+        base_type tmp = m_data >> char_shift;
+        std::memcpy(tmp_array, &tmp, num_chars);
+
+        result.assign(tmp_array, num_chars);
+
+        return result;
+    }
+
+    base_type index() const noexcept { return m_data & (~integer_mask); }
+
+    friend constexpr bool
+    operator==(const Indeterminate& lhs, const Indeterminate& rhs) noexcept
+    {
+        return lhs.m_data == rhs.m_data;
+    }
+
+    friend constexpr bool
+    operator!=(const Indeterminate& lhs, const Indeterminate& rhs) noexcept
+    {
+        return lhs.m_data != rhs.m_data;
+    }
+
+    friend constexpr bool
+    operator <(const Indeterminate& lhs, const Indeterminate& rhs) noexcept
+    {
+        return lhs.m_data < rhs.m_data;
+    }
+
+    friend constexpr bool
+    operator <=(const Indeterminate& lhs, const Indeterminate& rhs) noexcept
+    {
+        return lhs.m_data <= rhs.m_data;
+    }
+
+    friend constexpr bool
+    operator >(const Indeterminate& lhs, const Indeterminate& rhs) noexcept
+    {
+        return lhs.m_data > rhs.m_data;
+    }
+
+    friend constexpr bool
+    operator >=(const Indeterminate& lhs, const Indeterminate& rhs) noexcept
+    {
+        return lhs.m_data >= rhs.m_data;
+    }
+
+    friend hash_t hash_value(const Indeterminate& value) noexcept {
+        Hash<base_type> hasher;
+        return hasher(value.m_data);
+    }
+
+};
+
+std::ostream& operator<<(std::ostream& os, const Indeterminate& value);
+
+
+
+
+};// namespace rpy::generics
+
+#endif// ROUGHPY_GENERICS_INTERNAL_INDETERMINATE_H

--- a/platform/src/generics/polynomial_type/indeterminate.h
+++ b/platform/src/generics/polynomial_type/indeterminate.h
@@ -45,13 +45,13 @@ public:
 
     constexpr Indeterminate() noexcept : m_data(0) {}
 
-    constexpr explicit Indeterminate(base_type integer) noexcept
+    explicit Indeterminate(base_type integer) noexcept
         : m_data(integer & integer_mask)
     {
         RPY_DBG_ASSERT_LE(integer, integer_mask);
     }
 
-    constexpr explicit Indeterminate(char prefix, base_type integer) noexcept
+    explicit Indeterminate(char prefix, base_type integer) noexcept
     {
         RPY_DBG_ASSERT_LE(integer, integer_mask);
 

--- a/platform/src/generics/polynomial_type/indeterminate.h
+++ b/platform/src/generics/polynomial_type/indeterminate.h
@@ -20,7 +20,7 @@ namespace rpy::generics {
 
 class Indeterminate
 {
-    using base_type = int64_t;
+    using base_type = uint64_t;
     base_type m_data;
 
 public:

--- a/platform/src/generics/polynomial_type/indeterminate.h
+++ b/platform/src/generics/polynomial_type/indeterminate.h
@@ -15,7 +15,6 @@
 #include "roughpy/core/traits.h"
 #include "roughpy/core/types.h"
 
-#include "roughpy/platform/roughpy_platform_export.h"
 
 namespace rpy::generics {
 
@@ -85,7 +84,7 @@ public:
         return result;
     }
 
-    base_type index() const noexcept { return m_data & (~integer_mask); }
+    base_type index() const noexcept { return m_data & integer_mask; }
 
     friend constexpr bool
     operator==(const Indeterminate& lhs, const Indeterminate& rhs) noexcept

--- a/platform/src/generics/polynomial_type/monomial.cpp
+++ b/platform/src/generics/polynomial_type/monomial.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <numeric>
 #include <ostream>
 
 #include "roughpy/core/ranges.h"

--- a/platform/src/generics/polynomial_type/monomial.cpp
+++ b/platform/src/generics/polynomial_type/monomial.cpp
@@ -1,4 +1,4 @@
- zr//
+//
 // Created by sam on 26/11/24.
 //
 

--- a/platform/src/generics/polynomial_type/monomial.cpp
+++ b/platform/src/generics/polynomial_type/monomial.cpp
@@ -1,0 +1,9 @@
+//
+// Created by sam on 26/11/24.
+//
+
+#include "monomial.h"
+
+#include <ostream>
+
+

--- a/platform/src/generics/polynomial_type/monomial.cpp
+++ b/platform/src/generics/polynomial_type/monomial.cpp
@@ -4,6 +4,110 @@
 
 #include "monomial.h"
 
+#include <algorithm>
+#include <functional>
 #include <ostream>
 
+#include "roughpy/core/ranges.h"
 
+
+using namespace rpy;
+using namespace rpy::generics;
+
+deg_t Monomial::degree() const noexcept
+{
+    return std::accumulate(m_data.begin(),
+                           m_data.end(),
+                           0,
+                           [](auto acc, const auto& pair) {
+                               return acc + pair.second;
+                           });
+}
+
+
+deg_t Monomial::operator[](Indeterminate indeterminate) const noexcept {
+    auto it = m_data.find(indeterminate);
+    if (it == m_data.end()) { return 0; }
+    return it->second;
+}
+
+Monomial& Monomial::operator*=(const Monomial& rhs)
+{
+    const auto lend = m_data.end();
+    for (const auto& [ind, pow] : rhs) {
+        if (auto it = m_data.find(ind); it != lend) {
+            it->second += pow;
+        } else { m_data.emplace(ind, pow); }
+    }
+    return *this;
+}
+
+Monomial generics::operator*(const Monomial& lhs, const Monomial& rhs)
+{
+    Monomial result(lhs);
+    result *= rhs;
+    return result;
+}
+
+std::ostream& generics::operator<<(std::ostream& os, const Monomial& value)
+{
+    bool first = true;
+    for (const auto& [ind, pow] : value) {
+        if (first) { first = false; } else { os << ' '; }
+        if (pow > 0) {
+            os << ind;
+            if (pow > 1) { os << '^' << pow; }
+        }
+    }
+    return os;
+}
+
+bool generics::operator==(const Monomial& lhs, const Monomial& rhs) noexcept
+{
+    if (lhs.type() != rhs.type()) { return false; }
+
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin());
+}
+
+bool generics::operator<(const Monomial& lhs, const Monomial& rhs) noexcept
+{
+    const auto ldegree = lhs.degree();
+    const auto rdegree = rhs.degree();
+
+    if (ldegree < rdegree) { return true; }
+
+    if (ldegree == rdegree) {
+        return std::lexicographical_compare(lhs.begin(),
+                                            lhs.end(),
+                                            rhs.begin(),
+                                            rhs.end());
+    }
+
+    return false;
+}
+
+bool generics::operator<=(const Monomial& lhs, const Monomial& rhs) noexcept
+{
+    const auto ldegree = lhs.degree();
+    const auto rdegree = rhs.degree();
+
+    if (ldegree < rdegree) { return true; }
+
+    if (ldegree == rdegree) {
+        return std::lexicographical_compare(lhs.begin(),
+                                            lhs.end(),
+                                            rhs.begin(),
+                                            rhs.end(),
+                                            std::less_equal<>());
+    }
+
+    return false;
+}
+
+
+
+hash_t generics::hash_value(const Monomial& value)
+{
+    Hash<Monomial::map_type> hasher;
+    return hasher(value.m_data);
+}

--- a/platform/src/generics/polynomial_type/monomial.cpp
+++ b/platform/src/generics/polynomial_type/monomial.cpp
@@ -1,4 +1,4 @@
-//
+ zr//
 // Created by sam on 26/11/24.
 //
 

--- a/platform/src/generics/polynomial_type/monomial.h
+++ b/platform/src/generics/polynomial_type/monomial.h
@@ -1,0 +1,78 @@
+//
+// Created by sam on 26/11/24.
+//
+
+#ifndef ROUGHPY_GENERICS_INTERNAL_MONOMIAL_H
+#define ROUGHPY_GENERICS_INTERNAL_MONOMIAL_H
+
+#include <functional>
+#include <iosfwd>
+
+#include <boost/container/flat_map.hpp>
+#include <boost/container/small_vector.hpp>
+
+#include "roughpy/core/debug_assertion.h"
+#include "roughpy/core/macros.h"
+#include "roughpy/core/hash.h"
+#include "roughpy/core/types.h"
+
+
+#include "indeterminate.h"
+
+namespace rpy {
+namespace generics {
+
+class Monomial
+{
+    using map_storage_type = boost::container::
+            small_vector<pair<const Indeterminate, deg_t>, 1>;
+    using map_type = boost::container::
+            flat_map<Indeterminate, deg_t, std::less<>, map_storage_type>;
+
+    map_type m_data;
+
+public:
+
+    using iterator = typename map_type::iterator;
+    using const_iterator = typename map_type::const_iterator;
+
+    Monomial() = default;
+
+    explicit Monomial(Indeterminate indeterminate, deg_t degree=1) noexcept
+    {
+        m_data.emplace(indeterminate, degree);
+    }
+
+    template <typename InputIt>
+    explicit Monomial(InputIt begin, InputIt end)
+        : m_data(begin, end)
+    {}
+
+
+    deg_t degree() const noexcept;
+    deg_t type() const noexcept { return m_data.size(); }
+
+    iterator begin() noexcept { return m_data.begin(); }
+    iterator end() noexcept { return m_data.end(); }
+    const_iterator begin() const noexcept { return m_data.begin(); }
+    const_iterator end() const noexcept { return m_data.end(); }
+
+
+    Monomial& operator*=(const Monomial& rhs);
+
+
+    friend hash_t hash_value(const Monomial& value);
+
+};
+
+
+hash_t hash_value(const Monomial& value);
+Monomial operator*(const Monomial& lhs, const Monomial& rhs);
+std::ostream &operator<<(std::ostream &os, const Monomial& value);
+
+
+
+}// namespace generics
+}// namespace rpy
+
+#endif// ROUGHPY_GENERICS_INTERNAL_MONOMIAL_H

--- a/platform/src/generics/polynomial_type/monomial.h
+++ b/platform/src/generics/polynomial_type/monomial.h
@@ -60,6 +60,7 @@ public:
     RPY_NO_DISCARD
     deg_t type() const noexcept { return m_data.size(); }
 
+    void clear() noexcept { m_data.clear(); }
     RPY_NO_DISCARD bool empty() const noexcept { return m_data.empty(); }
 
     RPY_NO_DISCARD
@@ -71,6 +72,11 @@ public:
     RPY_NO_DISCARD
     const_iterator end() const noexcept { return m_data.end(); }
 
+    template <typename... Args>
+    auto emplace(Args&&... args) -> decltype(m_data.emplace(std::forward<Args>(args)...))
+    {
+        return m_data.emplace(std::forward<Args>(args)...);
+    }
 
     RPY_NO_DISCARD
     deg_t operator[](Indeterminate indeterminate) const noexcept;

--- a/platform/src/generics/polynomial_type/monomial.h
+++ b/platform/src/generics/polynomial_type/monomial.h
@@ -44,6 +44,11 @@ public:
         m_data.emplace(std::move(indeterminate), std::move(degree));
     }
 
+    explicit Monomial(char prefix, size_t index, deg_t degree=1) noexcept
+    {
+        m_data.emplace(Indeterminate(prefix, index), std::move(degree));
+    }
+
     template <typename InputIt>
     explicit Monomial(InputIt begin, InputIt end)
         : m_data(begin, end)
@@ -54,6 +59,8 @@ public:
     deg_t degree() const noexcept;
     RPY_NO_DISCARD
     deg_t type() const noexcept { return m_data.size(); }
+
+    RPY_NO_DISCARD bool empty() const noexcept { return m_data.empty(); }
 
     RPY_NO_DISCARD
     iterator begin() noexcept { return m_data.begin(); }

--- a/platform/src/generics/polynomial_type/monomial.h
+++ b/platform/src/generics/polynomial_type/monomial.h
@@ -25,7 +25,7 @@ namespace generics {
 class Monomial
 {
     using map_storage_type = boost::container::
-            small_vector<pair<const Indeterminate, deg_t>, 1>;
+            small_vector<pair<Indeterminate, deg_t>, 1>;
     using map_type = boost::container::
             flat_map<Indeterminate, deg_t, std::less<>, map_storage_type>;
 
@@ -40,7 +40,7 @@ public:
 
     explicit Monomial(Indeterminate indeterminate, deg_t degree=1) noexcept
     {
-        m_data.emplace(indeterminate, degree);
+        m_data.emplace(std::move(indeterminate), std::move(degree));
     }
 
     template <typename InputIt>
@@ -58,10 +58,16 @@ public:
     const_iterator end() const noexcept { return m_data.end(); }
 
 
+    deg_t operator[](Indeterminate indeterminate) const noexcept;
+    deg_t& operator[](Indeterminate indeterminate) noexcept {
+        return m_data[indeterminate];
+    };
+
     Monomial& operator*=(const Monomial& rhs);
 
 
     friend hash_t hash_value(const Monomial& value);
+
 
 };
 
@@ -69,6 +75,26 @@ public:
 hash_t hash_value(const Monomial& value);
 Monomial operator*(const Monomial& lhs, const Monomial& rhs);
 std::ostream &operator<<(std::ostream &os, const Monomial& value);
+
+bool operator==(const Monomial& lhs, const Monomial& rhs) noexcept;
+
+inline bool operator!=(const Monomial& lhs, const Monomial& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+
+bool operator<(const Monomial& lhs, const Monomial& rhs) noexcept;
+bool operator<=(const Monomial& lhs, const Monomial& rhs) noexcept;
+
+inline bool operator>(const Monomial& lhs, const Monomial& rhs) noexcept
+{
+    return !(lhs <= rhs);
+}
+
+inline bool operator>=(const Monomial& lhs, const Monomial& rhs) noexcept
+{
+    return !(lhs < rhs);
+}
 
 
 

--- a/platform/src/generics/polynomial_type/monomial.h
+++ b/platform/src/generics/polynomial_type/monomial.h
@@ -22,6 +22,7 @@
 namespace rpy {
 namespace generics {
 
+
 class Monomial
 {
     using map_storage_type = boost::container::
@@ -74,7 +75,6 @@ public:
     Monomial& operator*=(const Monomial& rhs);
 
 
-    RPY_NO_DISCARD
     friend hash_t hash_value(const Monomial& value);
 
 
@@ -83,6 +83,7 @@ public:
 
 RPY_NO_DISCARD
 hash_t hash_value(const Monomial& value);
+
 RPY_NO_DISCARD
 Monomial operator*(const Monomial& lhs, const Monomial& rhs);
 std::ostream &operator<<(std::ostream &os, const Monomial& value);

--- a/platform/src/generics/polynomial_type/monomial.h
+++ b/platform/src/generics/polynomial_type/monomial.h
@@ -49,16 +49,24 @@ public:
     {}
 
 
+    RPY_NO_DISCARD
     deg_t degree() const noexcept;
+    RPY_NO_DISCARD
     deg_t type() const noexcept { return m_data.size(); }
 
+    RPY_NO_DISCARD
     iterator begin() noexcept { return m_data.begin(); }
+    RPY_NO_DISCARD
     iterator end() noexcept { return m_data.end(); }
+    RPY_NO_DISCARD
     const_iterator begin() const noexcept { return m_data.begin(); }
+    RPY_NO_DISCARD
     const_iterator end() const noexcept { return m_data.end(); }
 
 
+    RPY_NO_DISCARD
     deg_t operator[](Indeterminate indeterminate) const noexcept;
+    RPY_NO_DISCARD
     deg_t& operator[](Indeterminate indeterminate) noexcept {
         return m_data[indeterminate];
     };
@@ -66,31 +74,40 @@ public:
     Monomial& operator*=(const Monomial& rhs);
 
 
+    RPY_NO_DISCARD
     friend hash_t hash_value(const Monomial& value);
 
 
 };
 
 
+RPY_NO_DISCARD
 hash_t hash_value(const Monomial& value);
+RPY_NO_DISCARD
 Monomial operator*(const Monomial& lhs, const Monomial& rhs);
 std::ostream &operator<<(std::ostream &os, const Monomial& value);
 
+RPY_NO_DISCARD
 bool operator==(const Monomial& lhs, const Monomial& rhs) noexcept;
 
+RPY_NO_DISCARD
 inline bool operator!=(const Monomial& lhs, const Monomial& rhs) noexcept
 {
     return !(lhs == rhs);
 }
 
+RPY_NO_DISCARD
 bool operator<(const Monomial& lhs, const Monomial& rhs) noexcept;
+RPY_NO_DISCARD
 bool operator<=(const Monomial& lhs, const Monomial& rhs) noexcept;
 
+RPY_NO_DISCARD
 inline bool operator>(const Monomial& lhs, const Monomial& rhs) noexcept
 {
     return !(lhs <= rhs);
 }
 
+RPY_NO_DISCARD
 inline bool operator>=(const Monomial& lhs, const Monomial& rhs) noexcept
 {
     return !(lhs < rhs);

--- a/platform/src/generics/polynomial_type/polynomial.cpp
+++ b/platform/src/generics/polynomial_type/polynomial.cpp
@@ -92,16 +92,16 @@ void generics::poly_mul_inplace(Polynomial& lhs, const Polynomial& rhs)
     lhs = std::move(result);
 }
 
-void generics::poly_div_inplace(Polynomial& lhs, const dtl::RationalCoeff& rhs)
+void generics::poly_div_inplace(Polynomial& lhs, mpq_srcptr rhs)
 {
     dtl::RationalCoeff zero;
-    if (mpq_equal(rhs.content, zero.content)) {
+    if (mpq_equal(rhs, zero.content)) {
         RPY_THROW(std::domain_error, "division by zero");
     }
 
     for (auto it = lhs.begin(); it != lhs.end(); ++it) {
         // Divide the coefficient of the current term by rhs
-        mpq_div(it->second.content, it->second.content, rhs.content);
+        mpq_div(it->second.content, it->second.content, rhs);
     }
 }
 bool generics::poly_cmp_equal(

--- a/platform/src/generics/polynomial_type/polynomial.cpp
+++ b/platform/src/generics/polynomial_type/polynomial.cpp
@@ -1,0 +1,139 @@
+//
+// Created by sam on 26/11/24.
+//
+
+#include "polynomial.h"
+
+#include "roughpy/core/hash.h"
+
+#include "generics/multiprecision_types/mpq_string_rep.h"
+#include "generics/multiprecision_types/mpz_hash.h"
+
+using namespace rpy;
+using namespace rpy::generics;
+
+void generics::poly_add_inplace(Polynomial& lhs, const Polynomial& rhs)
+{
+    const auto lend = lhs.end();
+    dtl::RationalCoeff zero;
+    for (const auto& [rhs_key, rhs_coeff] : rhs) {
+        auto it = lhs.find(rhs_key);
+        if (it != lend) {
+            // Update existing term
+            mpq_add(it->second.content, it->second.content, rhs_coeff.content);
+            // If the resulting coefficient is zero, remove the term
+            if (mpq_equal(it->second.content, zero.content)) { lhs.erase(it); }
+        } else {
+            // Insert new term
+            lhs.emplace(rhs_key, rhs_coeff);
+        }
+    }
+}
+
+void generics::poly_sub_inplace(Polynomial& lhs, const Polynomial& rhs)
+{
+    const auto lend = lhs.end();
+    dtl::RationalCoeff zero;
+    for (const auto& [rhs_key, rhs_coeff] : rhs) {
+        auto it = lhs.find(rhs_key);
+        if (it != lend) {
+            // Update existing term
+            mpq_sub(it->second.content, it->second.content, rhs_coeff.content);
+            // If the resulting coefficient is zero, remove the term
+            if (mpq_equal(it->second.content, zero.content)) { lhs.erase(it); }
+        } else {
+            // Insert new term
+            auto [pos, inserted] = lhs.emplace(rhs_key, rhs_coeff);
+            RPY_DBG_ASSERT(inserted);
+            mpq_neg(pos->second.content, rhs_coeff.content);
+        }
+    }
+}
+
+void generics::poly_mul_inplace(Polynomial& lhs, const Polynomial& rhs)
+{
+    Polynomial result;
+    dtl::RationalCoeff zero;
+
+    for (const auto& [lhs_key, lhs_coeff] : lhs) {
+        for (const auto& [rhs_key, rhs_coeff] : rhs) {
+            auto new_key = lhs_key * rhs_key;
+
+            dtl::RationalCoeff new_coeff;
+            mpq_mul(new_coeff.content, lhs_coeff.content, rhs_coeff.content);
+
+            auto it = result.find(new_key);
+            if (it != result.end()) {
+                mpq_add(it->second.content,
+                        it->second.content,
+                        new_coeff.content);
+                // If the resulting coefficient is zero, remove the term
+                if (mpq_equal(it->second.content, zero.content)) {
+                    result.erase(it);
+                }
+            } else {
+                // Insert new term
+                result.emplace(new_key, new_coeff);
+            }
+        }
+    }
+
+    // Assign result back to lhs
+    lhs = std::move(result);
+}
+
+void generics::poly_div_inplace(Polynomial& lhs, const dtl::RationalCoeff& rhs)
+{
+    dtl::RationalCoeff zero;
+    if (mpq_equal(rhs.content, zero.content)) {
+        RPY_THROW(std::domain_error, "division by zero");
+    }
+
+    for (auto it = lhs.begin(); it != lhs.end();) {
+        // Divide the coefficient of the current term by rhs
+        mpq_div(it->second.content, it->second.content, rhs.content);
+    }
+}
+bool generics::poly_cmp_equal(
+        const Polynomial& lhs,
+        const Polynomial& rhs
+) noexcept
+{
+    if (lhs.size() != rhs.size()) { return false; }
+
+    return std::equal(
+            lhs.begin(),
+            lhs.end(),
+            rhs.begin(),
+            rhs.end(),
+            [](const auto& lhs_pair, const auto& rhs_pair) {
+                return lhs_pair.first == rhs_pair.first
+                        && mpq_equal(
+                                lhs_pair.second.content,
+                                rhs_pair.second.content
+                        );
+            }
+    );
+}
+
+hash_t generics::hash_value(const Polynomial& value)
+{
+    hash_t hash = 0;
+    for (const auto& [key, coeff] : value) {
+        hash_combine(hash, hash_value(key));
+        hash_combine(hash, mpq_hash(coeff.content));
+    }
+    return hash;
+}
+
+void generics::poly_print(std::ostream& os, const Polynomial& value)
+{
+    os << '{';
+    string tmp_coeff;
+    for (const auto& [key, coeff] : value) {
+        tmp_coeff.clear();
+        mpq_display_rep(tmp_coeff, coeff.content);
+        os << ' ' << tmp_coeff << '(' << key << ')';
+    }
+    os << " }";
+}

--- a/platform/src/generics/polynomial_type/polynomial.h
+++ b/platform/src/generics/polynomial_type/polynomial.h
@@ -84,6 +84,9 @@ public:
 
     using flat_map::flat_map;
 
+    Polynomial(const Polynomial& other) = default;
+    Polynomial(Polynomial&& other) noexcept = default;
+
     explicit Polynomial(dtl::RationalCoeff coeff)
         : flat_map({std::make_pair(Monomial(), std::move(coeff))})
     {}
@@ -138,6 +141,11 @@ inline bool operator==(const Polynomial& lhs, const Polynomial& rhs) noexcept
     return poly_cmp_equal(lhs, rhs);
 }
 
+inline std::ostream& operator<<(std::ostream& os, const Polynomial& value)
+{
+    poly_print(os, value);
+    return os;
+}
 
 }// namespace generics
 

--- a/platform/src/generics/polynomial_type/polynomial.h
+++ b/platform/src/generics/polynomial_type/polynomial.h
@@ -1,0 +1,131 @@
+//
+// Created by sam on 26/11/24.
+//
+
+#ifndef ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_H
+#define ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_H
+
+#include <iosfwd>
+
+#include <boost/container/flat_map.hpp>
+#include <gmp.h>
+
+#include "indeterminate.h"
+#include "monomial.h"
+
+namespace rpy {
+namespace generics {
+
+namespace dtl {
+
+struct RationalCoeff {
+    mpq_t content;
+
+    RationalCoeff() { mpq_init(content); }
+
+    // Copy constructor
+    RationalCoeff(const RationalCoeff& other)
+    {
+        mpq_init(content);
+        mpq_set(content, other.content);
+    }
+
+    // Move constructor
+    RationalCoeff(RationalCoeff&& other) noexcept
+    {
+        mpq_init(content);
+        mpq_swap(content, other.content);
+        mpq_clear(other.content);
+    }
+
+    // Copy assignment operator
+    RationalCoeff& operator=(const RationalCoeff& other)
+    {
+        if (this != &other) { mpq_set(content, other.content); }
+        return *this;
+    }
+
+    // Move assignment operator
+    RationalCoeff& operator=(RationalCoeff&& other) noexcept
+    {
+        if (this != &other) {
+            mpq_swap(content, other.content);
+            mpq_set_si(other.content, 0, 1);
+        }
+        return *this;
+    }
+
+    ~RationalCoeff() { mpq_clear(content); }
+};
+
+}// namespace dtl
+
+class Polynomial
+    : private boost::container::flat_map<Monomial, dtl::RationalCoeff>
+{
+public:
+    using typename flat_map::const_iterator;
+    using typename flat_map::const_pointer;
+    using typename flat_map::const_reference;
+    using typename flat_map::difference_type;
+    using typename flat_map::iterator;
+    using typename flat_map::key_type;
+    using typename flat_map::mapped_type;
+    using typename flat_map::pointer;
+    using typename flat_map::reference;
+    using typename flat_map::size_type;
+    using typename flat_map::value_type;
+
+    using flat_map::flat_map;
+
+    explicit Polynomial(dtl::RationalCoeff coeff)
+        : flat_map({std::make_pair(Monomial(), std::move(coeff))})
+    {}
+
+    explicit Polynomial(const Monomial& monomial, dtl::RationalCoeff coeff)
+        : flat_map({std::make_pair(monomial, std::move(coeff))})
+    {}
+
+    Polynomial& operator=(const Polynomial& other) = default;
+    Polynomial& operator=(Polynomial&& other) noexcept = default;
+
+    using flat_map::begin;
+    using flat_map::cbegin;
+    using flat_map::cend;
+    using flat_map::crbegin;
+    using flat_map::crend;
+    using flat_map::end;
+    using flat_map::erase;
+    using flat_map::find;
+    using flat_map::rbegin;
+    using flat_map::rend;
+
+    using flat_map::size;
+    using flat_map::empty;
+    using flat_map::emplace;
+    using flat_map::operator[];
+};
+
+void poly_add_inplace(Polynomial& lhs, const Polynomial& rhs);
+void poly_sub_inplace(Polynomial& lhs, const Polynomial& rhs);
+void poly_mul_inplace(Polynomial& lhs, const Polynomial& rhs);
+void poly_div_inplace(Polynomial& lhs, const dtl::RationalCoeff& rhs);
+
+bool poly_cmp_equal(const Polynomial& lhs, const Polynomial& rhs) noexcept;
+inline bool poly_cmp_is_zero(const Polynomial& value)
+{
+    return value.empty();
+}
+
+RPY_NO_DISCARD
+hash_t hash_value(const Polynomial& value);
+
+void poly_print(std::ostream& os, const Polynomial& value);
+
+
+
+}// namespace generics
+
+}// namespace rpy
+
+#endif// ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_H

--- a/platform/src/generics/polynomial_type/polynomial.h
+++ b/platform/src/generics/polynomial_type/polynomial.h
@@ -6,6 +6,7 @@
 #define ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_H
 
 #include <iosfwd>
+#include <utility>
 
 #include <boost/container/flat_map.hpp>
 #include <gmp.h>
@@ -35,7 +36,12 @@ struct RationalCoeff {
     {
         mpq_init(content);
         mpq_swap(content, other.content);
-        mpq_clear(other.content);
+    }
+
+    RationalCoeff(int64_t num, int64_t den)
+    {
+        mpq_init(content);
+        mpq_set_si(content, num, den);
     }
 
     // Copy assignment operator
@@ -86,6 +92,12 @@ public:
         : flat_map({std::make_pair(monomial, std::move(coeff))})
     {}
 
+    explicit Polynomial(
+            std::initializer_list<pair<Monomial, dtl::RationalCoeff>> list
+    )
+        : flat_map(list)
+    {}
+
     Polynomial& operator=(const Polynomial& other) = default;
     Polynomial& operator=(Polynomial&& other) noexcept = default;
 
@@ -100,10 +112,12 @@ public:
     using flat_map::rbegin;
     using flat_map::rend;
 
-    using flat_map::size;
-    using flat_map::empty;
     using flat_map::emplace;
+    using flat_map::empty;
+    using flat_map::size;
     using flat_map::operator[];
+
+    deg_t degree() const noexcept;
 };
 
 void poly_add_inplace(Polynomial& lhs, const Polynomial& rhs);
@@ -112,16 +126,17 @@ void poly_mul_inplace(Polynomial& lhs, const Polynomial& rhs);
 void poly_div_inplace(Polynomial& lhs, const dtl::RationalCoeff& rhs);
 
 bool poly_cmp_equal(const Polynomial& lhs, const Polynomial& rhs) noexcept;
-inline bool poly_cmp_is_zero(const Polynomial& value)
-{
-    return value.empty();
-}
+inline bool poly_cmp_is_zero(const Polynomial& value) { return value.empty(); }
 
-RPY_NO_DISCARD
-hash_t hash_value(const Polynomial& value);
+RPY_NO_DISCARD hash_t hash_value(const Polynomial& value);
 
 void poly_print(std::ostream& os, const Polynomial& value);
 
+
+inline bool operator==(const Polynomial& lhs, const Polynomial& rhs) noexcept
+{
+    return poly_cmp_equal(lhs, rhs);
+}
 
 
 }// namespace generics

--- a/platform/src/generics/polynomial_type/polynomial.h
+++ b/platform/src/generics/polynomial_type/polynomial.h
@@ -118,6 +118,7 @@ public:
     using flat_map::emplace;
     using flat_map::empty;
     using flat_map::size;
+    using flat_map::clear;
     using flat_map::operator[];
 
     deg_t degree() const noexcept;

--- a/platform/src/generics/polynomial_type/polynomial.h
+++ b/platform/src/generics/polynomial_type/polynomial.h
@@ -126,7 +126,11 @@ public:
 void poly_add_inplace(Polynomial& lhs, const Polynomial& rhs);
 void poly_sub_inplace(Polynomial& lhs, const Polynomial& rhs);
 void poly_mul_inplace(Polynomial& lhs, const Polynomial& rhs);
-void poly_div_inplace(Polynomial& lhs, const dtl::RationalCoeff& rhs);
+void poly_div_inplace(Polynomial& lhs, mpq_srcptr rhs);
+inline void poly_div_inplace(Polynomial& lhs, const dtl::RationalCoeff& rhs)
+{
+    poly_div_inplace(lhs, rhs.content);
+}
 
 bool poly_cmp_equal(const Polynomial& lhs, const Polynomial& rhs) noexcept;
 inline bool poly_cmp_is_zero(const Polynomial& value) { return value.empty(); }

--- a/platform/src/generics/polynomial_type/polynomial_arithmetic.cpp
+++ b/platform/src/generics/polynomial_type/polynomial_arithmetic.cpp
@@ -1,0 +1,10 @@
+//
+// Created by sam on 27/11/24.
+//
+
+#include "polynomial_arithmetic.h"
+
+namespace rpy {
+namespace generics {
+} // generics
+} // rpy

--- a/platform/src/generics/polynomial_type/polynomial_arithmetic.cpp
+++ b/platform/src/generics/polynomial_type/polynomial_arithmetic.cpp
@@ -4,7 +4,58 @@
 
 #include "polynomial_arithmetic.h"
 
-namespace rpy {
-namespace generics {
-} // generics
-} // rpy
+#include "roughpy/core/check.h"
+#include "roughpy/core/debug_assertion.h"
+
+#include "polynomial.h"
+
+bool rpy::generics::PolynomialArithmetic::
+has_operation(ArithmeticOperation op) const noexcept { return true; }
+
+void rpy::generics::PolynomialArithmetic::unsafe_add_inplace(void* lhs,
+    const void* rhs) const noexcept
+{
+    RPY_DBG_ASSERT_NE(lhs, nullptr);
+    RPY_DBG_ASSERT_NE(rhs, nullptr);
+
+    auto* src_ptr = static_cast<const Polynomial*>(rhs);
+    auto* dst_ptr = static_cast<Polynomial*>(lhs);
+
+    poly_add_inplace(*dst_ptr, *src_ptr);
+}
+
+void rpy::generics::PolynomialArithmetic::unsafe_sub_inplace(void* lhs,
+    const void* rhs) const
+{
+    RPY_DBG_ASSERT_NE(lhs, nullptr);
+    RPY_DBG_ASSERT_NE(rhs, nullptr);
+
+    auto* src_ptr = static_cast<const Polynomial*>(rhs);
+    auto* dst_ptr = static_cast<Polynomial*>(lhs);
+
+    poly_sub_inplace(*dst_ptr, *src_ptr);
+}
+
+void rpy::generics::PolynomialArithmetic::unsafe_mul_inplace(void* lhs,
+    const void* rhs) const
+{
+    RPY_DBG_ASSERT_NE(lhs, nullptr);
+    RPY_DBG_ASSERT_NE(rhs, nullptr);
+
+    auto* src_ptr = static_cast<const Polynomial*>(rhs);
+    auto* dst_ptr = static_cast<Polynomial*>(lhs);
+
+    poly_mul_inplace(*dst_ptr, *src_ptr);
+}
+
+void rpy::generics::PolynomialArithmetic::unsafe_div_inplace(void* lhs,
+    const void* rhs) const
+{
+    RPY_DBG_ASSERT_NE(lhs, nullptr);
+    RPY_DBG_ASSERT_NE(rhs, nullptr);
+
+    const auto* src_ptr = static_cast<mpq_srcptr>(rhs);
+    auto* dst_ptr = static_cast<Polynomial*>(lhs);
+
+    poly_div_inplace(*dst_ptr, src_ptr);
+}

--- a/platform/src/generics/polynomial_type/polynomial_arithmetic.h
+++ b/platform/src/generics/polynomial_type/polynomial_arithmetic.h
@@ -5,11 +5,32 @@
 #ifndef ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_ARITHMETIC_H
 #define ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_ARITHMETIC_H
 
+#include "roughpy/core/macros.h"
+
+#include "roughpy/generics/arithmetic_trait.h"
+
+
 namespace rpy {
 namespace generics {
 
-class PolynomialArithmetic {
+class PolynomialArithmetic : public ArithmeticTrait {
 
+public:
+
+    explicit PolynomialArithmetic(const Type* type, const Type* rational_type)
+        : ArithmeticTrait(type, rational_type)
+    {}
+
+    RPY_NO_DISCARD bool
+    has_operation(ArithmeticOperation op) const noexcept override;
+
+    void unsafe_add_inplace(void* lhs, const void* rhs) const noexcept override;
+
+    void unsafe_sub_inplace(void* lhs, const void* rhs) const override;
+
+    void unsafe_mul_inplace(void* lhs, const void* rhs) const override;
+
+    void unsafe_div_inplace(void* lhs, const void* rhs) const override;
 };
 
 } // generics

--- a/platform/src/generics/polynomial_type/polynomial_arithmetic.h
+++ b/platform/src/generics/polynomial_type/polynomial_arithmetic.h
@@ -1,0 +1,18 @@
+//
+// Created by sam on 27/11/24.
+//
+
+#ifndef ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_ARITHMETIC_H
+#define ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_ARITHMETIC_H
+
+namespace rpy {
+namespace generics {
+
+class PolynomialArithmetic {
+
+};
+
+} // generics
+} // rpy
+
+#endif //ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_ARITHMETIC_H

--- a/platform/src/generics/polynomial_type/polynomial_comparison.cpp
+++ b/platform/src/generics/polynomial_type/polynomial_comparison.cpp
@@ -1,0 +1,57 @@
+//
+// Created by sam on 27/11/24.
+//
+
+#include "polynomial_comparison.h"
+
+
+#include "roughpy/core/debug_assertion.h"
+
+#include "polynomial.h"
+
+
+
+using namespace rpy;
+using namespace rpy::generics;
+
+bool PolynomialComparison::has_comparison(ComparisonType comp) const noexcept
+{
+    if (comp == ComparisonType::Equal) { return true; }
+    return false;
+}
+
+bool PolynomialComparison::unsafe_compare_equal(const void* lhs,
+    const void* rhs) const noexcept
+{
+    RPY_DBG_ASSERT_NE(lhs, nullptr);
+    RPY_DBG_ASSERT_NE(rhs, nullptr);
+
+    auto* lhs_ptr = static_cast<const Polynomial*>(lhs);
+    auto* rhs_ptr = static_cast<const Polynomial*>(rhs);
+
+    return poly_cmp_equal(*lhs_ptr, *rhs_ptr);
+}
+
+bool PolynomialComparison::unsafe_compare_less(const void* lhs,
+    const void* rhs) const noexcept
+{
+    return false;
+}
+
+bool PolynomialComparison::unsafe_compare_less_equal(const void* lhs,
+    const void* rhs) const noexcept
+{
+    return false;
+}
+
+bool PolynomialComparison::unsafe_compare_greater(const void* lhs,
+    const void* rhs) const noexcept
+{
+    return false;
+}
+
+bool PolynomialComparison::unsafe_compare_greater_equal(const void* lhs,
+    const void* rhs) const noexcept
+{
+    return false;
+}

--- a/platform/src/generics/polynomial_type/polynomial_comparison.h
+++ b/platform/src/generics/polynomial_type/polynomial_comparison.h
@@ -1,0 +1,39 @@
+//
+// Created by sam on 27/11/24.
+//
+
+#ifndef ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_COMPARISON_H
+#define ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_COMPARISON_H
+
+#include "roughpy/generics/comparison_trait.h"
+
+namespace rpy {
+namespace generics {
+
+class PolynomialComparison : public ComparisonTrait {
+public:
+    PolynomialComparison(const Type* type) : ComparisonTrait(type) {}
+
+    RPY_NO_DISCARD bool
+    has_comparison(ComparisonType comp) const noexcept override;
+
+    RPY_NO_DISCARD bool unsafe_compare_equal(const void* lhs,
+        const void* rhs) const noexcept override;
+
+    RPY_NO_DISCARD bool unsafe_compare_less(const void* lhs,
+        const void* rhs) const noexcept override;
+
+    RPY_NO_DISCARD bool unsafe_compare_less_equal(const void* lhs,
+        const void* rhs) const noexcept override;
+
+    RPY_NO_DISCARD bool unsafe_compare_greater(const void* lhs,
+        const void* rhs) const noexcept override;
+
+    RPY_NO_DISCARD bool unsafe_compare_greater_equal(const void* lhs,
+        const void* rhs) const noexcept override;
+};
+
+} // generics
+} // rpy
+
+#endif //ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_COMPARISON_H

--- a/platform/src/generics/polynomial_type/polynomial_number.cpp
+++ b/platform/src/generics/polynomial_type/polynomial_number.cpp
@@ -1,0 +1,31 @@
+//
+// Created by sam on 27/11/24.
+//
+
+#include "polynomial_number.h"
+
+
+#include "polynomial.h"
+
+
+using namespace rpy;
+using namespace rpy::generics;
+
+bool PolynomialNumber::has_function(NumberFunction fn_id) const noexcept
+{
+    if (fn_id == NumberFunction::FromRational) { return true; }
+    return false;
+}
+
+void PolynomialNumber::unsafe_abs(void* dst, const void* src) const noexcept
+{
+    // Do nothing, undefined
+}
+
+void PolynomialNumber::unsafe_from_rational(void* dst,
+    int64_t numerator,
+    int64_t denominator) const
+{
+    auto* dst_ptr = static_cast<Polynomial*>(dst);
+    *dst_ptr = Polynomial(dtl::RationalCoeff{numerator, denominator});
+}

--- a/platform/src/generics/polynomial_type/polynomial_number.h
+++ b/platform/src/generics/polynomial_type/polynomial_number.h
@@ -1,0 +1,32 @@
+//
+// Created by sam on 27/11/24.
+//
+
+#ifndef ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_NUMBER_H
+#define ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_NUMBER_H
+
+#include "roughpy/generics/number_trait.h"
+
+namespace rpy {
+namespace generics {
+
+class PolynomialNumber : public NumberTrait {
+
+public:
+    explicit PolynomialNumber(const Type* tp) noexcept
+        : NumberTrait(tp, nullptr)
+    {}
+
+    bool has_function(NumberFunction fn_id) const noexcept override;
+
+    void unsafe_abs(void* dst, const void* src) const noexcept override;
+
+    void unsafe_from_rational(void* dst,
+        int64_t numerator,
+        int64_t denominator) const override;
+};
+
+} // generics
+} // rpy
+
+#endif //ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_NUMBER_H

--- a/platform/src/generics/polynomial_type/polynomial_type.cpp
+++ b/platform/src/generics/polynomial_type/polynomial_type.cpp
@@ -6,6 +6,10 @@
 
 #include <algorithm>
 #include <typeinfo>
+#include <utility>
+#include <iostream>
+
+#include <ctre.hpp>
 
 
 #include <roughpy/core/construct_inplace.h>
@@ -77,11 +81,6 @@ void PolynomialType::free_object(void* ptr) const
     mem::small_object_free(poly, sizeof(Polynomial));
 }
 
-bool PolynomialType::parse_from_string(void* data,
-                                       string_view str) const noexcept
-{
-    return Type::parse_from_string(data, str);
-}
 
 void PolynomialType::copy_or_move(void* dst,
                                   const void* src,
@@ -148,4 +147,145 @@ TypePtr PolynomialType::get() noexcept
 {
     static PolynomialType type;
     return &type;
+}
+
+
+/******************************************************************************
+ *                                 Parser                                     *
+ ******************************************************************************/
+
+namespace {
+
+
+template <typename T>
+bool parse_integer(T& value, string_view str) noexcept
+{
+
+    auto parse_result = std::from_chars(
+        str.data(),
+        str.data() + str.size(),
+        value,
+        10
+    );
+
+    return parse_result.ec == std::errc();
+}
+
+bool parse_dbl_coeff(generics::dtl::RationalCoeff& coeff, bool negative, string_view data) noexcept
+{
+    try {
+        auto dbl_coeff = std::stod(string(data));
+        mpq_set_d(coeff.content, negative ? -dbl_coeff : dbl_coeff);
+    } catch (std::invalid_argument&) {
+        return false;
+    }
+    return true;
+}
+
+bool parse_rat_coeff(generics::dtl::RationalCoeff& coeff, bool neg, string_view data) noexcept
+{
+    int64_t numerator;
+    int64_t denominator = 1;
+
+    constexpr auto rat_pattern = ctll::fixed_string{
+        R"((?<num>[1-9]\d*)(?:\/(?<den>[1-9]\d*))?)"
+    };
+
+    if (auto match = ctre::match<rat_pattern>(data)) {
+        if (auto num = match.get<"num">()) {
+            if (!parse_integer(numerator, num.view())) {
+                return false;
+            }
+        }
+        if (auto den = match.get<"den">()) {
+            if (!parse_integer(denominator, den.view())) {
+                return false;
+            }
+        }
+    } else {
+        return false;
+    }
+
+    mpq_set_si(coeff.content, neg ? -numerator : numerator, denominator);
+
+    return true;
+}
+
+
+bool parse_monomial(Monomial& result, string_view monomial_string) noexcept
+{
+    constexpr auto monomial_pattern = ctll::fixed_string{
+            R"(([a-zA-Z])([1-9]\d*)(?:\^([1-9]\d*))?)"
+    };
+
+    for (auto match : ctre::search_all<monomial_pattern>(monomial_string)) {
+        auto prefix = match.get<1>();
+        RPY_DBG_ASSERT(prefix);
+        auto index = match.get<2>();
+        RPY_DBG_ASSERT(index);
+
+        uint64_t index_digits = 0;
+        if (!parse_integer(index_digits, index.view())) {
+            result.clear();
+            return false;
+        }
+
+        Indeterminate ind(*prefix.begin(), index_digits);
+
+        deg_t pow = 1;
+        if (auto power = match.get<3>()) {
+            if (!parse_integer(pow, power.view())) {
+                result.clear();
+                return false;
+            }
+        }
+
+        result.emplace(ind, pow);
+    }
+
+    return true;
+}
+
+}
+
+bool PolynomialType::parse_from_string(void* data,
+                                       string_view str) const noexcept
+{
+    RPY_DBG_ASSERT_NE(data, nullptr);
+
+    auto* poly = static_cast<Polynomial*>(data);
+
+    constexpr auto term_pattern = ctll::fixed_string{
+            R"((?<sgn>\+|\-)?(?:(?<dbl>\d+\.\d*)|(?<rat>[1-9]\d*(?:\/[1-9]\d*)?))(?:\((?<mon>(?:[a-zA-Z][1-9]\d*(?:\^(?:[1-9]\d*))?)+)\))?)"
+    };
+
+    generics::dtl::RationalCoeff tmp_coeff;
+    for (auto match : ctre::search_all<term_pattern>(str)) {
+        auto sign_m = match.get<"sgn">();
+        bool negative = sign_m && *sign_m.begin() == '-';
+
+        if (auto dbl_grp = match.get<"dbl">()) {
+            if (!parse_dbl_coeff(tmp_coeff, negative, dbl_grp.view())) {
+                poly->clear();
+                return false;
+            }
+        } else if (auto rat_grp = match.get<"rat">()) {
+            if (!parse_rat_coeff(tmp_coeff, negative, rat_grp.view())) {
+                poly->clear();
+                return false;
+            }
+        }
+
+        Monomial mon;
+        if (auto monomial_grp = match.get<"mon">()) {
+            if (!parse_monomial(mon, monomial_grp.view())) {
+                poly->clear();
+                return false;
+            }
+        }
+
+        poly->emplace(mon, std::move(tmp_coeff));
+    }
+
+    return true;
 }

--- a/platform/src/generics/polynomial_type/polynomial_type.cpp
+++ b/platform/src/generics/polynomial_type/polynomial_type.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <typeinfo>
 #include <utility>
-#include <iostream>
 
 #include <ctre.hpp>
 

--- a/platform/src/generics/polynomial_type/polynomial_type.cpp
+++ b/platform/src/generics/polynomial_type/polynomial_type.cpp
@@ -1,0 +1,155 @@
+//
+// Created by sam on 27/11/24.
+//
+
+#include "polynomial_type.h"
+
+#include <algorithm>
+#include <typeinfo>
+
+
+#include <roughpy/core/construct_inplace.h>
+#include <roughpy/core/debug_assertion.h>
+
+#include <roughpy/platform/alloc.h>
+
+#include "indeterminate.h"
+#include "monomial.h"
+#include "polynomial.h"
+
+
+using namespace rpy;
+using namespace rpy::generics;
+
+void PolynomialType::inc_ref() const noexcept
+{
+    // do nothing
+}
+
+bool PolynomialType::dec_ref() const noexcept
+{
+    // Do nothing
+    return false;
+}
+
+intptr_t PolynomialType::ref_count() const noexcept { return 1; }
+
+const std::type_info& PolynomialType::type_info() const noexcept
+{
+    return typeid(Polynomial);
+}
+
+BasicProperties PolynomialType::basic_properties() const noexcept
+{
+    return {false, false, false, false, false, false, false, false, false,
+            false, false};
+}
+
+size_t PolynomialType::object_size() const noexcept
+{
+    return sizeof(Polynomial);
+}
+
+string_view PolynomialType::name() const noexcept
+{
+    return "Polynomial";
+}
+
+string_view PolynomialType::id() const noexcept
+{
+    return "poly";
+}
+
+void* PolynomialType::allocate_object() const
+{
+    auto* ptr = static_cast<Polynomial*>(mem::small_object_alloc(sizeof(Polynomial)));
+    if (ptr == nullptr) {
+        throw std::bad_alloc();
+    }
+    construct_inplace(ptr);
+
+    return ptr;
+}
+
+void PolynomialType::free_object(void* ptr) const
+{
+    auto* poly = static_cast<Polynomial*>(ptr);
+    poly->~Polynomial();
+    mem::small_object_free(poly, sizeof(Polynomial));
+}
+
+bool PolynomialType::parse_from_string(void* data,
+                                       string_view str) const noexcept
+{
+    return Type::parse_from_string(data, str);
+}
+
+void PolynomialType::copy_or_move(void* dst,
+                                  const void* src,
+                                  size_t count,
+                                  bool move) const
+{
+    RPY_DBG_ASSERT_NE(dst, nullptr);
+    auto* dst_poly = static_cast<Polynomial*>(dst);
+    const auto* src_poly = static_cast<const Polynomial*>(src);
+
+    if (src_poly == nullptr) {
+        for (size_t i = 0; i < count; ++i) {
+            dst_poly[i] = Polynomial();
+        }
+    } else if (move) {
+        auto* modifiable_src = const_cast<Polynomial*>(src_poly);
+        for (size_t i = 0; i < count; ++i) {
+            dst_poly[i] = std::move(modifiable_src[i]);
+        }
+    } else {
+        std::copy_n(src_poly, count, dst_poly);
+    }
+}
+
+void PolynomialType::destroy_range(void* data, size_t count) const
+{
+    RPY_DBG_ASSERT_NE(data, nullptr);
+    auto* poly = static_cast<Polynomial*>(data);
+    std::destroy_n(poly, count);
+}
+
+std::unique_ptr<const ConversionTrait> PolynomialType::
+convert_to(const Type& type) const noexcept { return Type::convert_to(type); }
+
+std::unique_ptr<const ConversionTrait> PolynomialType::
+convert_from(const Type& type) const noexcept
+{
+    return Type::convert_from(type);
+}
+
+const BuiltinTrait* PolynomialType::
+get_builtin_trait(BuiltinTraitID id) const noexcept
+{
+    return Type::get_builtin_trait(id);
+}
+
+const std::ostream& PolynomialType::display(std::ostream& os,
+                                            const void* value) const
+{
+    if (value == nullptr) {
+        return os << "{ }";
+    }
+    const auto* poly = static_cast<const Polynomial*>(value);
+    poly_print(os, *poly);
+    return os;
+}
+
+hash_t PolynomialType::hash_of(const void* value) const noexcept
+{
+    if (value == nullptr) {
+        return 0;
+    }
+    return hash_value(*static_cast<const Polynomial*>(value));
+}
+
+TypePtr PolynomialType::get() noexcept
+{
+    static PolynomialType type;
+    return &type;
+}

--- a/platform/src/generics/polynomial_type/polynomial_type.cpp
+++ b/platform/src/generics/polynomial_type/polynomial_type.cpp
@@ -41,7 +41,7 @@ const std::type_info& PolynomialType::type_info() const noexcept
 
 BasicProperties PolynomialType::basic_properties() const noexcept
 {
-    return {false, false, false, false, false, false, false, false, false,
+    return {false, false, false, false, false, false, false, false, true,
             false, false};
 }
 
@@ -50,22 +50,15 @@ size_t PolynomialType::object_size() const noexcept
     return sizeof(Polynomial);
 }
 
-string_view PolynomialType::name() const noexcept
-{
-    return "Polynomial";
-}
+string_view PolynomialType::name() const noexcept { return "Polynomial"; }
 
-string_view PolynomialType::id() const noexcept
-{
-    return "poly";
-}
+string_view PolynomialType::id() const noexcept { return "poly"; }
 
 void* PolynomialType::allocate_object() const
 {
-    auto* ptr = static_cast<Polynomial*>(mem::small_object_alloc(sizeof(Polynomial)));
-    if (ptr == nullptr) {
-        throw std::bad_alloc();
-    }
+    auto* ptr = static_cast<Polynomial*>(mem::small_object_alloc(
+        sizeof(Polynomial)));
+    if (ptr == nullptr) { throw std::bad_alloc(); }
     construct_inplace(ptr);
 
     return ptr;
@@ -94,17 +87,13 @@ void PolynomialType::copy_or_move(void* dst,
     const auto* src_poly = static_cast<const Polynomial*>(src);
 
     if (src_poly == nullptr) {
-        for (size_t i = 0; i < count; ++i) {
-            dst_poly[i] = Polynomial();
-        }
+        for (size_t i = 0; i < count; ++i) { dst_poly[i] = Polynomial(); }
     } else if (move) {
         auto* modifiable_src = const_cast<Polynomial*>(src_poly);
         for (size_t i = 0; i < count; ++i) {
             dst_poly[i] = std::move(modifiable_src[i]);
         }
-    } else {
-        std::copy_n(src_poly, count, dst_poly);
-    }
+    } else { std::copy_n(src_poly, count, dst_poly); }
 }
 
 void PolynomialType::destroy_range(void* data, size_t count) const
@@ -132,9 +121,7 @@ get_builtin_trait(BuiltinTraitID id) const noexcept
 const std::ostream& PolynomialType::display(std::ostream& os,
                                             const void* value) const
 {
-    if (value == nullptr) {
-        return os << "{ }";
-    }
+    if (value == nullptr) { return os << "{ }"; }
     const auto* poly = static_cast<const Polynomial*>(value);
     poly_print(os, *poly);
     return os;
@@ -142,9 +129,7 @@ const std::ostream& PolynomialType::display(std::ostream& os,
 
 hash_t PolynomialType::hash_of(const void* value) const noexcept
 {
-    if (value == nullptr) {
-        return 0;
-    }
+    if (value == nullptr) { return 0; }
     return hash_value(*static_cast<const Polynomial*>(value));
 }
 

--- a/platform/src/generics/polynomial_type/polynomial_type.cpp
+++ b/platform/src/generics/polynomial_type/polynomial_type.cpp
@@ -13,6 +13,7 @@
 
 #include <roughpy/platform/alloc.h>
 
+
 #include "indeterminate.h"
 #include "monomial.h"
 #include "polynomial.h"
@@ -20,6 +21,11 @@
 
 using namespace rpy;
 using namespace rpy::generics;
+
+PolynomialType::PolynomialType()
+    : m_arithmetic(this, MultiPrecisionTypes::get().rational_type.get()),
+      m_comparison(this),
+      m_number(this) {}
 
 void PolynomialType::inc_ref() const noexcept
 {
@@ -115,7 +121,12 @@ convert_from(const Type& type) const noexcept
 const BuiltinTrait* PolynomialType::
 get_builtin_trait(BuiltinTraitID id) const noexcept
 {
-    return Type::get_builtin_trait(id);
+    switch (id) {
+        case BuiltinTraitID::Arithmetic: return &m_arithmetic;
+        case BuiltinTraitID::Comparison: return &m_comparison;
+        case BuiltinTraitID::Number: return &m_number;
+    }
+    RPY_UNREACHABLE_RETURN(nullptr);
 }
 
 const std::ostream& PolynomialType::display(std::ostream& os,

--- a/platform/src/generics/polynomial_type/polynomial_type.h
+++ b/platform/src/generics/polynomial_type/polynomial_type.h
@@ -7,11 +7,19 @@
 
 #include "roughpy/generics/type.h"
 
+#include "polynomial_arithmetic.h"
+#include "polynomial_comparison.h"
+#include "polynomial_number.h"
+
 namespace rpy {
 namespace generics {
 
 class PolynomialType : public Type {
+    PolynomialArithmetic m_arithmetic;
+    PolynomialComparison m_comparison;
+    PolynomialNumber m_number;
 
+    PolynomialType();
 
 protected:
     void inc_ref() const noexcept override;

--- a/platform/src/generics/polynomial_type/polynomial_type.h
+++ b/platform/src/generics/polynomial_type/polynomial_type.h
@@ -1,0 +1,70 @@
+//
+// Created by sam on 27/11/24.
+//
+
+#ifndef ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_TYPE_H
+#define ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_TYPE_H
+
+#include "roughpy/generics/type.h"
+
+namespace rpy {
+namespace generics {
+
+class PolynomialType : public Type {
+
+
+protected:
+    void inc_ref() const noexcept override;
+
+    RPY_NO_DISCARD bool dec_ref() const noexcept override;
+
+public:
+    RPY_NO_DISCARD intptr_t ref_count() const noexcept override;
+
+    RPY_NO_DISCARD const std::type_info& type_info() const noexcept override;
+
+    RPY_NO_DISCARD BasicProperties basic_properties() const noexcept override;
+
+    RPY_NO_DISCARD size_t object_size() const noexcept override;
+
+    RPY_NO_DISCARD string_view name() const noexcept override;
+
+    RPY_NO_DISCARD string_view id() const noexcept override;
+
+protected:
+    void* allocate_object() const override;
+
+    void free_object(void* ptr) const override;
+
+public:
+    bool parse_from_string(void* data, string_view str) const noexcept override;
+
+    void copy_or_move(void* dst,
+        const void* src,
+        size_t count,
+        bool move) const override;
+
+    void destroy_range(void* data, size_t count) const override;
+
+    RPY_NO_DISCARD std::unique_ptr<const ConversionTrait> convert_to(
+        const Type& type) const noexcept override;
+
+    RPY_NO_DISCARD std::unique_ptr<const ConversionTrait> convert_from(
+        const Type& type) const noexcept override;
+
+    RPY_NO_DISCARD const BuiltinTrait* get_builtin_trait(
+        BuiltinTraitID id) const noexcept override;
+
+    const std::ostream&
+    display(std::ostream& os, const void* value) const override;
+
+    hash_t hash_of(const void* value) const noexcept override;
+
+
+    static TypePtr get() noexcept;
+};
+
+} // generics
+} // rpy
+
+#endif //ROUGHPY_GENERICS_INTERNAL_POLYNOMIAL_TYPE_H

--- a/platform/src/generics/polynomial_type/test_indeterminate.cpp
+++ b/platform/src/generics/polynomial_type/test_indeterminate.cpp
@@ -1,0 +1,120 @@
+//
+// Created by sam on 26/11/24.
+//
+#include <gtest/gtest.h>
+
+#include "indeterminate.h"
+
+
+using namespace rpy;
+using namespace rpy::generics;
+
+
+// Test Default Constructor
+TEST(TestIndeterminate, TestDefaultConstructor) {
+    Indeterminate ind;
+    EXPECT_EQ(ind.prefix(), "x");
+    EXPECT_EQ(ind.index(), 0);
+}
+
+// Test Constructor with Integer
+TEST(TestIndeterminate, TestConstructorWithInteger) {
+    Indeterminate ind(123);
+    EXPECT_EQ(ind.prefix(), "x");
+    EXPECT_EQ(ind.index(), 123);
+}
+
+// Test Constructor with Character and Integer
+TEST(TestIndeterminate, TestConstructorWithCharAndInteger) {
+    Indeterminate ind('y', 456);
+    EXPECT_EQ(ind.prefix(), "y");
+    EXPECT_EQ(ind.index(), 456);
+}
+
+// Test Constructor with Character Array and Integer
+TEST(TestIndeterminate, TestConstructorWithCharArrayAndInteger) {
+    Indeterminate ind({'z'}, 789);
+    EXPECT_EQ(ind.prefix(), "z");
+    EXPECT_EQ(ind.index(), 789);
+}
+
+// Test Equality Operator
+TEST(TestIndeterminate, TestEqualityOperator) {
+    Indeterminate ind1('x', 303);
+    Indeterminate ind2('x', 303);
+    EXPECT_TRUE(ind1 == ind2);
+
+    Indeterminate ind3('y', 303);
+    EXPECT_FALSE(ind1 == ind3);
+
+    Indeterminate ind4('x', 304);
+    EXPECT_FALSE(ind1 == ind4);
+
+    Indeterminate ind5('x', 2304134);
+    EXPECT_FALSE(ind1 == ind5);
+}
+
+// Test Inequality Operator
+TEST(TestIndeterminate, TestInequalityOperator) {
+    Indeterminate ind1('x', 304);
+    Indeterminate ind2('x', 304);
+    EXPECT_FALSE(ind1 != ind2);
+
+    Indeterminate ind3('y', 304);
+    EXPECT_TRUE(ind1 != ind3);
+
+    Indeterminate ind4('x', 305);
+    EXPECT_TRUE(ind1 != ind4);
+
+    Indeterminate ind5('x', 2304134);
+    EXPECT_TRUE(ind1 != ind5);
+}
+
+// Test Less Than Operator
+TEST(TestIndeterminate, TestLessThanOperator) {
+    Indeterminate ind1('x', 606);
+    Indeterminate ind2('x', 707);
+    EXPECT_LT(ind1, ind2);
+}
+
+// Test Less Than or Equal Operator
+TEST(TestIndeterminate, TestLessThanOrEqualOperator) {
+    Indeterminate ind1('x', 808);
+    Indeterminate ind2('x', 808);
+    EXPECT_LE(ind1, ind2);
+}
+
+// Test Greater Than Operator
+TEST(TestIndeterminate, TestGreaterThanOperator) {
+    Indeterminate ind1('x', 909);
+    Indeterminate ind2('x', 808);
+    EXPECT_GT(ind1, ind2);
+}
+
+// Test Greater Than or Equal Operator
+TEST(TestIndeterminate, TestGreaterThanOrEqualOperator) {
+    Indeterminate ind1('x', 1010);
+    Indeterminate ind2('x', 1010);
+    EXPECT_GE(ind1, ind2);
+}
+
+TEST(TestIndeterminate, TestHash)
+{
+    Indeterminate ind1('x', 1);
+    Indeterminate ind2('x', 1);
+    EXPECT_EQ(ind1, ind2);
+    EXPECT_EQ(hash_value(ind1), hash_value(ind2));
+
+    Indeterminate ind3('x', 2);
+    EXPECT_NE(hash_value(ind1), hash_value(ind3));
+}
+
+
+TEST(TestIndeterminate, TestDisplay)
+{
+    Indeterminate ind1('x', 1);
+
+    std::stringstream ss1;
+    ss1 << ind1;
+    EXPECT_EQ(ss1.str(), "x1");
+}

--- a/platform/src/generics/polynomial_type/test_monomial.cpp
+++ b/platform/src/generics/polynomial_type/test_monomial.cpp
@@ -1,0 +1,52 @@
+//
+// Created by sam on 26/11/24.
+//
+
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+
+#include "monomial.h"
+
+using namespace rpy;
+using namespace rpy::generics;
+
+TEST(TestMonomial, TestEmptyMonomial)
+{
+    Monomial m;
+
+    EXPECT_EQ(m.degree(), 0);
+    EXPECT_EQ(m.type(), 0);
+}
+
+TEST(TestMonomial, TestUnidimConstructorDegreeAndType)
+{
+    Monomial m(Indeterminate('x', 1));
+
+    EXPECT_EQ(m.degree(), 1);
+    EXPECT_EQ(m.type(), 1);
+}
+
+TEST(TestMonomial, TestDisplay)
+{
+    Monomial m1;
+    Monomial m2(Indeterminate('x', 1));
+    Monomial m3(Indeterminate('x', 2), 2);
+
+    std::stringstream ss1;
+    ss1 << m1;
+
+    EXPECT_EQ(ss1.str(), "");
+
+    std::stringstream ss2;
+    ss2 << m2;
+    EXPECT_EQ(ss2.str(), "x1");
+
+    std::stringstream ss3;
+    ss3 << m3;
+    EXPECT_EQ(ss3.str(), "x2^2");
+}
+
+
+

--- a/platform/src/generics/polynomial_type/test_polynomial.cpp
+++ b/platform/src/generics/polynomial_type/test_polynomial.cpp
@@ -25,8 +25,61 @@ TEST(TestPolynomial, TestDefaultValue)
 
     EXPECT_TRUE(p.empty());
     EXPECT_EQ(p.degree(), 0);
+    EXPECT_TRUE(poly_cmp_is_zero(p));
 }
 
+
+TEST(TestPolynomial, TestPolynomialEquality)
+{
+    Polynomial p1{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {2, 1}}
+    };// { 1 + 2(x1) }
+
+    Polynomial p2{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {2, 1}}
+    }; // { 1 + 2(x1) }
+
+    Polynomial p3{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {3, 1}}
+    }; // { 1 + 3(x1) }
+
+    Polynomial p4{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('y'), 1), {2, 1}}
+    }; // { 1 + 3(x1) }
+
+    EXPECT_TRUE(poly_cmp_equal(p1, p2));
+    EXPECT_FALSE(poly_cmp_equal(p1, p3));
+    EXPECT_FALSE(poly_cmp_equal(p1, p4));
+}
+
+TEST(TestPolynomial, TestPolynomialHash)
+{
+    Polynomial p1{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {2, 1}}
+    };// { 1 + 2(x1) }
+
+    Polynomial p2{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {2, 1}}
+    };// { 1 + 2(x1) }
+
+    Polynomial p3{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {3, 1}}
+    };// { 1 + 3(x1) }
+
+    auto hash1 = Hash<Polynomial>{}(p1);
+    auto hash2 = Hash<Polynomial>{}(p2);
+    auto hash3 = Hash<Polynomial>{}(p3);
+
+    EXPECT_EQ(hash1, hash2);// Hashes should be the same for p1 and p2
+    EXPECT_NE(hash1, hash3);// Hashes should be different for p1 and p3
+}
 
 TEST(TestPolynomial, TestPolynomialDisplay)
 {

--- a/platform/src/generics/polynomial_type/test_polynomial.cpp
+++ b/platform/src/generics/polynomial_type/test_polynomial.cpp
@@ -9,3 +9,123 @@
 using namespace rpy;
 using namespace rpy::generics;
 
+
+namespace rpy::generics {
+
+void PrintTo(const Polynomial& p, std::ostream* os)
+{
+    poly_print(*os, p);
+}
+
+}
+
+TEST(TestPolynomial, TestDefaultValue)
+{
+    Polynomial p;
+
+    EXPECT_TRUE(p.empty());
+    EXPECT_EQ(p.degree(), 0);
+}
+
+
+TEST(TestPolynomial, TestPolynomialDisplay)
+{
+    Polynomial p1;
+
+    std::stringstream ss1;
+    poly_print(ss1, p1);
+
+    EXPECT_EQ(ss1.str(), "{ }");
+
+    Polynomial p2 { {Monomial(), {1, 1}}};
+    std::stringstream ss2;
+    poly_print(ss2, p2);
+
+    EXPECT_EQ(ss2.str(), "{ 1 }");
+
+    Polynomial p3 { {Monomial(), {1, 1}}, {Monomial(Indeterminate('x', 2), 2), {1, 2}}};
+    std::stringstream ss3;
+    poly_print(ss3, p3);
+
+    EXPECT_EQ(ss3.str(), "{ 1 1/2(x2^2) }");
+}
+
+TEST(TestPolynomial, TestPolynomialAdditionCommonTerms)
+{
+    Polynomial p1{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {2, 1}}
+    };// { 1 + 2(x1) }
+    Polynomial p2{
+            {Monomial(Indeterminate('x'), 1), {1, 1}}
+    };// { 1(x1) }
+
+    poly_add_inplace(p1, p2);
+
+    Polynomial expected {
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {3, 1}}
+    };
+
+    EXPECT_EQ(p1, expected);
+}
+
+
+TEST(TestPolynomial, TestPolynomialSubtractionCommonTerms)
+{
+    Polynomial p1{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {2, 1}}
+    };// { 1 + 2(x1) }
+    Polynomial p2{
+            {Monomial(Indeterminate('x'), 1), {1, 1}}
+    };// { 1(x1) }
+
+    poly_sub_inplace(p1, p2);
+    Polynomial expected {
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {1, 1}}
+    }; // { 1 1(x1) }
+
+    EXPECT_EQ(p1, expected);
+
+}
+
+TEST(TestPolynomial, TestPolynomialMultiplication)
+{
+    Polynomial p1{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {2, 1}}
+    };// { 1 2(x1) }
+    Polynomial p2{
+            {Monomial(Indeterminate('x'), 1), {3, 1}}
+    };// { 1(x1) }
+
+
+    poly_mul_inplace(p1, p2);
+    Polynomial expected {
+            {Monomial('x', 1), {1, 1}},
+            {Monomial('x', 1, 2), {1, 1}}
+    }; // { 1(x1) 2(x1^2) }
+
+    EXPECT_EQ(p1, expected);
+}
+
+
+TEST(TestPolynomial, TestDivisonByRational)
+{
+    Polynomial p1{
+            {Monomial(), {1, 1}},
+            {Monomial(Indeterminate('x'), 1), {2, 1}}
+    };// { 1 2(x1) }
+
+    generics::dtl::RationalCoeff r(1, 2); // 1/2
+    poly_div_inplace(p1, r);
+
+    Polynomial expected {
+            {Monomial(), {2, 1}},
+            {Monomial(Indeterminate('x'), 1), {4, 1}}
+    }; // { 2 2(x1) }
+
+    EXPECT_EQ(p1, expected);
+}

--- a/platform/src/generics/polynomial_type/test_polynomial.cpp
+++ b/platform/src/generics/polynomial_type/test_polynomial.cpp
@@ -95,20 +95,22 @@ TEST(TestPolynomial, TestPolynomialMultiplication)
 {
     Polynomial p1{
             {Monomial(), {1, 1}},
-            {Monomial(Indeterminate('x'), 1), {2, 1}}
+            {Monomial('x', 1), {2, 1}}
     };// { 1 2(x1) }
     Polynomial p2{
-            {Monomial(Indeterminate('x'), 1), {3, 1}}
-    };// { 1(x1) }
+            {Monomial('x', 1), {3, 1}}
+    };// { 3(x1) }
+
+    Polynomial result(p1);
 
 
-    poly_mul_inplace(p1, p2);
+    poly_mul_inplace(result, p2);
     Polynomial expected {
-            {Monomial('x', 1), {1, 1}},
-            {Monomial('x', 1, 2), {1, 1}}
-    }; // { 1(x1) 2(x1^2) }
+            {Monomial('x', 1), {3, 1}},
+            {Monomial('x', 1, 2), {6, 1}}
+    }; // { 3(x1) 6(x1^2) }
 
-    EXPECT_EQ(p1, expected);
+    EXPECT_EQ(result, expected) << p1 << ' ' << p2;
 }
 
 

--- a/platform/src/generics/polynomial_type/test_polynomial.cpp
+++ b/platform/src/generics/polynomial_type/test_polynomial.cpp
@@ -1,0 +1,11 @@
+//
+// Created by sam on 26/11/24.
+//
+
+#include <gtest/gtest.h>
+
+#include "polynomial.h"
+
+using namespace rpy;
+using namespace rpy::generics;
+

--- a/platform/src/generics/polynomial_type/test_polynomial_type.cpp
+++ b/platform/src/generics/polynomial_type/test_polynomial_type.cpp
@@ -100,6 +100,14 @@ TEST_F(TestPolynomialType, TestParseMixedMonomial)
     EXPECT_EQ(ss.str(), "{ 1(x1 x2) }");
 }
 
+TEST_F(TestPolynomialType, TestParseMixedMonomialWithPowers)
+{
+    Value value(polynomial_type, string_view("{ 1(x1^2x2x3) }"));
+    std::stringstream ss;
+    polynomial_type->display(ss, value.data());
+    EXPECT_EQ(ss.str(), "{ 1(x1^2 x2 x3) }");
+}
+
 TEST_F(TestPolynomialType, TestParseFloatCoefficient)
 {
     Value value(polynomial_type, string_view("{ 1.5(x1) }"));

--- a/platform/src/generics/polynomial_type/test_polynomial_type.cpp
+++ b/platform/src/generics/polynomial_type/test_polynomial_type.cpp
@@ -86,10 +86,44 @@ TEST_F(TestPolynomialType, TestBasicProperties)
 
 TEST_F(TestPolynomialType, TestDisplayAndParseFromString)
 {
-    Value value(polynomial_type, string_view("{ 15/2 2(x1) 1(x2^2) }")); // Example string
+    Value value(polynomial_type, string_view("{ 15/2 2(x1) 1(x2^2) }"));
     std::stringstream ss;
     polynomial_type->display(ss, value.data());
-    EXPECT_EQ(ss.str(), "{ 15/2 2(x1) 1(x2^2) }"); // Example string
+    EXPECT_EQ(ss.str(), "{ 15/2 2(x1) 1(x2^2) }");
+}
+
+TEST_F(TestPolynomialType, TestParseMixedMonomial)
+{
+    Value value(polynomial_type, string_view("{ 1(x1x2) }"));
+    std::stringstream ss;
+    polynomial_type->display(ss, value.data());
+    EXPECT_EQ(ss.str(), "{ 1(x1 x2) }");
+}
+
+TEST_F(TestPolynomialType, TestParseFloatCoefficient)
+{
+    Value value(polynomial_type, string_view("{ 1.5(x1) }"));
+    std::stringstream ss;
+    polynomial_type->display(ss, value.data());
+    EXPECT_EQ(ss.str(), "{ 3/2(x1) }");
+}
+
+TEST_F(TestPolynomialType, TestParseNegativeCoefficients)
+{
+    Value value(polynomial_type,
+        string_view("{ -1 -1.25(x1) -22/7(x2) }"));
+    std::stringstream ss;
+    polynomial_type->display(ss, value.data());
+    EXPECT_EQ(ss.str(), "{ -1 -5/4(x1) -22/7(x2) }");
+}
+
+TEST_F(TestPolynomialType, TestParsePositiveCoefficients)
+{
+    Value value(polynomial_type,
+        string_view("{ +1 +1.25(x1) +22/7(x2) }"));
+    std::stringstream ss;
+    polynomial_type->display(ss, value.data());
+    EXPECT_EQ(ss.str(), "{ 1 5/4(x1) 22/7(x2) }");
 }
 
 /******************************************************************************

--- a/platform/src/generics/polynomial_type/test_polynomial_type.cpp
+++ b/platform/src/generics/polynomial_type/test_polynomial_type.cpp
@@ -1,0 +1,215 @@
+//
+// Created by sam on 27/11/24.
+//
+#include <gtest/gtest.h>
+
+#include "roughpy/generics/arithmetic_trait.h"
+#include "roughpy/generics/builtin_trait.h"
+#include "roughpy/generics/comparison_trait.h"
+#include "roughpy/generics/number_trait.h"
+#include "roughpy/generics/type.h"
+#include "roughpy/generics/values.h"
+
+using namespace rpy;
+using namespace rpy::generics;
+
+namespace {
+
+class TestPolynomialType : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        polynomial_type = get_polynomial_type();
+    }
+
+public:
+    const ComparisonTrait* comp_trait() const noexcept
+    {
+        return trait_cast<const ComparisonTrait>(
+                polynomial_type->get_builtin_trait(BuiltinTraitID::Comparison)
+        );
+    }
+
+    const ArithmeticTrait* arith_trait() const noexcept
+    {
+        return trait_cast<const ArithmeticTrait>(
+                polynomial_type->get_builtin_trait(BuiltinTraitID::Arithmetic)
+        );
+    }
+
+    const NumberTrait* num_trait() const noexcept
+    {
+        return trait_cast<const NumberTrait>(
+                polynomial_type->get_builtin_trait(BuiltinTraitID::Number)
+        );
+    }
+
+    TypePtr polynomial_type;
+};
+
+}// namespace
+
+TEST_F(TestPolynomialType, TestID)
+{
+    EXPECT_EQ(polynomial_type->id(), "polynomial_id"); // Adjust ID accordingly
+    EXPECT_EQ(polynomial_type->name(), "polynomial");
+}
+
+TEST_F(TestPolynomialType, TestRefCounting)
+{
+    EXPECT_EQ(polynomial_type->ref_count(), 1);
+
+    {
+        RPY_MAYBE_UNUSED TypePtr new_ref(polynomial_type);
+        EXPECT_EQ(polynomial_type->ref_count(), 1);
+    }
+
+    EXPECT_EQ(polynomial_type->ref_count(), 1);
+}
+
+TEST_F(TestPolynomialType, TestBasicProperties)
+{
+    EXPECT_EQ(polynomial_type->object_size(), sizeof(void*)); // Adjust if necessary
+
+    EXPECT_FALSE(concepts::is_standard_layout(*polynomial_type));
+    EXPECT_FALSE(concepts::is_trivially_copyable(*polynomial_type));
+    EXPECT_FALSE(concepts::is_trivially_constructible(*polynomial_type));
+    EXPECT_FALSE(concepts::is_trivially_default_constructible(*polynomial_type));
+    EXPECT_FALSE(concepts::is_trivially_copy_constructible(*polynomial_type));
+    EXPECT_FALSE(concepts::is_trivially_copy_assignable(*polynomial_type));
+    EXPECT_FALSE(concepts::is_trivially_destructible(*polynomial_type));
+    EXPECT_FALSE(concepts::is_polymorphic(*polynomial_type));
+    EXPECT_TRUE(concepts::is_signed(*polynomial_type));
+    EXPECT_FALSE(concepts::is_unsigned(*polynomial_type));
+    EXPECT_FALSE(concepts::is_integral(*polynomial_type));
+    EXPECT_FALSE(concepts::is_arithmetic(*polynomial_type));
+}
+
+TEST_F(TestPolynomialType, TestDisplayAndParseFromString)
+{
+    Value value(polynomial_type, string_view("x^2+3*x+2")); // Example string
+    std::stringstream ss;
+    polynomial_type->display(ss, value.data());
+    EXPECT_EQ(ss.str(), "x^2+3*x+2"); // Example string
+}
+
+/******************************************************************************
+ *                                Comparison                                  *
+ ******************************************************************************/
+
+TEST_F(TestPolynomialType, TestHasEqualOperator)
+{
+    auto* comp = comp_trait();
+    ASSERT_NE(comp, nullptr);
+
+    EXPECT_TRUE(comp->has_comparison(ComparisonType::Equal));
+}
+
+TEST_F(TestPolynomialType, TestHasLessThanOperator)
+{
+    auto* comp = comp_trait();
+    ASSERT_NE(comp, nullptr);
+    EXPECT_FALSE(comp->has_comparison(ComparisonType::Less));
+}
+
+TEST_F(TestPolynomialType, TestHasGreaterThanOperator)
+{
+    auto* comp = comp_trait();
+    ASSERT_NE(comp, nullptr);
+    EXPECT_FALSE(comp->has_comparison(ComparisonType::Greater));
+}
+
+TEST_F(TestPolynomialType, TestHasLessThanOrEqualOperator)
+{
+    auto* comp = comp_trait();
+    ASSERT_NE(comp, nullptr);
+    EXPECT_FALSE(comp->has_comparison(ComparisonType::LessEqual));
+}
+
+TEST_F(TestPolynomialType, TestHasGreaterThanOrEqualOperator)
+{
+    auto* comp = comp_trait();
+    ASSERT_NE(comp, nullptr);
+    EXPECT_FALSE(comp->has_comparison(ComparisonType::GreaterEqual));
+}
+
+/******************************************************************************
+ *                                Arithmetic                                  *
+ ******************************************************************************/
+
+TEST_F(TestPolynomialType, TestAddOperator)
+{
+    auto* arith = arith_trait();
+    ASSERT_NE(arith, nullptr);
+
+    EXPECT_TRUE(arith->has_operation(ArithmeticOperation::Add));
+}
+
+TEST_F(TestPolynomialType, TestSubtractOperator)
+{
+    auto* arith = arith_trait();
+    ASSERT_NE(arith, nullptr);
+
+    EXPECT_TRUE(arith->has_operation(ArithmeticOperation::Sub));
+}
+
+TEST_F(TestPolynomialType, TestMultiplyOperator)
+{
+    auto* arith = arith_trait();
+    ASSERT_NE(arith, nullptr);
+
+    EXPECT_TRUE(arith->has_operation(ArithmeticOperation::Mul));
+}
+
+TEST_F(TestPolynomialType, TestDivideOperator)
+{
+    auto* arith = arith_trait();
+    ASSERT_NE(arith, nullptr);
+
+    EXPECT_FALSE(arith->has_operation(ArithmeticOperation::Div)); // Depending on your polynomial type
+}
+
+/******************************************************************************
+ *                                Number-like                                 *
+ ******************************************************************************/
+
+TEST_F(TestPolynomialType, TestRealAndImaginary)
+{
+    const auto* num = num_trait();
+    ASSERT_NE(num, nullptr);
+
+    EXPECT_FALSE(num->has_function(NumberFunction::Real));
+    EXPECT_FALSE(num->has_function(NumberFunction::Imaginary));
+}
+
+TEST_F(TestPolynomialType, TestAbsFunction)
+{
+    const auto* num = num_trait();
+    ASSERT_NE(num, nullptr);
+    EXPECT_FALSE(num->has_function(NumberFunction::Abs));
+}
+
+TEST_F(TestPolynomialType, TestSqrtExpLogFunction)
+{
+    const auto* num = num_trait();
+    ASSERT_NE(num, nullptr);
+
+    EXPECT_FALSE(num->has_function(NumberFunction::Sqrt));
+    EXPECT_FALSE(num->has_function(NumberFunction::Exp));
+    EXPECT_FALSE(num->has_function(NumberFunction::Log));
+}
+
+TEST_F(TestPolynomialType, TestPowFunction)
+{
+    const auto* num = num_trait();
+    ASSERT_NE(num, nullptr);
+    EXPECT_FALSE(num->has_function(NumberFunction::Pow));
+}
+
+TEST_F(TestPolynomialType, TestFromRationalFunction)
+{
+    const auto* num = num_trait();
+    ASSERT_NE(num, nullptr);
+    EXPECT_FALSE(num->has_function(NumberFunction::FromRational));
+}

--- a/platform/src/generics/polynomial_type/test_polynomial_type.cpp
+++ b/platform/src/generics/polynomial_type/test_polynomial_type.cpp
@@ -165,7 +165,7 @@ TEST_F(TestPolynomialType, TestDivideOperator)
     auto* arith = arith_trait();
     ASSERT_NE(arith, nullptr);
 
-    EXPECT_FALSE(arith->has_operation(ArithmeticOperation::Div)); // Depending on your polynomial type
+    EXPECT_TRUE(arith->has_operation(ArithmeticOperation::Div)); // Depending on your polynomial type
 }
 
 /******************************************************************************
@@ -209,5 +209,5 @@ TEST_F(TestPolynomialType, TestFromRationalFunction)
 {
     const auto* num = num_trait();
     ASSERT_NE(num, nullptr);
-    EXPECT_FALSE(num->has_function(NumberFunction::FromRational));
+    EXPECT_TRUE(num->has_function(NumberFunction::FromRational));
 }

--- a/platform/src/generics/polynomial_type/test_polynomial_type.cpp
+++ b/platform/src/generics/polynomial_type/test_polynomial_type.cpp
@@ -52,8 +52,8 @@ public:
 
 TEST_F(TestPolynomialType, TestID)
 {
-    EXPECT_EQ(polynomial_type->id(), "polynomial_id"); // Adjust ID accordingly
-    EXPECT_EQ(polynomial_type->name(), "polynomial");
+    EXPECT_EQ(polynomial_type->id(), "poly");
+    EXPECT_EQ(polynomial_type->name(), "Polynomial");
 }
 
 TEST_F(TestPolynomialType, TestRefCounting)
@@ -70,8 +70,6 @@ TEST_F(TestPolynomialType, TestRefCounting)
 
 TEST_F(TestPolynomialType, TestBasicProperties)
 {
-    EXPECT_EQ(polynomial_type->object_size(), sizeof(void*)); // Adjust if necessary
-
     EXPECT_FALSE(concepts::is_standard_layout(*polynomial_type));
     EXPECT_FALSE(concepts::is_trivially_copyable(*polynomial_type));
     EXPECT_FALSE(concepts::is_trivially_constructible(*polynomial_type));
@@ -88,10 +86,10 @@ TEST_F(TestPolynomialType, TestBasicProperties)
 
 TEST_F(TestPolynomialType, TestDisplayAndParseFromString)
 {
-    Value value(polynomial_type, string_view("x^2+3*x+2")); // Example string
+    Value value(polynomial_type, string_view("{ 15/2 2(x1) 1(x2^2) }")); // Example string
     std::stringstream ss;
     polynomial_type->display(ss, value.data());
-    EXPECT_EQ(ss.str(), "x^2+3*x+2"); // Example string
+    EXPECT_EQ(ss.str(), "{ 15/2 2(x1) 1(x2^2) }"); // Example string
 }
 
 /******************************************************************************

--- a/platform/src/generics/polynomial_types.cpp
+++ b/platform/src/generics/polynomial_types.cpp
@@ -1,0 +1,13 @@
+//
+// Created by sam on 27/11/24.
+//
+
+
+#include "roughpy/generics/type.h"
+
+#include "polynomial_type/polynomial_type.h"
+
+
+rpy::generics::TypePtr rpy::generics::get_polynomial_type() noexcept {
+    return PolynomialType::get();
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,97 +1,80 @@
 {
-  "name": "roughpy",
-  "version-string": "1.0.0",
-  "dependencies": [
-    {
-      "name": "libsndfile",
-      "version>=": "1.2.0"
-    },
-    {
-      "name": "eigen3",
-      "version>=": "3.4.0#2"
-    },
-    {
-      "name": "boost-align",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-container",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-core",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-url",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-multiprecision",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-type-traits",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-endian",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-dll",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "pcg",
-      "version>=": "2021-04-06#2"
-    },
-    {
-      "name": "cereal",
-      "version>=": "1.3.2#1"
-    },
-    {
-      "name": "boost-smart-ptr",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-uuid",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-interprocess",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "opencl",
-      "version>=": "v2024.05.08"
-    },
-    {
-      "name": "boost-stacktrace",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "range-v3",
-      "version>=": "0.12.0#4"
-    },
-    {
-      "name": "mpfr",
-      "version>=": "4.2.1"
-    },
-    {
-      "name": "gmp",
-      "version>=": "6.3.0#1"
-    }
-  ],
-  "features": {
-    "tests": {
-      "description": "dependencies for the unit tests",
-      "dependencies": [
-        {
-          "name": "gtest",
-          "version>=": "1.13.0"
-        }
-      ]
+  "name" : "roughpy",
+  "version-string" : "1.0.0",
+  "dependencies" : [ {
+    "name" : "libsndfile",
+    "version>=" : "1.2.0"
+  }, {
+    "name" : "eigen3",
+    "version>=" : "3.4.0#2"
+  }, {
+    "name" : "boost-align",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "boost-container",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "boost-core",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "boost-url",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "boost-multiprecision",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "boost-type-traits",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "boost-endian",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "boost-dll",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "pcg",
+    "version>=" : "2021-04-06#2"
+  }, {
+    "name" : "cereal",
+    "version>=" : "1.3.2#1"
+  }, {
+    "name" : "boost-smart-ptr",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "boost-uuid",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "boost-interprocess",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "opencl",
+    "version>=" : "v2024.05.08"
+  }, {
+    "name" : "boost-stacktrace",
+    "version>=" : "1.83.0"
+  }, {
+    "name" : "range-v3",
+    "version>=" : "0.12.0#4"
+  }, {
+    "name" : "mpfr",
+    "version>=" : "4.2.1"
+  }, {
+    "name" : "gmp",
+    "version>=" : "6.3.0#1"
+  }, {
+    "name" : "ctre",
+    "version>=" : "3.9.0"
+  }, {
+    "name" : "fmt",
+    "version>=" : "11.0.2#1"
+  } ],
+  "features" : {
+    "tests" : {
+      "description" : "dependencies for the unit tests",
+      "dependencies" : [ {
+        "name" : "gtest",
+        "version>=" : "1.13.0"
+      } ]
     }
   }
 }


### PR DESCRIPTION
This adds basic support for polynomial coefficients. This is part of the generic values overhaul outlined in #168.

To support the string parsing, I've brought in CTRE (compile time regular expressions) to avoid using `<regex>` which is dreadfully slow and tricky to use. I've also brought in `fmt` because it will be useful.
