### PR TITLE
fix: check all Slide strides are zero (#257)

### DIFF
--- a/roughpy/src/args/strided_copy.h
+++ b/roughpy/src/args/strided_copy.h
@@ -85,6 +85,12 @@ inline bool is_C_contiguous(
 ) noexcept
 {
     if (strides.empty()) { return true; }
+
+    const size_t strides_sum = std::accumulate(strides.begin(), strides.end(), 0);
+    if (strides_sum == 0) {
+        return true;
+    }
+
     T compressed_size = (itemsize) ? *itemsize : 1;
     for (auto i = strides.size(); i > 0;) {
         if (strides[--i] != compressed_size) { return false; }


### PR DESCRIPTION
- Additional check added for Slice being empty by counting overall strides. Required because before numpy 2.4.0, the stides.empty check could bail out early checking just strides.p_data being nullptr. From 2.4.0 the internal representation has changed to be an array of zerors.
- This caused test_path_creation_odd_data tests to fail for 2D and 3D cases, for example for 2D array where shape.m_size is 2, now p_data is [0, 0] rather than nullptr before. This resulted in is_C_contiguous returning false rather than true since 2.4.0, changing the code path to attempt to stride_copy an empty array.