### PR TITLE
Fix pool allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ find_boost(VERSION 1.83 COMPONENTS
     endian
     interprocess
     multiprecision
+    pool
     smart_ptr
     type_traits
     url

--- a/platform/src/alloc.cpp
+++ b/platform/src/alloc.cpp
@@ -5,8 +5,8 @@
 #include "roughpy/platform/alloc.h"
 
 #include <new>
-#include <memory_resource>
 
+#include <boost/pool/singleton_pool.hpp>
 #include <boost/align/aligned_alloc.hpp>
 #include <roughpy/core/traits.h>
 
@@ -25,61 +25,108 @@ void rpy::mem::aligned_free(void* ptr, size_t size) noexcept
     boost::alignment::aligned_free(ptr);
 }
 
+//
+// namespace {
+//
+// class PageAlignedMemoryResource : public std::pmr::memory_resource
+// {
+//
+// protected:
+//     void* do_allocate(size_t bytes, size_t alignment) override
+//     {
+//         ignore_unused(alignment);
+//         void* ptr = mem::aligned_alloc(small_chunk_size, bytes);
+//         if (!ptr) { throw std::bad_alloc(); }
+//         return ptr;
+//     }
+//
+//     void do_deallocate(void* p, size_t bytes, size_t alignment) override
+//     {
+//         ignore_unused(alignment);
+//         return mem::aligned_free(p, bytes);
+//     }
+//
+//     bool do_is_equal(const std::pmr::memory_resource& other
+//     ) const noexcept override
+//     {
+//         return this == &other;
+//     }
+//
+// public:
+//     static PageAlignedMemoryResource* get() noexcept
+//     {
+//         static PageAlignedMemoryResource instance;
+//         return &instance;
+//     }
+// };
+//
+// std::pmr::synchronized_pool_resource* get_pool() noexcept
+// {
+//     static std::pmr::synchronized_pool_resource pool (
+//         std::pmr::pool_options{ small_blocks_per_chunk, small_block_size },
+//         PageAlignedMemoryResource::get());
+//     return &pool;
+// }
+// }
+
 
 namespace {
 
-class PageAlignedMemoryResource : public std::pmr::memory_resource
+
+struct MyAlignedAlloc
 {
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
 
-protected:
-    void* do_allocate(size_t bytes, size_t alignment) override
+    static char* malloc BOOST_PREVENT_MACRO_SUBSTITUTION(const size_type size) noexcept
     {
-        ignore_unused(alignment);
-        void* ptr = mem::aligned_alloc(small_chunk_size, bytes);
-        if (!ptr) { throw std::bad_alloc(); }
-        return ptr;
+        return static_cast<char*>(mem::aligned_alloc(small_chunk_size, size));
     }
 
-    void do_deallocate(void* p, size_t bytes, size_t alignment) override
+    static void free BOOST_PREVENT_MACRO_SUBSTITUTION(char* const block) noexcept
     {
-        ignore_unused(alignment);
-        return mem::aligned_free(p, bytes);
+        mem::aligned_free(block, small_chunk_size);
     }
 
-    bool do_is_equal(const std::pmr::memory_resource& other
-    ) const noexcept override
-    {
-        return this == &other;
-    }
-
-public:
-    static PageAlignedMemoryResource* get() noexcept
-    {
-        static PageAlignedMemoryResource instance;
-        return &instance;
-    }
 };
 
-std::pmr::synchronized_pool_resource* get_pool() noexcept
+boost::pool<MyAlignedAlloc>* get_pool() noexcept
 {
-    static std::pmr::synchronized_pool_resource pool (
-        std::pmr::pool_options{ small_blocks_per_chunk, small_block_size },
-        PageAlignedMemoryResource::get());
+    static boost::pool<MyAlignedAlloc> pool {small_block_size, small_blocks_per_chunk};
     return &pool;
 }
+
+
 }
+
 
 void* rpy::mem::small_object_alloc(size_t size)
 {
-    return get_pool()->allocate(size);
+    static constexpr size_t max_alignment = alignof(std::max_align_t);
+    // return get_pool()->allocate(size);
+    if (size > small_block_size) {
+        return aligned_alloc(max_alignment, size);
+    }
+    return get_pool()->malloc();
 }
+
 void rpy::mem::small_object_free(void* ptr, size_t size)
 {
-    get_pool()->deallocate(ptr, size);
+    if (size > small_block_size) {
+        aligned_free(ptr, size);
+    } else {
+        get_pool()->free(static_cast<char*>(ptr));
+    }
+
+    // get_pool()->deallocate(ptr, size);
 }
-void* SmallObjectBase::operator new(size_t size) {
+
+void* SmallObjectBase::operator new(size_t size)
+{
     return small_object_alloc(size);
 }
-void SmallObjectBase::operator delete(void* object, size_t size) {
+
+void SmallObjectBase::operator delete(void* object, size_t size)
+{
     small_object_free(object, size);
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -64,6 +64,9 @@
   }, {
     "name" : "fmt",
     "version>=" : "11.0.2#1"
+  }, {
+    "name" : "boost-pool",
+    "version>=" : "1.86.0"
   } ],
   "features" : {
     "tests" : {


### PR DESCRIPTION
Older versions of libc++, such as those found on MacOs <14, don't implement `std::pmr::memory_resource`, but for some reason still compiles and links. This leads to a rather frustrating missing symbol error at load-time, causing the program to fail unexpectedly. For this reason, I've swapped out the `std::pmr::synchronized_pool_allocator` for a `boost::pool` that also provides a pool-style allocator that we can use for small objects. I don't know if this functions in precisely the same way was the std version, but at least it is platform independent and faster than "malloc"ing everything.