### PR TITLE
test: pybind embed test framework (#199)

### DIFF
--- a/roughpy/CMakeLists.txt
+++ b/roughpy/CMakeLists.txt
@@ -47,6 +47,11 @@ if (ROUGHPY_LINK_NUMPY)
     list(APPEND _python_components NumPy)
 endif ()
 
+if (ROUGHPY_BUILD_TESTS)
+    # Required to link test_RoughPy_PyModule
+    list(APPEND _python_components Development.Embed)
+endif()
+
 
 find_package(Python 3.8 REQUIRED COMPONENTS ${_python_components})
 unset(_python_components)
@@ -252,6 +257,17 @@ if (ROUGHPY_BUILD_TESTS)
 #
 #
 
+    # Tests interrogating Python data in C++
+    add_executable(test_RoughPy_PyModule
+        src/test_python_embed.cpp
+    )
 
+    target_link_libraries(test_RoughPy_PyModule
+        PRIVATE
+            pybind11::embed
+            RoughPy::Algebra # FIXME review linkage
+    )
+
+    setup_roughpy_cpp_tests(test_RoughPy_PyModule)
 
 endif()

--- a/roughpy/src/test_python_embed.cpp
+++ b/roughpy/src/test_python_embed.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 RoughPy Developers. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+#include <pybind11/embed.h>
+#include <roughpy/algebra/free_tensor.h>
+
+namespace {
+
+namespace py = pybind11;
+using namespace pybind11::literals; // use _a literal
+
+} // namespace
+
+
+TEST(test_RoughPy_PyModule, CreateFreeTensor)
+{
+    py::scoped_interpreter guard{};
+    py::module_ rp = py::module_::import("roughpy");
+    py::object context = rp.attr("get_context")(
+        "width"_a = 2,
+        "depth"_a = 3,
+        "coeffs"_a = rp.attr("RationalPoly")
+    );
+
+    int N = context.attr("tensor_size")().cast<int>();
+    py::list ones;
+    for (int i = 0; i < N; ++i) {
+        ones.append(1);
+    }
+
+    py::object a = rp.attr("FreeTensor")(
+        ones,
+        "ctx"_a = context
+    );
+    std::string a_str = py::str(a).cast<std::string>();
+
+    // Initial test: check that C++ cast is correct and values match
+    auto* a_ptr = a.cast<rpy::algebra::FreeTensor*>();
+    std::ostringstream a_ptr_str;
+    a_ptr_str << *a_ptr;
+    ASSERT_EQ(a_ptr_str.str(), a_str);
+}


### PR DESCRIPTION
- Initial unit test is a placeholder to demonstrate pybind11::embed functionality, constructing a FreeTensor from a context in Python API and then checking the returned pointer in C++ API.
- Outstanding FIXME in CMakeLists to review linkage; running more than import results in a `double free or corruption (out)` which I think is due to using external rougpy import rather than private embedding.