### PR TITLE
Build roughpy-jax wheel from nested pyproject.toml

### DIFF
--- a/roughpy_jax/CHANGELOG
+++ b/roughpy_jax/CHANGELOG
@@ -1,0 +1,2 @@
+Unreleased
+  - roughpy_jax

--- a/roughpy_jax/CMakeLists.txt
+++ b/roughpy_jax/CMakeLists.txt
@@ -1,3 +1,20 @@
+if(ROUGHPY_TEST_BUILD)
+    # FIXME experimental wheel building work see test_build for notes
+
+    # If running python build, this is the CMakeLists.txt root, so need cmake version
+    cmake_minimum_required(VERSION 3.28)
+
+    if (NOT EXISTS "_deps/find_python.cmake")
+        message(FATAL_ERROR "Cannot find find_python.cmake. Please run via test_build.sh")
+    endif()
+
+    if (NOT EXISTS "_deps/roughpy_compute")
+        message(FATAL_ERROR "Cannot find roughpy_compute. Please run via test_build.sh")
+    endif()
+
+    include(_deps/find_python.cmake)
+endif()
+
 project(RoughPy_JaxModule LANGUAGES CXX)
 
 # Optionally enable CUDA build
@@ -27,6 +44,9 @@ execute_process(
             "-c" "from jax import ffi; print(ffi.include_dir())"
     OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE XLA_DIR
 )
+if ("${XLA_DIR}" STREQUAL "")
+    message(FATAL_ERROR "Could not find XLA include directory")
+endif()
 message(STATUS "XLA include directory: ${XLA_DIR}")
 
 python_add_library(RoughPy_JaxModule MODULE
@@ -61,6 +81,13 @@ target_include_directories(RoughPy_JaxModule PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/src
     ${CMAKE_CURRENT_LIST_DIR}/..
 )
+
+if (ROUGHPY_TEST_BUILD)
+    # FIXME experimental work as above with _deps
+    target_include_directories(RoughPy_JaxModule PRIVATE
+        _deps
+    )
+endif ()
 
 # Use same naming convention as rpy_compute (except without cpython versioning)
 set_target_properties(RoughPy_JaxModule PROPERTIES PREFIX "")

--- a/roughpy_jax/README.md
+++ b/roughpy_jax/README.md
@@ -1,0 +1,3 @@
+# roughpy-jax
+
+roughpy-jax wraps RoughPy in the JAX framework for working with streaming data as rough paths, and working with algebraic objects such as free tensors, shuffle tensors, and elements of the free Lie algebra.

--- a/roughpy_jax/pyproject.toml
+++ b/roughpy_jax/pyproject.toml
@@ -1,0 +1,73 @@
+[build-system]
+build-backend = "scikit_build_core.build"
+requires = [
+    "scikit-build-core>=0.11",
+    "setuptools>=61",
+    "wheel",
+    "jax"
+]
+
+[project]
+name = "roughpy-jax"
+version = "0.0.1"
+dynamic = ["readme"]
+description = ""
+authors = [
+    { name = "The RoughPy Authors", email = "info@datasig.ac.uk" }
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: C++",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS"
+]
+dependencies = [
+    "jax",
+]
+
+[tool.scikit-build]
+cmake.args = [
+    "-DROUGHPY_TEST_BUILD=ON",
+    "-DROUGHPY_BUILD_PYLIB=ON"
+]
+build.verbose = true
+cmake.build-type = "Release"
+experimental=true
+metadata.readme.provider = "scikit_build_core.metadata.fancy_pypi_readme"
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+text = "# Changelog\n\n"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "CHANGELOG"
+
+[tool.cibuildwheel]
+skip = [
+    "*win32",
+    "*-musl*",
+    "pp*",
+    "*linux_i686",
+    "*universal2",
+    "cp3{6,7,8}-*",
+    "cp3{9}-macos*"
+]
+build-verbosity=1

--- a/roughpy_jax/test_build.sh
+++ b/roughpy_jax/test_build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# FIXME experimental test build of roughpy-jax wheel
+#
+# Python build cannot access files in the parent folder so cmake/ and roughpy_compute/
+# directories are copied in here into _deps folder used in CMakeLists.txt.
+#
+# Possible workarounds:
+# - Move roughpy_jax into a separate repo and bring in RoughPy as a submodule or CMake find
+# - Remove roughpy_jax/pyproject.toml and instead build roughpy-jax from root project
+
+echo "Copying python build deps..."
+rm -rf _deps
+mkdir _deps
+cp ../cmake/find_python.cmake _deps
+cp -r ../roughpy_compute _deps
+
+echo "Building wheel..."
+python -m build --wheel
+
+echo "Done!"


### PR DESCRIPTION
## Experimental build of roughpy-jax wheel in subdir

Early check whether building project in subdir may cause future problems.

This is not in CI, just testing build locally for now on a Linux machine. Run `test_build.sh` from `roughpy_jax/`.

## Notes

- Python build cannot access files in the parent folder. This highlights that cmake/find_python.cmake and roughpy_compute/ are needed. `test_build.sh` copies them in before it gets into the python build and cmake ecosystem.
- Note that although this builds locally on Linux, when pip installing and running `import roughpy_jax` in python, it fails with `ImportError: dynamic module does not define module export function (PyInit__rpy_jax_internals)`, suggesting a linkage issue.
- Regard this work as a feasibility study; copying files from parent dir is not idiomatic to python build. Nicer solutions are: 1) move roughpy_jax into a separate repo and bring in RoughPy as a submodule or CMake find package; 2) remove roughpy_jax/pyproject.toml and instead build roughpy-jax from root project.