### PR TITLE
Fix build wheel action

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -101,12 +101,6 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: install pkgconfig on windows
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          choco install pkgconfiglite
-
       - name: Install build deps on MacOs
         if: runner.os == 'macOs'
         run:  brew install autoconf automake libtool m4 ninja

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -107,6 +107,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 11.0.0
           GITHUB_TOK: "${{ secrets.GITHUB_TOKEN }}"
           CMAKE_GENERATOR: "Ninja"
+          CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -89,6 +89,13 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
+      - name: Setup msbuild on Windows
+        if: runner.os == 'Windows'
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Enable developer command prompt
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install build deps on MacOs
         if: runner.os == 'macOs'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -116,7 +116,6 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 11.0.0
           GITHUB_TOK: "${{ secrets.GITHUB_TOKEN }}"
-          CMAKE_GENERATOR: "Ninja"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -106,6 +106,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 11.0.0
           GITHUB_TOK: "${{ secrets.GITHUB_TOKEN }}"
+          CMAKE_GENERATOR: "Ninja"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -89,17 +89,6 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Setup msbuild on Windows
-        if: runner.os == 'Windows'
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Setup ninja on Windows
-        if: runner.os == 'Windows'
-        uses: ashutoshvarma/setup-ninja@v1.1
-
-      - name: Enable developer command prompt
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install build deps on MacOs
         if: runner.os == 'macOs'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,11 +91,11 @@ jobs:
       if: runner.os == 'Windows'
       uses: ilammy/msvc-dev-cmd@v1
 
-    - name: install pkgconfig on windows
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        choco install pkgconfiglite
+#    - name: install pkgconfig on windows
+#      if: runner.os == 'Windows'
+#      shell: bash
+#      run: |
+#        choco install pkgconfiglite
 
     - name: install autoconf on macos
       if: runner.os == 'macOs'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,7 +117,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DROUGHPY_BUILD_TESTS=ON -DROUGHPY_BUILD_PYMODULE_INPLACE=ON
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DROUGHPY_BUILD_TESTS=ON
       env:
         CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
         MACOSX_DEPLOYMENT_TARGET: 11.0.0

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -89,9 +89,6 @@ target_link_libraries(RoughPy_Platform PUBLIC
 
 set_target_properties(RoughPy_Platform PROPERTIES ROUGHPY_COMPONENT Platform)
 
-if (APPLE)
-    target_compile_definitions(RoughPy_Platform PUBLIC BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED)
-endif()
 
 
 set_library_version_properties(RoughPy_Platform)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ before-all = "bash tools/ci/before-all-common.sh"
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel"
 repair-wheel-command = "delvewheel repair -w {dest_dir} --ignore-in-wheel {wheel}"
+environment = [
+    "SKBUILD_CMAKE_DEFINE=\"CC=cl;CXX=cl\""
+]
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = "auditwheel show {wheel} && auditwheel repair -w {dest_dir} {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ before-all = "bash tools/ci/before-all-common.sh"
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel"
 repair-wheel-command = "delvewheel repair -w {dest_dir} --ignore-in-wheel {wheel}"
-environment = { SKBUILD_CMAKE_DEFINE = "CC=cl;CXX=cl" }
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = "auditwheel show {wheel} && auditwheel repair -w {dest_dir} {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,9 +125,7 @@ before-all = "bash tools/ci/before-all-common.sh"
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel"
 repair-wheel-command = "delvewheel repair -w {dest_dir} --ignore-in-wheel {wheel}"
-environment = [
-    "SKBUILD_CMAKE_DEFINE=\"CC=cl;CXX=cl\""
-]
+environment = { SKBUILD_CMAKE_DEFINE = "CC=cl;CXX=cl" }
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = "auditwheel show {wheel} && auditwheel repair -w {dest_dir} {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,6 @@ test-command = [
     "pytest {project}/tests"
 ]
 before-all = "bash tools/ci/before-all-common.sh"
-environment= "CMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake VCPKG_OVERLAY_TRIPLETS=./tools/ci/triplets"
 
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel"

--- a/tools/ci/before-all-common.sh
+++ b/tools/ci/before-all-common.sh
@@ -27,6 +27,10 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+echo $OSTYPE
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  yum install -y curl zip unzip tar
+fi
 
 
 git clone https://github.com/Microsoft/vcpkg.git tools/vcpkg


### PR DESCRIPTION
The wheel action needed an update to make it use Ninja on Windows; MSBuild is painfully slow and Ninja makes this run much faster. Bringing over the settings from the test action made the build fail. It turned out that Visual studio brought it's own version of VCPKG that was being used preferentially because VCPKG_ROOT was not set in the wheels action. This caused the installation of dependencies to fail (out-of-date vcpkg or something more sinister). This is fixed by setting the toolchain explicitly, like in the tests action. For some reason, this makes the installation successful.