### PR TITLE
Fix bug in ft_adjoint_left_mul_vpj_fwd

### DIFF
--- a/roughpy_jax/algebra.py
+++ b/roughpy_jax/algebra.py
@@ -1216,8 +1216,8 @@ def ft_adjoint_left_mul_adjoint_derivative(
 
 
 def _ft_adjoint_left_mul_vjp_fwd(op: FreeTensorT, arg: ShuffleTensorT):
-    ct_result = ft_adjoint_left_mul_adjoint_derivative(op, arg)
-    return ct_result, (op, arg)
+    result = ft_adjoint_left_mul(op, arg)
+    return result, (op, arg)
 
 
 def _ft_adjoint_left_mul_vjp_bwd(residuals, ct_result):


### PR DESCRIPTION
The implementation of the function formerly, incorrectly, used the adjoint derivative in the fwd call. Fix this to use the primal function.