### PR TITLE
Move stream protocols to `concepts` module and update imports

### DIFF
--- a/roughpy_jax/streams/__init__.py
+++ b/roughpy_jax/streams/__init__.py
@@ -1,0 +1,3 @@
+
+ from .concepts import Stream, ValueStream
+

--- a/roughpy_jax/streams/concepts.py
+++ b/roughpy_jax/streams/concepts.py
@@ -1,13 +1,9 @@
 import typing
 
-from typing import Protocol, TypeVar, Self, Callable
-
-import numpy as np
-import jax
-import jax.numpy as jnp
+from typing import Protocol, TypeVar, Callable
 
 
-from .intervals import Interval
+from roughpy_jax.intervals import Interval
 
 LieT = TypeVar("LieT")
 GroupT = TypeVar("GroupT")
@@ -161,7 +157,7 @@ class ValueStream(Protocol[LieT, GroupT, StreamValueT]):
         """
         ...
 
-    def query(self, interval: Interval) -> Self:
+    def query(self, interval: Interval) -> ValueStream:
         """
         Query the value stream over an interval.
 


### PR DESCRIPTION
To avoid a bunch of merge conflicts and circular imports later on, I've moved the streams to a package instead of a single module. The protocols are now in `streams.concepts` so they can be imported in other stream implementation files without risking circular imports. 