### PR TITLE
Bug in l2t and t2l caching

### DIFF
--- a/roughpy_jax/ops.py
+++ b/roughpy_jax/ops.py
@@ -12,6 +12,40 @@ from jax import Array
 
 from .csc import csc_matvec
 
+# Cache for l2t and t2l sparse matrices keyed by (width, depth, dtype_str).
+#
+# The C++ LieBasis.get_l2t_matrix() and get_t2l_matrix() share the same
+# internal buffer: each call overwrites it and returns a view of the new
+# contents.  Calling get_t2l_matrix() therefore corrupts any subsequent call
+# to get_l2t_matrix() (and vice-versa).
+#
+# We work around this by computing *both* matrices together on first access,
+# copying the numpy arrays immediately after each call so they own their own
+# memory, and storing the copies here.  All subsequent accesses use the cached
+# copies and never call the C++ functions again.
+_lie_sparse_matrix_cache: dict[
+    tuple, tuple[tuple[np.ndarray, np.ndarray, np.ndarray],
+                 tuple[np.ndarray, np.ndarray, np.ndarray]]
+] = {}
+
+
+def _get_lie_sparse_matrices(lie_basis, dtype):
+    """Return cached (l2t_arrays, t2l_arrays) for a given LieBasis and dtype.
+
+    l2t_arrays = (data, indices, indptr) for the Lie-to-tensor sparse matrix.
+    t2l_arrays = (data, indices, indptr) for the tensor-to-Lie sparse matrix.
+    """
+    key = (lie_basis.width, lie_basis.depth, str(dtype))
+    if key not in _lie_sparse_matrix_cache:
+        # Get l2t FIRST and copy immediately before t2l can overwrite the buffer
+        l2t = lie_basis.get_l2t_matrix(dtype)
+        l2t_arrays = (l2t.data.copy(), l2t.indices.copy(), l2t.indptr.copy())
+        # Now get t2l – this may overwrite the C++ buffer, but l2t is already saved
+        t2l = lie_basis.get_t2l_matrix(dtype)
+        t2l_arrays = (t2l.data.copy(), t2l.indices.copy(), t2l.indptr.copy())
+        _lie_sparse_matrix_cache[key] = (l2t_arrays, t2l_arrays)
+    return _lie_sparse_matrix_cache[key]
+
 
 class BasisLike(typing.Protocol, cabc.Hashable):
     width: np.int32
@@ -879,12 +913,14 @@ class DenseLieToTensor(Operation, DenseOperation):
         arg_basis = self.bases[0]
         tensor_basis = self.bases[1]
 
-        l2t = arg_basis.get_l2t_matrix(self.data_dtype)
+        l2t_data, l2t_indices, l2t_indptr = _get_lie_sparse_matrices(
+            arg_basis, self.data_dtype
+        )[0]
 
         return self.StaticArgs(
-            l2t_data=l2t.data,
-            l2t_indices=l2t.indices,
-            l2t_indptr=l2t.indptr,
+            l2t_data=l2t_data,
+            l2t_indices=l2t_indices,
+            l2t_indptr=l2t_indptr,
             l2t_size=np.int32(tensor_basis.size()),
             **kwargs,
         )
@@ -921,12 +957,14 @@ class DenseTensorToLie(Operation, DenseOperation):
     def make_static_args(self, kwargs) -> type[TypedDict]:
         lie_basis = self.bases[1]
 
-        t2l = lie_basis.get_t2l_matrix(self.data_dtype)
+        t2l_data, t2l_indices, t2l_indptr = _get_lie_sparse_matrices(
+            lie_basis, self.data_dtype
+        )[1]
 
         return self.StaticArgs(
-            t2l_data=t2l.data,
-            t2l_indices=t2l.indices,
-            t2l_indptr=t2l.indptr,
+            t2l_data=t2l_data,
+            t2l_indices=t2l_indices,
+            t2l_indptr=t2l_indptr,
             t2l_size=np.int32(lie_basis.size()),
             **kwargs,
         )


### PR DESCRIPTION
Reposting this here for ease of conversation

I ran into a very strange bug with l2t and t2l when writing the cbh test on Thursday, whereby a 1.5x round trip (i.e. l2t -> t2l -> l2t) produces a garbage result - wrote this test to confirm. I couldn't for the life of me figure it out but Claude found a potential fix for this in the ops code where we were potentially re-using a cache (or something) between the two calls to t2l and l2t, which means the latter corrupts any subsequent calls to the former. and vice versa. 

@alexallmont @inakleinbottle it would be good to get some knowing eyes on this. 