### PR TITLE
Fix infinite loop if support not specified

### DIFF
--- a/roughpy/src/streams/lie_increment_stream.cpp
+++ b/roughpy/src/streams/lie_increment_stream.cpp
@@ -114,8 +114,7 @@ static py::object lie_increment_stream_from_increments(py::object data, py::kwar
 
     dimn_t num_increments = ks_stream.row_count();
 
-    auto effective_support
-            = intervals::RealInterval::right_unbounded(0.0, md.interval_type);
+    intervals::RealInterval effective_support (0.0, 1.0, md.interval_type);
 
     if (kwargs.contains("indices")) {
         auto indices_arg = kwargs_pop(kwargs, "indices");
@@ -232,7 +231,13 @@ static py::object lie_increment_stream_from_increments(py::object data, py::kwar
              *md.resolution},
             md.schema
     ));
-    if (md.support) { result.restrict_to(*md.support); }
+
+    if (md.support) {
+        result.restrict_to(*md.support);
+    }
+    else {
+        result.restrict_to(effective_support);
+    }
 
     return py::reinterpret_steal<py::object>(
             python::RPyStream_FromStream(std::move(result))

--- a/tests/streams/test_lie_increment_path.py
+++ b/tests/streams/test_lie_increment_path.py
@@ -411,3 +411,61 @@ def test_construct_sequence_of_lies():
     lsig = stream.log_signature(rp.RealInterval(0, 1))
 
     assert lsig == seq[0], f"{lsig} != {seq[0]}"
+
+
+def esig_stream2sig(array, depth):
+    no_pts, width = array.shape
+    ctx = rp.get_context(width=width, depth=depth, coeffs=rp.DPReal)
+
+    increments = np.diff(array, axis=0)
+
+    stream = rp.LieIncrementStream.from_increments(increments, ctx=ctx)
+
+    return stream.signature()
+
+
+def test_equivariance_esig_treelike1():
+
+    tree_like = np.array([
+            [0.0, 0],
+            [1, 0],
+            [1, 1],
+            [1, 0],
+            [2, 0],
+            [3, 1],
+            [2, 2],
+            [1, 1],
+            [2, 2],
+            [1, 3],
+            [2, 2],
+            [3, 3],
+            [2, 2],
+            [3, 1],
+            [4, 1],
+            [3, 1],
+            [2, 0],
+            [2, -1],
+            [2, 0],
+            [1, 0],
+            [1, -1],
+            [1, 0],
+            [0, 0],
+        ], dtype=np.float64)
+
+    pruned = np.array([[0.0, 0.0]], dtype=np.float64)
+
+    assert_array_almost_equal(esig_stream2sig(tree_like, 2), esig_stream2sig(pruned, 2))
+
+
+def test_equivariance_esig_treelike2():
+
+    tree_like = np.array([[0.0, 0], [1, 3], [0, 0], [1, 5], [2, 5], [1, 5], [0, 6], [1, 5], [0, 0]], dtype=np.float64)
+    pruned = np.array([[0., 0.]], dtype=np.float64)
+
+    assert_array_almost_equal(esig_stream2sig(tree_like, 2), esig_stream2sig(pruned, 2))
+
+def test_equivariance_esig_treelike3():
+    tree_like = np.array([[0.0, 0], [1, 1], [3, 1], [2, 1], [1, 1], [2, 0]], dtype=np.float64)
+    pruned = np.array([[0., 0.], [1. ,1.], [2., 0]], dtype=np.float64)
+
+    assert_array_almost_equal(esig_stream2sig(tree_like, 2), esig_stream2sig(pruned, 2))


### PR DESCRIPTION
The esig interface exposed a bug in which not specifying the support would cause an infinite loop as the dyadic intervals over the unbounded interval [0, +inf) were enumerated in the case where no increments were provided to stream constructor. This is caused by the construct setting the unbounded interval as the default value, which is usually overwritten by either the additional arguments or is inferred from the timestamps during the construction process. Of course, both fail is the support is not provided and no data is provided. This is now fixed by setting the effective support to [0, 1).