### PR TITLE
Fixed the degree bits in the libalgebra lite index_key type

### DIFF
--- a/vendored/libalgebra_lite/index_key.h
+++ b/vendored/libalgebra_lite/index_key.h
@@ -17,7 +17,7 @@ namespace dtl {
 struct index_key_access;
 } // namespace dtl
 
-template <int DegreeDigits=4, typename Int=dimn_t>
+template <int DegreeDigits=8, typename Int=dimn_t>
 class index_key
 {
     using limits = std::numeric_limits<Int>;


### PR DESCRIPTION
The index_key is used for basis keys for libalgebra_lite tensors and Lie algebras. The default number of bits was set to 4, meaning a maximum of degree 15 for basis keys. This is probably the source of numerous errors in RoughPy when using degree >= 16. This change fixes the number of bits to 8, giving a maximum of degree 255, which should be completely sufficient until we can finally get rid of libalgebra_lite and replacing the badness within