### PR TITLE
Fix various things with the GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,11 +79,6 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      #    - uses: microsoft/setup-msbuild@v1.1
-      #      if: runner.os == 'Windows'
-      #      with:
-      #        msbuild-architecture: x64
-
     - name: use ninja
       shell: bash
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,12 +88,6 @@ jobs:
       if: runner.os == 'Windows'
       uses: microsoft/setup-msbuild@v2
 
-    - name: Add msys2 to path for Windows
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        echo "C:\\msys64" >> $GITHUB_PATH
-
     - name: Setup ninja on Windows
       if: runner.os == 'Windows'
       uses: ashutoshvarma/setup-ninja@v1.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,15 +2,26 @@ name: tests
 
 on:
   workflow_dispatch:
-#  push:
-#    branches: [ "main" ]
-#    paths-ignore:
-#      - "examples/**"
-#      - "doc/**"
-#      - "README.md"
-#      - "*.txt"
-#      - "CHANGELOG"
-#      - "tools/*.py"
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - "examples/**"
+      - "doc/**"
+      - "README.md"
+      - "CHANGELOG"
+      - "tools/*.py"
+      - ".github/workflows/build_wheels.yml"
+      - ".github/dependabot.yml"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "branding/**"
+      - ".gitignore"
+      - "CMakePresets.json"
+      - "THANKS.txt"
+      - "LICENSE.txt"
+      - "VERSION.txt"
+      - "CITATION.cff"
+      - ".gitignore"
+
   pull_request:
     branches: [ "main" ]
     paths-ignore:
@@ -30,6 +41,8 @@ on:
       - "VERSION.txt"
       - "CITATION.cff"
       - ".gitignore"
+
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,6 @@ jobs:
       shell: bash
       run: |
         echo "C:\\msys64" >> $GITHUB_PATH
-        echo "VCPKG_FORCE_SYSTEM_BINARIES=1" >> $GITHUB_ENV
 
     - name: Setup ninja on Windows
       if: runner.os == 'Windows'
@@ -138,6 +137,7 @@ jobs:
       env:
         CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
         MACOSX_DEPLOYMENT_TARGET: 11.0.0
+        VCPKG_FORCE_SYSTEM_BINARIES: 1
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,6 +93,13 @@ jobs:
       if: runner.os == 'Windows'
       uses: microsoft/setup-msbuild@v2
 
+    - name: Add msys2 to path for Windows
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        echo "C:\\msys64" >> $GITHUB_PATH
+        echo "VCPKG_FORCE_SYSTEM_BINARIES=1" >> $GITHUB_ENV
+
     - name: Setup ninja on Windows
       if: runner.os == 'Windows'
       uses: ashutoshvarma/setup-ninja@v1.1
@@ -129,15 +136,12 @@ jobs:
       run: |
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DROUGHPY_BUILD_TESTS=ON -DROUGHPY_BUILD_PYMODULE_INPLACE=ON
       env:
-        VERBOSE: 1
         CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
         MACOSX_DEPLOYMENT_TARGET: 11.0.0
 
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{ github.workspace }}/build --config ${{env.BUILD_TYPE}}
-      env:
-        VERBOSE: 1
 
     - name: Test
       shell: bash


### PR DESCRIPTION
There are several problems with the GitHub actions. The first, and probably most serious, is that the cached artefacts from previous builds are not used when running tests on new PRs currently. This is devastating on Windows where building all the dependencies take ~25 minutes. This eats up a lot of compute time but also really hinders fast iterations where one creates multiple PRs in quick succession.

I've re-enabled the tests on push to main, which should do two things. Fist, it will trigger workflows whenever main is updated (which should only occur on merged PRs anyway) and it will build cache entries on the main branch, where they can be reused in others. (All actions on a repo have access to the default branch https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache.) This will at least create caches semi-regularly in the main branch which then will be used for all workflows (at least in theory).

There are other fixes that I will incorporate, but I've opened this PR immediately to see the workflow runs.