### PR TITLE
Basic operations for rpj algebras

### DIFF
--- a/roughpy_jax/algebra.py
+++ b/roughpy_jax/algebra.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import partial
-from typing import TypeVar
+from typing import TypeVar, Callable
 
 import jax
 import jax.numpy as jnp
@@ -10,6 +10,7 @@ from roughpy import compute as rpc
 
 from roughpy_jax.ops import Operation
 
+AlgebraT = TypeVar("AlgebraT")
 FreeTensorT = TypeVar("FreeTensorT")
 ShuffleTensorT = TypeVar("ShuffleTensorT")
 LieT = TypeVar("LieT")
@@ -60,6 +61,35 @@ class LieBasis(rpc.LieBasis):
     pass
 
 
+def _algebra_add(
+    a: AlgebraT, b: AlgebraT, *, impl: Callable[[jax.Array, ...], jax.Array]
+) -> AlgebraT:
+    cls = type(a)
+
+    if not issubclass(type(b), cls):
+        return NotImplemented
+
+    basis = a.basis
+    # TODO: check basis and batching dims etc for better messages or adjusting truncation depth
+
+    result_data = impl(a.data, b.data)
+
+    return cls(result_data, basis)
+
+
+def _algebra_scalar_multiply(a: AlgebraT, s: jax.typing.ArrayLike) -> AlgebraT:
+    cls = type(a)
+    basis = a.basis
+
+    result_data = jnp.dot(a.data, s)
+
+    return cls(result_data, basis)
+
+
+def _algebra___array__(self, dtype=None, copy=None) -> np.ndarray:
+    return self.data.__array__(dtype=dtype, copy=copy)
+
+
 def _tensor_dataclass(cls):
     """
     Combined decorator for roughpy_jax tensor objects
@@ -67,6 +97,26 @@ def _tensor_dataclass(cls):
     Registers dataclass and JAX data class with dynamic data and static basis
     """
     cls = dataclass(cls)
+
+    cls.__array__ = _algebra___array__
+
+    cls.__add__ = partial(_algebra_add, impl=jnp.add)
+    cls.__sub__ = partial(_algebra_add, impl=jnp.subtract)
+
+    def _mul_impl(self, other):
+        if isinstance(other, (jax.Array, np.ndarray, np.generic, float, int)):
+            return _algebra_scalar_multiply(self, other)
+        return NotImplemented
+
+    cls.__mul__ = _mul_impl
+
+    def _rmul_impl(self, other):
+        if isinstance(other, (jax.Array, np.ndarray, np.generic, float, int)):
+            return _algebra_scalar_multiply(self, other)
+        return NotImplemented
+
+    cls.__rmul__ = _rmul_impl
+
     return jax.tree_util.register_dataclass(
         cls, data_fields=["data"], meta_fields=["basis"]
     )


### PR DESCRIPTION
Standard operators for `FreeTensor`, `ShuffleTensor`, and `Lie` types like `__add__`, `__sub__` and scalar multiplication. Also added `__array__` so we can use select numpy functions without copies.

This still needs a lot of work after the fact, but this is to get us moving with the tests framework. I'll add details to #303.