### PR TITLE
Github action for roughpy jax

### DIFF
--- a/.github/workflows/roughpy-jax-tests.yml
+++ b/.github/workflows/roughpy-jax-tests.yml
@@ -1,88 +1,72 @@
-name: roughpy-jax-pytests
+name: roughpy-jax-tests
 
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
-    paths-ignore: &generic-ignore-paths
-      - "examples/**"
-      - "doc/**"
-      - "README.md"
-      - "CHANGELOG"
-      - "tools/*.py"
-      - ".github/workflows/build_wheels.yml"
-      - ".github/dependabot.yml"
-      - ".github/ISSUE_TEMPLATE/**"
-      - "branding/**"
-      - ".gitignore"
-      - "CMakePresets.json"
-      - "THANKS.txt"
-      - "LICENSE.txt"
-      - "VERSION.txt"
-      - "CITATION.cff"
-      - ".gitignore"
-
+    branches:
+      - "220-roughpy-jax"
+    paths: &roughpy_jax_paths
+      - ".github/workflows/roughpy-jax-tests.yml"
+      - "roughpy_jax/**"
   pull_request:
-    branches: [ "main" ]
-    paths-ignore: *generic-ignore-paths
+    branches:
+      - "220-roughpy-jax"
+    paths: *roughpy_jax_paths
+
+concurrency:
+  group: roughpy-jax-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   BUILD_TYPE: RelWithDebInfo
-  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+  CMAKE_GENERATOR: Ninja
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: true
-      matrix:
-        os:
-          - ubuntu-latest
+  tests:
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
-      with:
-        submodules: true
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
 
-    - uses: actions/setup-python@v5
-      with:
-        python-version: 3.13
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
 
-    - name: Setup gha caching for vcpkg
-      uses: actions/github-script@v7
-      with:
-        script: |
+      - name: Setup gha caching for vcpkg
+        uses: actions/github-script@v7
+        with:
+          script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-    - name: Python dependencies
-      shell: bash
-      run: |
-        python -m pip install numpy ninja pytest jax "pybind11<3.0.0"
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install jax ninja numpy pytest "pybind11<3.0.0"
 
-    - name: setup vcpkg
-      shell: bash
-      run: |
-        git clone https://github.com/Microsoft/vcpkg.git tools/vcpkg
+      - name: Checkout vcpkg
+        shell: bash
+        run: git clone --depth=1 https://github.com/Microsoft/vcpkg.git tools/vcpkg
 
-    - name: Configure CMake
-      run: |
-        cmake -B ${{github.workspace}}/build \
-          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-          -DROUGHPY_BUILD_TESTS=ON \
-          -DROUGHPY_JAX=ON
-      env:
-        CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
-        MACOSX_DEPLOYMENT_TARGET: 11.0.0
-        VCPKG_FORCE_SYSTEM_BINARIES: 1
-        CMAKE_GENERATOR: "Ninja"
+      - name: Configure CMake
+        run: |
+          cmake -B "${{ github.workspace }}/build" \
+            -DCMAKE_BUILD_TYPE="${{ env.BUILD_TYPE }}" \
+            -DROUGHPY_BUILD_TESTS=ON \
+            -DROUGHPY_JAX=ON
+        env:
+          CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
+          VCPKG_FORCE_SYSTEM_BINARIES: 1
 
-    - name: Build
-      run: cmake --build ${{ github.workspace }}/build --config ${{env.BUILD_TYPE}}
+      - name: Build
+        run: cmake --build "${{ github.workspace }}/build" --config "${{ env.BUILD_TYPE }}"
 
-    - name: PyTests
-      shell: bash
-      run: pytest -sv roughpy_jax/
-      env:
-        PYTHONPATH: ${{ github.workspace }}
+      - name: Run roughpy_jax tests
+        shell: bash
+        run: pytest -sv roughpy_jax
+        env:
+          PYTHONPATH: ${{ github.workspace }}


### PR DESCRIPTION
I've cleaned up the roughpy-jax github action and changed the root branch so it now runs on PRs into 220-roughpy-jax, which is our defacto root branch for the jax work.