### PR TITLE
Fix bug signature domain

### DIFF
--- a/streams/src/stream.cpp
+++ b/streams/src/stream.cpp
@@ -151,6 +151,9 @@ rpy::streams::Stream::Lie rpy::streams::Stream::log_signature(
     auto amended_query = refine_interval(interval);
     if (!amended_query) { return zero_lie(ctx); }
 
+    if (resolution < amended_query->second) {
+        resolution = amended_query->second;
+    }
     return log_signature_impl(amended_query->first, resolution, ctx);
 }
 Stream::FreeTensor Stream::signature(

--- a/streams/src/stream.cpp
+++ b/streams/src/stream.cpp
@@ -151,9 +151,6 @@ rpy::streams::Stream::Lie rpy::streams::Stream::log_signature(
     auto amended_query = refine_interval(interval);
     if (!amended_query) { return zero_lie(ctx); }
 
-    if (resolution < amended_query->second) {
-        resolution = amended_query->second;
-    }
     return log_signature_impl(amended_query->first, resolution, ctx);
 }
 Stream::FreeTensor Stream::signature(

--- a/tests/streams/test_lie_increment_path.py
+++ b/tests/streams/test_lie_increment_path.py
@@ -483,7 +483,7 @@ def test_linear_signature():
 
     stream = LieIncrementStream.from_increments(np.array([increment]), indices=indices, ctx=ctx)
 
-    sig = stream.signature(rp.RealInterval(0., 1.))
+    sig = stream.signature(rp.RealInterval(0., 1.), resolution=0)
 
     level0 = np.array([1.])
     level1 = increment

--- a/tests/streams/test_lie_increment_path.py
+++ b/tests/streams/test_lie_increment_path.py
@@ -483,7 +483,7 @@ def test_linear_signature():
 
     stream = LieIncrementStream.from_increments(np.array([increment]), indices=indices, ctx=ctx)
 
-    sig = stream.signature(rp.RealInterval(0., 1.), resolution=0)
+    sig = stream.signature(rp.RealInterval(0., 1.))
 
     level0 = np.array([1.])
     level1 = increment


### PR DESCRIPTION
The internals of Lie increment path have changed somewhat leading to a problem whereby requesting a signature over the unit interval with resolution 0, does not provide the correct answer. The problem is that internally the query interval is trimmed to without an adjusted resolution. This PR fixes this issue.