### PR TITLE
Add conan build support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Python dependencies
       shell: bash
       run: |
-        python -m pip install numpy ninja pytest pybind11
+        python -m pip install numpy ninja pytest pybind11<3.0.0
 
     - name: setup vcpkg
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Python dependencies
       shell: bash
       run: |
-        python -m pip install numpy ninja pytest pybind11<3.0.0
+        python -m pip install numpy ninja pytest "pybind11<3.0.0"
 
     - name: setup vcpkg
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ else()
     find_package(OpenCL CONFIG REQUIRED)
     find_package(PCGRandom REQUIRED)
     find_package(GMP REQUIRED)
-    find_package(MPR REQUIRED)
+    find_package(MPFR REQUIRED)
 endif()
 
 message(STATUS "Target architecture ${RPY_ARCH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,13 @@ option(ROUGHPY_LINK_NUMPY "Link with Numpy library for array handling" ${ROUGHPY
 option(ROUGHPY_GENERATE_DEVICE_CODE "Generate code for objects on devices" OFF)
 option(ROUGHPY_DISABLE_BLAS "Disable linking to blas/lapack" ON)
 
+if (DEFINED CONAN_COMMAND
+        OR "${CMAKE_PROJECT_TOP_LEVEL_INCLUDES}" MATCHES "conan_provider.cmake"
+        OR "${CMAKE_TOOLCHAIN_FILE}" MATCHES "conan_toolchain.cmake")
+    set(RPY_USING_CONAN ON CACHE BOOL "Are we using the Conan package manager")
+else()
+    set(RPY_USING_CONAN CACHE BOOL "Are we using the Conan package manager")
+endif()
 
 # RoughPy usually requires vcpkg to ensure all the dependencies are installed
 # and available for the build system. This file sets everything up including,
@@ -175,14 +182,23 @@ find_boost(VERSION 1.83 COMPONENTS
 
 find_package(Eigen3 CONFIG REQUIRED)
 find_package(SndFile CONFIG CONFIG REQUIRED)
-find_package(OpenCL CONFIG REQUIRED)
 find_package(cereal CONFIG REQUIRED)
-find_package(PCGRandom REQUIRED)
-find_package(GMP REQUIRED)
-find_package(MPFR REQUIRED)
 find_package(range-v3 CONFIG REQUIRED)
 find_package(ctre CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
+
+if (RPY_USING_CONAN)
+    find_package(OpenCLICDLoader CONFIG REQUIRED)
+    find_package(OpenCLHeaders CONFIG REQUIRED)
+    find_package(pcg-cpp CONFIG REQUIRED)
+    find_package(gmp CONFIG REQUIRED)
+    find_package(mpfr CONFIG REQUIRED)
+else()
+    find_package(OpenCL CONFIG REQUIRED)
+    find_package(PCGRandom REQUIRED)
+    find_package(GMP REQUIRED)
+    find_package(MPR REQUIRED)
+endif()
 
 message(STATUS "Target architecture ${RPY_ARCH}")
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,7 +20,7 @@
       "hidden": true,
       "cacheVariables": {
         "ROUGHPY_BUILD_TESTS": "ON",
-        "ROUGHPY_BUILD_TEST_PYTHON_EMBED": "ON"
+        "ROUGHPY_BUILD_TEST_PYTHON_EMBED": "OFF"
       }
     },
     {

--- a/algebra/src/CMakeLists.txt
+++ b/algebra/src/CMakeLists.txt
@@ -19,7 +19,7 @@ if (ROUGHPY_BUILD_TESTS)
     target_link_libraries(test_algebra PRIVATE
         RoughPy::Algebra
         GTest::gtest
-        GMP::GMP
+        gmp::gmp
     )
 
     setup_roughpy_cpp_tests(test_algebra)

--- a/cmake/Modules/FindGMP.cmake
+++ b/cmake/Modules/FindGMP.cmake
@@ -19,7 +19,7 @@ if (PC_GMP_FOUND)
     set(GMP_COMPILE_OPTIONS ${PC_GMP_CFLAGS} ${PC_GMP_CFLAGS_OTHER})
     set(GMP_LINK_OPTIONS ${PC_GMP_LDFLAGS} ${PC_GMP_LDFLAGS_OTHER})
 
-    add_library(GMP::GMP ALIAS PkgConfig::PC_GMP)
+    add_library(gmp::gmp ALIAS PkgConfig::PC_GMP)
 else()
 
     set(_gmp_lib_names gmp libgmp gmp-10 libgmp-10 mpir libmpir)
@@ -68,7 +68,6 @@ else()
     )
 
     if (GMP_FOUND AND NOT TARGET gmp::gmp)
-        message(STATUS "Found gmp library, adding target")
         add_library(gmp::gmp UNKNOWN IMPORTED GLOBAL)
         set_target_properties(gmp::gmp PROPERTIES
                 IMPORTED_LOCATION "${GMP_LIBRARY}"

--- a/cmake/Modules/FindGMP.cmake
+++ b/cmake/Modules/FindGMP.cmake
@@ -67,9 +67,9 @@ else()
             GMP_LINK_OPTIONS
     )
 
-    if (GMP_FOUND AND NOT TARGET GMP::GMP)
-        add_library(GMP::GMP UNKNOWN IMPORTED GLOBAL)
-        set_target_properties(GMP::GMP PROPERTIES
+    if (GMP_FOUND AND NOT TARGET gmp::gmp)
+        add_library(gmp::gmp UNKNOWN IMPORTED GLOBAL)
+        set_target_properties(gmp::gmp PROPERTIES
                 IMPORTED_LOCATION "${GMP_LIBRARY}"
                 INTERFACE_INCLUDE_DIRECTORIES "${GMP_INCLUDE_DIR}"
                 IMPORTED_IMPLIB "${GMP_LIBRARY}"

--- a/cmake/Modules/FindGMP.cmake
+++ b/cmake/Modules/FindGMP.cmake
@@ -68,6 +68,7 @@ else()
     )
 
     if (GMP_FOUND AND NOT TARGET gmp::gmp)
+        message(STATUS "Found gmp library, adding target")
         add_library(gmp::gmp UNKNOWN IMPORTED GLOBAL)
         set_target_properties(gmp::gmp PROPERTIES
                 IMPORTED_LOCATION "${GMP_LIBRARY}"

--- a/cmake/Modules/FindMPFR.cmake
+++ b/cmake/Modules/FindMPFR.cmake
@@ -67,9 +67,9 @@ else ()
             MPFR_LINK_OPTIONS
     )
 
-    if (MPFR_FOUND AND NOT MPFR::MPFR)
-        add_library(MPFR::MPFR UNKNOWN IMPORTED GLOBAL)
-        set_target_properties(MPFR::MPFR PROPERTIES
+    if (MPFR_FOUND AND NOT mpfr::mpfr)
+        add_library(mpfr::mpfr UNKNOWN IMPORTED GLOBAL)
+        set_target_properties(mpfr::mpfr PROPERTIES
                 IMPORTED_LOCATION "${MPFR_LIBRARY}"
                 INTERFACE_INCLUDE_DIRECTORIES "${MPFR_INCLUDE_DIR}"
                 IMPORTED_IMPLIB "${MPFR_LIBRARY}"

--- a/cmake/Modules/FindMPFR.cmake
+++ b/cmake/Modules/FindMPFR.cmake
@@ -21,7 +21,7 @@ if (PC_MPFR_FOUND)
     set(MPFR_COMPILE_OPTIONS "${PC_MPFR_CFLAGS} ${PC_MPFR_CFLAGS_OTHER}")
     set(MPFR_LINK_OPTIONS "${PC_MPFR_LDFLAGS} ${PC_MPFR_LDFLAGS_OTHER}")
 
-    add_library(MPFR::MPFR ALIAS PkgConfig::PC_MPFR)
+    add_library(mpfr::mpfr ALIAS PkgConfig::PC_MPFR)
 else ()
     set(_mpfr_lib_names mpfr libmpfr)
 

--- a/cmake/Modules/FindPCGRandom.cmake
+++ b/cmake/Modules/FindPCGRandom.cmake
@@ -9,10 +9,10 @@ find_package_handle_standard_args(PCGRandom
         )
 
 
-if (PCGRandom_FOUND AND NOT TARGET PCGRandom::pcg_random)
+if (PCGRandom_FOUND AND NOT TARGET pcg-cpp::pcg-cpp)
 
-    add_library(PCGRandom::pcg_random IMPORTED INTERFACE GLOBAL)
-    set_target_properties(PCGRandom::pcg_random PROPERTIES
+    add_library(pcg-cpp::pcg-cpp IMPORTED INTERFACE GLOBAL)
+    set_target_properties(pcg-cpp::pcg-cpp PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${PCGRandom_INCLUDE_DIRS}"
             )
 

--- a/cmake/roughpy_helpers.cmake
+++ b/cmake/roughpy_helpers.cmake
@@ -59,6 +59,9 @@ function(find_boost)
 
     cmake_parse_arguments("BOOST" "" "VERSION" "COMPONENTS" ${ARGN})
 
+    if (ROUGHPY_NO_VCPKG)
+        find_package(Boost ${BOOST_VERSION} CONFIG REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+    else()
     foreach (lib IN LISTS BOOST_COMPONENTS)
         message(STATUS "finding boost library ${lib}")
         if (DEFINED BOOST_VERSION)
@@ -72,8 +75,9 @@ function(find_boost)
         endif()
 
     endforeach ()
+        add_library(Boost::boost ALIAS Boost::headers)
+    endif()
 
-    add_library(Boost::boost ALIAS Boost::headers)
 
 endfunction()
 

--- a/cmake/vcpkg_setup.cmake
+++ b/cmake/vcpkg_setup.cmake
@@ -1,7 +1,8 @@
 
 include_guard()
 
-if (ROUGHPY_NO_VCPKG OR "${CMAKE_TOOLCHAIN_FILE}" MATCHES "vcpkg.cmake")
+if (ROUGHPY_NO_VCPKG OR "${CMAKE_TOOLCHAIN_FILE}" MATCHES "vcpkg.cmake"
+    OR RPY_USING_CONAN)
     # Do not use vcpkg, or vcpkg toolchain already set up
     message(DEBUG "Not using vcpkg or toolchain already set")
     return()

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,0 +1,15 @@
+# This file is managed by Conan, contents will be overwritten.
+# To keep your changes, remove these comment lines, but the plugin won't be able to modify your requirements
+
+requirements:
+  - "opencl-icd-loader/2023.12.14"
+  - "opencl-headers/2023.12.14"
+  - "pcg-cpp/cci.20220409"
+  - "cereal/1.3.2"
+  - "range-v3/0.12.0"
+  - "fmt/11.2.0"
+  - "mpfr/4.2.2"
+  - "ctre/3.9.0"
+  - "libsndfile/1.2.2"
+  - "boost/1.88.0"
+  - "gmp/6.3.0"

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,23 @@
+# This file is managed by Conan, contents will be overwritten.
+# To keep your changes, remove these comment lines, but the plugin won't be able to modify your requirements
+
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMakeToolchain
+
+class ConanApplication(ConanFile):
+    package_type = "application"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.user_presets_path = False
+        tc.generate()
+
+    def requirements(self):
+        requirements = self.conan_data.get('requirements', [])
+        for requirement in requirements:
+            self.requires(requirement)

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -8,7 +8,8 @@ add_library(RoughPy::PrecompiledHeaders ALIAS RoughPy_PrecompiledHeaders)
 target_link_libraries(RoughPy_PrecompiledHeaders INTERFACE
         Boost::headers
         cereal::cereal
-        GMP::GMP
+#        GMP::GMP
+        gmp::gmp
         Libalgebra_lite::Libalgebra_lite
 )
 
@@ -81,6 +82,7 @@ target_link_libraries(RoughPy_Platform PUBLIC
         Boost::system
         Boost::url
         Eigen3::Eigen
+        cereal::cereal
         Libalgebra_lite::Libalgebra_lite
         PRIVATE
         RoughPy::PrecompiledHeaders

--- a/platform/src/generics/multiprecision_types/CMakeLists.txt
+++ b/platform/src/generics/multiprecision_types/CMakeLists.txt
@@ -46,8 +46,8 @@ target_sources(RoughPy_Platform PRIVATE
 
 
 target_link_libraries(RoughPy_Platform PRIVATE
-        GMP::GMP
-        MPFR::MPFR
+        gmp::gmp
+        mpfr::mpfr
 )
 
 

--- a/platform/src/generics/polynomial_type/CMakeLists.txt
+++ b/platform/src/generics/polynomial_type/CMakeLists.txt
@@ -46,7 +46,7 @@ if (ROUGHPY_BUILD_TESTS)
     target_link_libraries(test_polynomial PRIVATE
             RoughPy::Core
             Boost::headers
-            GMP::GMP
+            gmp::gmp
             GTest::gtest
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 
 [project]
 name = "RoughPy"
-author = "The RoughPy Authors"
-author_email = "info@datasig.ac.uk"
+authors = [
+    { name="The RoughPy Authors", email = "info@datasig.ac.uk" }
+    ]
 #license = {file = "LICENSE.txt" }
 license = { text = "BSD-3-Clause" }
 keywords = [
@@ -12,8 +13,8 @@ keywords = [
     "signatures"
 ]
 
-include_package_data = true
-packages = ["roughpy"]
+#include_package_data = true
+#packages = ["roughpy"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
@@ -46,7 +47,6 @@ dynamic = ["version", "readme"]
 requires = [
     "scikit-build-core[pyproject]",
     "pybind11<3.0.0",
-    "ninja; platform_system!='Windows'",
     "numpy>=2.0.0",
     #    "mkl-devel; platform_machine in 'x86_64 x86 AMD64'",
     #    "mkl-static; platform_machine in 'x86_64 x86 AMD64'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dynamic = ["version", "readme"]
 [build-system]
 requires = [
     "scikit-build-core[pyproject]",
-    "pybind11",
+    "pybind11<3.0.0",
     "ninja; platform_system!='Windows'",
     "numpy>=2.0.0",
     #    "mkl-devel; platform_machine in 'x86_64 x86 AMD64'",

--- a/scalars/CMakeLists.txt
+++ b/scalars/CMakeLists.txt
@@ -86,7 +86,8 @@ target_link_libraries(RoughPy_Scalars PUBLIC
         RoughPy::Platform
         PRIVATE
         RoughPy::PrecompiledHeaders
-        PCGRandom::pcg_random
+#        PCGRandom::pcg_random
+        pcg-cpp::pcg-cpp
 )
 
 set_target_properties(RoughPy_Scalars PROPERTIES ROUGHPY_COMPONENT Scalars)
@@ -108,7 +109,7 @@ if (ROUGHPY_BUILD_TESTS)
             src/test_scalar_type.cpp
     )
 
-    target_link_libraries(test_scalars PRIVATE RoughPy::Scalars GTest::gtest)
+    target_link_libraries(test_scalars PRIVATE RoughPy::Scalars pcg-cpp::pcg-cpp GTest::gtest)
 
 
     setup_roughpy_cpp_tests(test_scalars)


### PR DESCRIPTION
Vcpkg is a rather frustrating package manager. It's slow and often has problems with its ports not being updated frequently enough. Unfortunately, we've built the ecosystem around using vcpkg, which has started to cause some problems. This PR adds support for using conan as a package manager instead. This shouldn't break the existing vcpkg support, but it will make using the build system somewhat easier.