### PR TITLE
rpy-compute: 

### DIFF
--- a/platform/src/generics/mocking/CMakeLists.txt
+++ b/platform/src/generics/mocking/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(RoughPy_Platform_Mocking
 )
 
 target_link_libraries(RoughPy_Platform_Mocking
-    PRIVATE
+    PUBLIC
         RoughPy::Platform
         GTest::gmock
 )

--- a/platform/src/generics/test_array.cpp
+++ b/platform/src/generics/test_array.cpp
@@ -29,7 +29,7 @@ TEST(TestArray, TestDestructorAllocDealloc)
     auto type_ptr = Rc<MockType>{new MockType};
     {
         // Mock double size and confirm data assigned on construction
-        EXPECT_CALL(*type_ptr, object_size()).Times(1).WillOnce([]{
+        EXPECT_CALL(*type_ptr, object_size()).Times(1).WillRepeatedly([]{
             // Arbitrary type size for valid example
             return sizeof(double);
         });

--- a/roughpy/compute/__init__.py
+++ b/roughpy/compute/__init__.py
@@ -215,3 +215,28 @@ def ft_exp(x: FreeTensor) -> FreeTensor:
         result[0] += 1
 
     return FreeTensor(result, x.basis)
+
+
+@_api("1.0.0")
+def ft_adjoint_left_mul(op: FreeTensor, arg: ShuffleTensor) -> ShuffleTensor:
+    """
+    Compute the adjoint of a free tensor left-multiplication.
+
+    The operator L_A: T -> T defined by L_A(X) = A * X (where * denotes
+    free tensor multiplication) is a well-defined linear operator on the
+    free tensor algebra. The adjoint of this function L_A* is a linear
+    operator on the shuffle algebra. This operator aggregates the
+    coefficients of S according to their prefix in A.
+
+    :param op: The operand of the left multiplication L_A
+    :param arg: The shuffle tensor argument on which to apply the adjoint
+    :return: The result of L_A*(S)
+    """
+
+    _check_basis_compat(op.basis, arg.basis)
+
+    result = np.zeros_like(arg.data)
+
+    _internals.dense_ft_adjoint_left_mul(result, op.data, arg.data, op.basis, arg.basis)
+
+    return ShuffleTensor(result, arg.basis)

--- a/roughpy/compute/__init__.py
+++ b/roughpy/compute/__init__.py
@@ -20,11 +20,10 @@ from dataclasses import dataclass
 
 from . import _rpy_compute_internals as _internals
 
-
 __all__ = []
 
-def _api(version: str, *args, **kwargs):
 
+def _api(version: str, *args, **kwargs):
     def deco(func_or_class):
         global __all__
         __all__.append(func_or_class.__name__)
@@ -59,7 +58,6 @@ class TensorBasis(_internals.TensorBasis):
 @_api("1.0.0")
 class LieBasis(_internals.LieBasis):
     pass
-
 
 
 @_api("1.0.0")
@@ -97,7 +95,6 @@ def _check_basis_compat(out_basis: TensorBasis, *other_bases: TensorBasis):
             raise ValueError(f"Incompatible width for basis {i}")
 
 
-
 # Basic functions
 @_api("1.0.0")
 def ft_fma(a: FreeTensor, b: FreeTensor, c: FreeTensor, **kwargs):
@@ -117,6 +114,7 @@ def ft_fma(a: FreeTensor, b: FreeTensor, c: FreeTensor, **kwargs):
     # In the future, we will need to handle alternative prototype tensors here.
 
     _internals.dense_ft_fma(a.data, b.data, c.data, b.basis, c.basis.depth)
+
 
 @_api("1.0.0")
 def ft_mul(a: FreeTensor, b: FreeTensor, **kwargs) -> FreeTensor:
@@ -173,7 +171,6 @@ def antipode(a: FreeTensor, **kwargs) -> FreeTensor:
     return FreeTensor(result, a.basis)
 
 
-
 def st_fma(*args, **kwargs):
     ...
 
@@ -182,15 +179,12 @@ def st_inplace_mul(*args, **kwargs):
     ...
 
 
-
 def lie_to_tensor(*args, **kwargs):
     ...
 
 
 def tensor_to_lie(*args, **kwargs):
     ...
-
-
 
 
 def ft_exp(x: FreeTensor) -> FreeTensor:
@@ -237,6 +231,7 @@ def ft_adjoint_left_mul(op: FreeTensor, arg: ShuffleTensor) -> ShuffleTensor:
 
     result = np.zeros_like(arg.data)
 
-    _internals.dense_ft_adjoint_left_mul(result, op.data, arg.data, op.basis, arg.basis)
+    _internals.dense_ft_adjoint_left_mul(
+        result, op.data, arg.data, op.basis, arg.basis.depth, op.basis.depth, arg.basis.depth)
 
     return ShuffleTensor(result, arg.basis)

--- a/roughpy/compute/_src/dense_basic.cpp
+++ b/roughpy/compute/_src/dense_basic.cpp
@@ -276,22 +276,25 @@ struct DenseFTAdjLMul
     template <typename OutIter, typename OpIter, typename ArgIter>
     void operator()(OutIter out_iter, OpIter op_iter, ArgIter arg_iter) const
     {
+        auto const* basis = static_cast<TensorBasis const*>(config_->
+            basis_data);
+
         DenseTensorView<OutIter> out(
             out_iter,
-            *config_->basis_data,
+            *basis,
             config_->out_min_degree,
             config_->out_max_degree
         );
 
         DenseTensorView<OpIter> op(
             op_iter,
-            *config_->basis_data,
+            *basis,
             config_->lhs_min_degree,
             config_->lhs_max_degree);
 
         DenseTensorView<ArgIter> arg(
             arg_iter,
-            *config_->basis_data,
+            *basis,
             config_->rhs_min_degree,
             config_->rhs_max_degree);
 

--- a/roughpy/compute/_src/dense_basic.cpp
+++ b/roughpy/compute/_src/dense_basic.cpp
@@ -359,7 +359,7 @@ PyObject* py_dense_ft_adj_lmul(PyObject* self [[maybe_unused]],
                                     &arg_obj,
                                     &basis_obj,
                                     &config.out_max_degree,
-                                    &config.lhs_min_degree,
+                                    &config.lhs_max_degree,
                                     &config.rhs_max_degree)) {
         return nullptr;
     }

--- a/roughpy/compute/_src/dense_basic.cpp
+++ b/roughpy/compute/_src/dense_basic.cpp
@@ -5,6 +5,7 @@
 #include <roughpy_compute/dense/views.hpp>
 
 #include <roughpy_compute/dense/basic/free_tensor_antipode.hpp>
+#include <roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp>
 #include <roughpy_compute/dense/basic/free_tensor_fma.hpp>
 #include <roughpy_compute/dense/basic/free_tensor_inplace_mul.hpp>
 #include <roughpy_compute/dense/basic/shuffle_tensor_product.hpp>

--- a/roughpy/compute/_src/dense_basic.cpp
+++ b/roughpy/compute/_src/dense_basic.cpp
@@ -348,14 +348,16 @@ PyObject* py_dense_ft_adj_lmul(PyObject* self [[maybe_unused]],
     PyObject *out_obj, *op_obj, *arg_obj;
 
     CallConfig config;
+    PyObject* basis_obj = nullptr;
 
-    if (PyArg_ParseTupleAndKeywords(args,
+    if (!PyArg_ParseTupleAndKeywords(args,
                                     kwargs,
                                     "OOOO|iii",
                                     kwords,
                                     &out_obj,
                                     &op_obj,
                                     &arg_obj,
+                                    &basis_obj,
                                     &config.out_max_degree,
                                     &config.lhs_min_degree,
                                     &config.rhs_max_degree)) {
@@ -363,10 +365,11 @@ PyObject* py_dense_ft_adj_lmul(PyObject* self [[maybe_unused]],
     }
 
     TensorBasis basis;
-    auto handle = to_basis(out_obj, basis);
+    auto handle = to_basis(basis_obj, basis);
     if (!handle) {
         return nullptr;
     }
+    config.basis_data = &basis;
 
     if (!update_algebra_params(config)) {
         return nullptr;

--- a/roughpy/compute/_src/dense_basic.cpp
+++ b/roughpy/compute/_src/dense_basic.cpp
@@ -283,6 +283,8 @@ PyObject *py_dense_antipode(PyObject * self [[maybe_unused]], PyObject *args, Py
         // error already set
         return nullptr;
     }
+
+    return binary_function_outer<DenseAntipode>(out_obj, arg_obj, config);
 }
 
 /*******************************************************************************
@@ -379,14 +381,17 @@ PyObject* py_dense_st_fma(PyObject*, PyObject*, PyObject*)
     Py_RETURN_NOTIMPLEMENTED;
 }
 
-PyObject *py_dense_st_inplace_mul(PyObject *, PyObject *, PyObject *) {
+PyObject* py_dense_st_inplace_mul(PyObject*, PyObject*, PyObject*)
+{
     Py_RETURN_NOTIMPLEMENTED;
 }
 
-PyObject *py_dense_lie_to_tensor(PyObject *, PyObject *, PyObject *) {
+PyObject* py_dense_lie_to_tensor(PyObject*, PyObject*, PyObject*)
+{
     Py_RETURN_NOTIMPLEMENTED;
 }
 
-PyObject *py_dense_tensor_to_lie(PyObject *, PyObject *, PyObject *) {
+PyObject* py_dense_tensor_to_lie(PyObject*, PyObject*, PyObject*)
+{
     Py_RETURN_NOTIMPLEMENTED;
 }

--- a/roughpy/compute/_src/dense_basic.h
+++ b/roughpy/compute/_src/dense_basic.h
@@ -17,6 +17,10 @@ PyObject* py_dense_ft_fma(PyObject*, PyObject*, PyObject*);
 RPY_NO_EXPORT
 PyObject* py_dense_ft_inplace_mul(PyObject*, PyObject*, PyObject*);
 
+
+RPY_NO_EXPORT
+PyObject* py_dense_ft_adj_lmul(PyObject*, PyObject*, PyObject*);
+
 RPY_NO_EXPORT
 PyObject* py_dense_st_fma(PyObject* , PyObject* , PyObject* );
 RPY_NO_EXPORT

--- a/roughpy/compute/_src/roughpy_compute_module.c
+++ b/roughpy/compute/_src/roughpy_compute_module.c
@@ -7,7 +7,8 @@
 #include "dense_basic.h"
 
 
-static int init_module(PyObject *module) {
+static int init_module(PyObject* module)
+{
     if (init_lie_basis(module) < 0) { return -1; }
     if (init_tensor_basis(module) < 0) { return -1; }
 
@@ -16,48 +17,54 @@ static int init_module(PyObject *module) {
 
 
 static PyMethodDef roughpy_compute_methods[] = {
-    {
-        "dense_ft_fma", (PyCFunction) py_dense_ft_fma,
-        METH_VARARGS | METH_KEYWORDS,
-        "dense free tensor fused multiply-add."
-    },
-    {
-        "dense_ft_inplace_mul", (PyCFunction) py_dense_ft_inplace_mul,
-        METH_VARARGS | METH_KEYWORDS,
-        "dense free tensor inplace multiply."
-    },
-    {
-        "dense_ft_antipode", (PyCFunction) py_dense_antipode,
-        METH_VARARGS | METH_KEYWORDS,
-        "dense free tensor antipode"
-    },
-    {NULL, NULL, 0, NULL}
+        {
+                "dense_ft_fma", (PyCFunction) py_dense_ft_fma,
+                METH_VARARGS | METH_KEYWORDS,
+                "dense free tensor fused multiply-add."
+        },
+        {
+                "dense_ft_inplace_mul", (PyCFunction) py_dense_ft_inplace_mul,
+                METH_VARARGS | METH_KEYWORDS,
+                "dense free tensor inplace multiply."
+        },
+        {
+                "dense_ft_antipode", (PyCFunction) py_dense_antipode,
+                METH_VARARGS | METH_KEYWORDS,
+                "dense free tensor antipode"
+        },
+        {
+                "dense_ft_adjoint_left_mul", (PyCFunction) py_dense_ft_adj_lmul,
+                METH_VARARGS | METH_KEYWORDS,
+                "dense free tensor adjoint left multiply"
+        },
+        {NULL, NULL, 0, NULL}
 };
 
 
 static PyModuleDef_Slot roughpy_compute_slots[] = {
-    {Py_mod_exec, init_module},
+        {Py_mod_exec, init_module},
 #if Py_VERSION_HEX >= PYVER_HEX(3, 12)
-    {
-        Py_mod_multipe_interpreters,
-        Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED
-    },
+        {
+                Py_mod_multipe_interpreters,
+                Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED
+        },
 #endif
-    {0, NULL}
+        {0, NULL}
 };
 
 
 static PyModuleDef rpy_compute_internals_module = {
-    .m_base = PyModuleDef_HEAD_INIT,
-    .m_name = "_rpy_compute_internals",
-    .m_size = 0,
-    .m_slots = roughpy_compute_slots,
-    .m_methods = roughpy_compute_methods
+        .m_base = PyModuleDef_HEAD_INIT,
+        .m_name = "_rpy_compute_internals",
+        .m_size = 0,
+        .m_slots = roughpy_compute_slots,
+        .m_methods = roughpy_compute_methods
 };
 
 
 PyMODINIT_FUNC
-PyInit__rpy_compute_internals(void) {
+PyInit__rpy_compute_internals(void)
+{
     import_array();
 
     return PyModuleDef_Init(&rpy_compute_internals_module);

--- a/roughpy_compute/CMakeLists.txt
+++ b/roughpy_compute/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(roughpy_compute INTERFACE
         common/cache_array.hpp
         common/operations.hpp
         dense/views.hpp
+        dense/basic/free_tensor_adjoint_left_mul.hpp
         dense/basic/free_tensor_antipode.hpp
         dense/basic/free_tensor_fma.hpp
         dense/basic/free_tensor_inplace_mul.hpp

--- a/roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp
+++ b/roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp
@@ -16,8 +16,16 @@ void ft_adj_lmul(DenseTensorView<OutIter> out,
     using Degree = typename DenseTensorView<OutIter>::Degree;
     using Index = typename DenseTensorView<OutIter>::Index;
 
+    auto out_max_degree = out.max_degree();
+    auto out_min_degree = out.min_degree();
 
-    for (Degree op_degree=0; op_degree <= op.max_degree(); ++op_degree) {
+    for (Degree out_degree=out_max_degree; out_degree >= out_min_degree; --out_degree) {
+        auto op_min_degree = std::max(Degree{0}, out_degree - op.max_degree());
+        auto op_max_degree = std::min(out_degree, op.max_degree() - arg.min_degree());
+
+
+        for ()
+
 
     }
 

--- a/roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp
+++ b/roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp
@@ -1,0 +1,30 @@
+#ifndef ROUGHPY_COMPUTE_DENSE_BASIC_FREE_TENSOR_ADJOINT_LEFT_MUL_HPP
+#define ROUGHPY_COMPUTE_DENSE_BASIC_FREE_TENSOR_ADJOINT_LEFT_MUL_HPP
+
+
+#include "roughpy_compute/dense/views.hpp"
+
+
+namespace rpy::compute::basic {
+inline namespace v1 {
+
+template <typename OutIter, typename OpIter, typename ArgIter>
+void ft_adj_lmul(DenseTensorView<OutIter> out,
+                 DenseTensorView<OpIter> op,
+                 DenseTensorView<ArgIter> arg)
+{
+    using Degree = typename DenseTensorView<OutIter>::Degree;
+    using Index = typename DenseTensorView<OutIter>::Index;
+
+
+    for (Degree op_degree=0; op_degree <= op.max_degree(); ++op_degree) {
+
+    }
+
+
+}
+}// version namespace
+}// namespace rpy::compute::basic
+
+
+#endif //ROUGHPY_COMPUTE_DENSE_BASIC_FREE_TENSOR_ADJOINT_LEFT_MUL_HPP

--- a/roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp
+++ b/roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp
@@ -50,6 +50,7 @@ void ft_adj_lmul(DenseTensorView<OutIter> out,
 
         auto arg_frag = arg.at_level(arg_degree);
 
+
         for (Degree out_degree = out_max_degree;
             out_degree >= out_min_degree;
             --out_degree)
@@ -68,12 +69,8 @@ void ft_adj_lmul(DenseTensorView<OutIter> out,
                 for (Index i=0; i < out_frag.size(); ++i) {
                     out_frag[i] += op_val * arg_frag[i + op_offset];
                 }
-
-
             }
             // ReSharper restore CppDFANullDereference
-
-
 
         }
     }

--- a/roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp
+++ b/roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp
@@ -39,8 +39,8 @@ void ft_adj_lmul(DenseTensorView<OutIter> out,
      * as those operations do.
      */
 
-    const auto arg_max_degree = std::min(arg.max_degree - op.min_degree(), out.max_degree());
-    auto arg_min_degree = std::max(arg.min_degree - op.max_degree(), out.min_degree());
+    const auto arg_max_degree = std::min(arg.max_degree() - op.min_degree(), out.max_degree());
+    auto arg_min_degree = std::max(arg.min_degree() - op.max_degree(), out.min_degree());
 
     for (Degree arg_degree = arg_max_degree; arg_degree >= arg_min_degree; --
          arg_degree)
@@ -48,7 +48,7 @@ void ft_adj_lmul(DenseTensorView<OutIter> out,
         auto out_min_degree = std::max(arg_degree - op.max_degree(), out.min_degree());
         auto out_max_degree = std::min(arg_degree - op.min_degree(), out.max_degree());
 
-        auto arg_frag = out.at_level(arg_degree);
+        auto arg_frag = arg.at_level(arg_degree);
 
         for (Degree out_degree = out_max_degree;
             out_degree >= out_min_degree;
@@ -57,7 +57,7 @@ void ft_adj_lmul(DenseTensorView<OutIter> out,
             const auto op_degree = arg_degree - out_degree ;
 
             auto op_frag = op.at_level(op_degree);
-            auto out_frag = arg.at_level(out_degree);
+            auto out_frag = out.at_level(out_degree);
 
 
             // ReSharper disable CppDFANullDereference

--- a/roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp
+++ b/roughpy_compute/dense/basic/free_tensor_adjoint_left_mul.hpp
@@ -7,32 +7,54 @@
 
 namespace rpy::compute::basic {
 inline namespace v1 {
-
-template <typename OutIter, typename OpIter, typename ArgIter>
+template<typename OutIter, typename OpIter, typename ArgIter>
 void ft_adj_lmul(DenseTensorView<OutIter> out,
                  DenseTensorView<OpIter> op,
-                 DenseTensorView<ArgIter> arg)
-{
+                 DenseTensorView<ArgIter> arg) {
     using Degree = typename DenseTensorView<OutIter>::Degree;
     using Index = typename DenseTensorView<OutIter>::Index;
 
     auto out_max_degree = out.max_degree();
     auto out_min_degree = out.min_degree();
 
-    for (Degree out_degree=out_max_degree; out_degree >= out_min_degree; --out_degree) {
+    for (Degree out_degree = out_max_degree; out_degree >= out_min_degree; --
+         out_degree)
+    {
         auto op_min_degree = std::max(Degree{0}, out_degree - op.max_degree());
-        auto op_max_degree = std::min(out_degree, op.max_degree() - arg.min_degree());
+        auto op_max_degree = std::min(out_degree,
+                                      op.max_degree() - arg.min_degree());
+
+        auto out_frag = out.at_level(out_degree);
+
+        for (Degree op_degree = op_max_degree; op_degree >= op_min_degree; --
+             op_degree)
+        {
+            auto arg_degree = out_degree + op_degree;
+
+            auto op_frag = op.at_level(op_degree);
+            auto arg_frag = arg.at_level(arg_degree);
 
 
-        for ()
+            // ReSharper disable CppDFANullDereference
+            for (Index op_idx=0; op_idx < op_frag.size(); ++op_idx) {
+                const auto op_offset = op_idx * out_frag.size();
+                const auto& op_val = op_frag[op_idx];
+
+                for (Index i=0; i < out_frag.size(); ++i) {
+                    out_frag[i] += op_val * arg_frag[i + op_offset];
+                }
 
 
+            }
+            // ReSharper restore CppDFANullDereference
+
+
+
+        }
     }
-
-
 }
-}// version namespace
-}// namespace rpy::compute::basic
+} // version namespace
+} // namespace rpy::compute::basic
 
 
 #endif //ROUGHPY_COMPUTE_DENSE_BASIC_FREE_TENSOR_ADJOINT_LEFT_MUL_HPP

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST CACHE INTERNAL "")
 add_library(RoughPy_test_harness STATIC src/main.cpp)
 
 
-target_link_libraries(RoughPy_test_harness PUBLIC GTest::gtest)
+target_link_libraries(RoughPy_test_harness PUBLIC GTest::gtest GTest::gmock)
 
 
 

--- a/testing/src/main.cpp
+++ b/testing/src/main.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <cstdio>
 
@@ -45,7 +46,9 @@ int main(int argc, char** argv)
 
     // make sure the output format is exactly as for the gtest_main function
     printf("Running main() from file %s\n", __FILE__);
-    testing::InitGoogleTest(&argc, argv);
+    // testing::InitGoogleTest(&argc, argv);
+    testing::InitGoogleMock(&argc, argv);
+
     const auto result = RUN_ALL_TESTS();
 
 #if defined(_WIN32) && defined(_DEBUG) && !defined(RPY_NO_DEBUG_MODIFICATION)

--- a/tests/compute/test_adjoint_left_ft_mul.py
+++ b/tests/compute/test_adjoint_left_ft_mul.py
@@ -21,7 +21,7 @@ def test_adjoint_left_ft_mul_identity():
 
     R = rpc.ft_adjoint_left_mul(A, S)
 
-    assert_array_equal(A.data, R.data)
+    assert_array_equal(R.data, S.data)
 
 
 def test_adjoint_left_ft_mul_letter():

--- a/tests/compute/test_adjoint_left_ft_mul.py
+++ b/tests/compute/test_adjoint_left_ft_mul.py
@@ -1,0 +1,42 @@
+
+import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_array_equal
+import pytest
+
+from roughpy import compute as rpc
+
+
+
+
+def test_adjoint_left_ft_mul_identity():
+
+    basis = rpc.TensorBasis(2, 2)
+
+    A_data = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+
+    A = rpc.FreeTensor(A_data, basis)
+
+    rng = np.random.default_rng()
+    S = rpc.ShuffleTensor(rng.uniform(-1, 1, size=basis.size()), basis)
+
+    R = rpc.ft_adjoint_left_mul(A, S)
+
+    assert_array_equal(A.data, R.data)
+
+
+def test_adjoint_left_ft_mul_letter():
+    basis = rpc.TensorBasis(2, 2)
+
+    A_data = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+
+    A = rpc.FreeTensor(A_data, basis)
+
+    rng = np.random.default_rng()
+
+    S = rpc.ShuffleTensor(rng.uniform(-1, 1, size=basis.size()), basis)
+
+    R = rpc.ft_adjoint_left_mul(A, S)
+
+    expected_data = np.array([S.data[1], S.data[3], S.data[4], 0.0, 0.0, 0.0, 0.0])
+
+    assert_array_equal(R.data, expected_data)


### PR DESCRIPTION
This PR adds the adjoint of left free-tensor multiplication to the roughpy.compute module.