### PR TITLE
Fix various compatibility and stability issues in Python functions

### DIFF
--- a/roughpy/compute/_src/dense_basic.cpp
+++ b/roughpy/compute/_src/dense_basic.cpp
@@ -99,12 +99,13 @@ PyObject* py_dense_ft_fma(PyObject* self [[maybe_unused]], PyObject* args, PyObj
 
     if (!PyArg_ParseTupleAndKeywords(args,
                                      kwargs,
-                                     "OOOO|ii",
+                                     "OOOO|iii",
                                      kwords,
                                      &out_obj,
                                      &lhs_obj,
                                      &rhs_obj,
                                      &basis_obj,
+                                     &config.out_max_degree,
                                      &config.lhs_max_degree,
                                      &config.rhs_max_degree
                                      )) {

--- a/roughpy/compute/_src/dense_basic.cpp
+++ b/roughpy/compute/_src/dense_basic.cpp
@@ -183,7 +183,7 @@ struct DenseFTInplaceMul
 PyObject* py_dense_ft_inplace_mul(PyObject* self, PyObject* args, PyObject* kwargs)
 {
     static constexpr char const* const kwords[] = {
-        "out", "lhs", "rhs", "basis", "out_depth", "rhs_depth",
+        "lhs", "rhs", "basis", "out_depth", "rhs_depth",
         nullptr
     };
 

--- a/roughpy/compute/_src/lie_basis.c
+++ b/roughpy/compute/_src/lie_basis.c
@@ -129,6 +129,8 @@ static int construct_lie_basis(PyLieBasis* self)
     memcpy(dst_ptr, data_ptr, size * sizeof(npy_intp) * 2);
 
     Py_SETREF(self->data, resized_data);
+    // resized_data is now a borrowed reference, clear it to avoid misuse
+    resized_data = NULL;
     // Py_XDECREF(self->data);
     // self->data = tmp;
     // tmp = NULL;
@@ -139,6 +141,13 @@ static int construct_lie_basis(PyLieBasis* self)
     // self->degree_begin = degree_begin;
     // degree_begin = NULL;
     Py_SETREF(self->degree_begin, degree_begin);
+    /*
+     * At this point we have transferred owneship of degree_begin to the struct
+     * where it rightfully belongs, so the degree_begin variable now does not
+     * hold a strong reference. To avoid a use-after-free bug caused by the
+     * Py_XDECREF below, we clear this reference.
+     */
+    degree_begin = NULL;
 
     ret = 0;
 

--- a/roughpy/compute/_src/py_binary_array_fn.hpp
+++ b/roughpy/compute/_src/py_binary_array_fn.hpp
@@ -30,6 +30,10 @@ PyObject* outer_loop_binary(
     }
 
     CacheArray<npy_intp, Fn::CoreDims + 1> index(ndims);
+    for (npy_intp i = 0; i < ndims; ++i) {
+        index[i] = 0;
+    }
+
     auto advance = [&index, &ndims, &shape] {
         for (npy_intp pos = ndims - 1 - Fn::CoreDims; pos >= 0; --pos) {
             index[pos] += 1;

--- a/roughpy/compute/_src/py_binary_array_fn.hpp
+++ b/roughpy/compute/_src/py_binary_array_fn.hpp
@@ -94,7 +94,7 @@ PyObject* binary_function_outer(PyObject* out_obj,
         return nullptr;
     }
 
-    if (PyArray_Check(arg_obj)) {
+    if (!PyArray_Check(arg_obj)) {
         PyErr_SetString(PyExc_TypeError, "arg must be a numpy array");
         return nullptr;
     }

--- a/roughpy/compute/_src/py_ternary_array_fn.hpp
+++ b/roughpy/compute/_src/py_ternary_array_fn.hpp
@@ -89,7 +89,7 @@ PyObject* ternary_function_outer(PyObject* out_obj [[maybe_unused]],
         return nullptr;
     }
 
-    if (PyArray_Check(lhs_obj)) {
+    if (!PyArray_Check(lhs_obj)) {
         PyErr_SetString(PyExc_TypeError, "lhs must be a numpy array");
         return nullptr;
     }
@@ -110,7 +110,7 @@ PyObject* ternary_function_outer(PyObject* out_obj [[maybe_unused]],
         return nullptr;
     }
 
-    if (PyArray_Check(rhs_obj)) {
+    if (!PyArray_Check(rhs_obj)) {
         PyErr_SetString(PyExc_TypeError, "rhs must be a numpy array");
         return nullptr;
     }

--- a/roughpy/compute/_src/py_ternary_array_fn.hpp
+++ b/roughpy/compute/_src/py_ternary_array_fn.hpp
@@ -30,6 +30,9 @@ PyObject* outer_loop_ternary(
     }
 
     CacheArray<npy_intp, Fn::CoreDims + 1> index(ndims);
+    for (npy_intp i = 0; i < ndims; ++i) {
+        index[i] = 0;
+    }
 
     auto advance = [&index, &ndims, &shape] {
         for (npy_intp pos = ndims - 1 - Fn::CoreDims; pos >= 0; --pos) {

--- a/roughpy/compute/_src/tensor_basis.c
+++ b/roughpy/compute/_src/tensor_basis.c
@@ -127,7 +127,11 @@ static PyObject* tensor_basis_truncate(PyObject* self,
 
     new_obj->width = self_->width;
     new_obj->depth = new_depth;
-    new_obj->degree_begin = Py_NewRef(self_->degree_begin);
+
+    // We want to do this, but the Py_NewRef was added in 3.10
+    // new_obj->degree_begin = Py_NewRef(self_->degree_begin);
+    Py_INCREF(self_->degree_begin);
+    new_obj->degree_begin = self_->degree_begin;
 
     return (PyObject*) new_obj;
 }

--- a/roughpy/compute/_src/tensor_basis.c
+++ b/roughpy/compute/_src/tensor_basis.c
@@ -71,17 +71,20 @@ static int tensor_basis_init(PyTensorBasis* self,
         Py_XSETREF(self->degree_begin, Py_NewRef(degree_begin));
     } else {
         npy_intp const shape[1] = {self->depth + 2};
-        Py_XSETREF(self->degree_begin, PyArray_SimpleNew(1, shape, NPY_INTP));
+        PyObject* arr = PyArray_SimpleNew(1, shape, NPY_INTP);
+        // Py_XSETREF(self->degree_begin, PyArray_SimpleNew(1, shape, NPY_INTP));
 
-        if (!self->degree_begin) { return -1; }
+        if (!arr) { return -1; }
 
         npy_intp* data = (npy_intp*) PyArray_DATA(
-            (PyArrayObject*) self->degree_begin);
+            (PyArrayObject*) arr);
 
         data[0] = 0;
         for (npy_intp i = 1; i < self->depth + 2; ++i) {
             data[i] = 1 + data[i - 1] * self->width;
         }
+
+        Py_XSETREF(self->degree_begin, arr);
     }
 
     return 0;


### PR DESCRIPTION
This pull request addresses several bugs in the initial commit of the free-standing-compute components.

- Updated to use `Py_INCREF` for compatibility with Python < 3.10.
- Fixed reference assignment and parameter initialization in `TensorBasis` and `LieBasis` to ensure proper memory handling.
- Resolved keyword argument mismatch in inplace multiplication.
- Corrected type checks in `py_binary_array_fn` and `py_ternary_array_fn` to validate NumPy array inputs properly.
- Guaranteed initialization of `index` arrays in `py_binary_array_fn` and `py_ternary_array_fn` to ensure consistent behavior.
- Fixed missing argument parsing in `ft_fma`.
