### PR TITLE
Add RestrictionStream to handle restriction of a stream to a new inte…

### DIFF
--- a/streams/CMakeLists.txt
+++ b/streams/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(RoughPy_Streams SHARED
         include/roughpy/streams/parametrization.h
         include/roughpy/streams/stream_construction_helper.h
         include/roughpy/streams/channels.h
+        include/roughpy/streams/restriction_stream.h
+        src/restriction_stream.cpp
 )
 add_library(RoughPy::Streams ALIAS RoughPy_Streams)
 

--- a/streams/include/roughpy/streams/restriction_stream.h
+++ b/streams/include/roughpy/streams/restriction_stream.h
@@ -1,0 +1,38 @@
+//
+// Created by sammorley on 06/12/24.
+//
+
+#ifndef ROUGHPY_STREAMS_RESTRICTION_STREAM_H
+#define ROUGHPY_STREAMS_RESTRICTION_STREAM_H
+
+#include <memory>
+
+#include "roughpy/intervals/real_interval.h"
+
+#include "stream_base.h"
+#include "roughpy_streams_export.h"
+
+namespace rpy::streams {
+
+class ROUGHPY_STREAMS_EXPORT RestrictionStream : public StreamInterface {
+    intervals::RealInterval m_domain;
+    std::shared_ptr<const StreamInterface> p_stream;
+
+
+public:
+    RPY_NO_DISCARD bool
+    empty(const intervals::Interval& interval) const noexcept override;
+
+protected:
+    RPY_NO_DISCARD algebra::Lie log_signature_impl(
+        const intervals::Interval& interval,
+        const algebra::Context& ctx) const override;
+
+
+};
+
+
+
+}
+
+#endif //ROUGHPY_STREAMS_RESTRICTION_STREAM_H

--- a/streams/src/restriction_stream.cpp
+++ b/streams/src/restriction_stream.cpp
@@ -1,0 +1,40 @@
+//
+// Created by sammorley on 06/12/24.
+//
+
+#include "roughpy/streams/restriction_stream.h"
+
+#include <utility>
+
+using namespace rpy;
+using namespace rpy::streams;
+
+
+namespace {
+
+intervals::RealInterval intersection(const intervals::Interval& a,
+                                     const intervals::Interval& b)
+{
+    // TODO: Delete this once the proper function is merged
+    return {std::max(a.inf(), b.inf()), std::min(a.sup(), b.sup()), a.type()};
+}
+
+}
+
+bool rpy::streams::RestrictionStream::empty(
+    const intervals::Interval& interval) const noexcept
+{
+    if (!m_domain.intersects_with(interval)) { return true; }
+    auto query = intersection(m_domain, interval);
+    return p_stream->empty(query);
+}
+
+rpy::algebra::Lie rpy::streams::RestrictionStream::log_signature_impl(
+    const intervals::Interval& interval,
+    const algebra::Context& ctx) const
+{
+    RPY_CHECK(m_domain.intersects_with(interval));
+
+    auto query = intersection(m_domain, interval);
+    return p_stream->log_signature(query, ctx);
+}


### PR DESCRIPTION
Added a `RestrictionStream` class to handle the restriction of a stream to an interval that is not the original support.

Currently uses an inferior, self-defined intersection method. The value streams branch already contains a proper implementation in the intevals component, so this will be resolved there.