### PR TITLE
Small object allocators for algebras and streams

### DIFF
--- a/algebra/include/roughpy/algebra/interfaces/algebra_interface.h
+++ b/algebra/include/roughpy/algebra/interfaces/algebra_interface.h
@@ -31,6 +31,7 @@
 #include <roughpy/algebra/context_fwd.h>
 
 #include <roughpy/core/macros.h>
+#include "roughpy/platform/alloc.h"
 #include <roughpy/scalars/scalar_type.h>
 
 
@@ -47,7 +48,7 @@ namespace dtl {
  * various places. If you define an algebra interface, it should derive
  * from the base AlgebraInterface, which publicly derives from this tag.
  */
-class AlgebraInterfaceBase
+class AlgebraInterfaceBase : public mem::SmallObjectBase
 {
 protected:
     context_pointer p_ctx;

--- a/streams/include/roughpy/streams/stream_base.h
+++ b/streams/include/roughpy/streams/stream_base.h
@@ -40,6 +40,7 @@
 #include <roughpy/intervals/real_interval.h>
 #include <roughpy/platform/serialization.h>
 #include <roughpy/platform/errors.h>
+#include "roughpy/platform/alloc.h"
 
 #include "schema.h"
 
@@ -97,7 +98,7 @@ inline resolution_t param_to_resolution(param_t arg) noexcept
  * computed from log signatures, rather than using the data to compute these
  * independently.)
  */
-class ROUGHPY_STREAMS_EXPORT StreamInterface
+class ROUGHPY_STREAMS_EXPORT StreamInterface : public mem::SmallObjectBase
 {
     StreamMetadata m_metadata;
     std::shared_ptr<StreamSchema> p_schema;


### PR DESCRIPTION
The base algebra interface and stream interface now inherit from `SmallObjectBase` and will make use of the pool allocator for allocations rather than a raw `malloc` or `operator new`. This should improve performance in the long run since lots of these allocations occur.