### PR TITLE
Add validation checks for width and depth in context creation

### DIFF
--- a/roughpy/src/algebra/context.cpp
+++ b/roughpy/src/algebra/context.cpp
@@ -485,6 +485,9 @@ static py::handle py_get_context(
         const py::kwargs& kwargs
 )
 {
+    RPY_CHECK_GT(width, 0);
+    RPY_CHECK_GT(depth, 0);
+
     // TODO: Make this accept extra arguments.
     return python::RPyContext_FromContext(
             get_context(width, depth, python::to_stype_ptr(ctype), {})


### PR DESCRIPTION
Width 0 or depth 0 are not well-behaved cases in RoughPy. This PR adds checks to the `get_context` function to ensure that these are properly reported as erroneous. For the time being, these cases must be treated as undefined behaviour, and thus should not be used. Our position on this may change in the future. Closes #177.