### PR TITLE
314 fix t2l caching mechanism

### DIFF
--- a/roughpy/compute/_src/lie_basis.c
+++ b/roughpy/compute/_src/lie_basis.c
@@ -1272,7 +1272,7 @@ PyObject* get_t2l_matrix(PyObject* basis, PyObject* dtype_obj)
     if (t2l == NULL) { return NULL; }
 
     Py_INCREF(t2l);
-    PyDict_SetItem(self->l2t, (PyObject*) dtype, t2l);
+    PyDict_SetItem(self->t2l, (PyObject*) dtype, t2l);
 
     return t2l;
 }

--- a/tests/compute/test_l2t_and_t2l.py
+++ b/tests/compute/test_l2t_and_t2l.py
@@ -1,11 +1,8 @@
-
 from roughpy import compute as rpc
 
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-
-
 
 
 def test_l2t_t2l_roundtrip():
@@ -25,7 +22,6 @@ def test_l2t_t2l_roundtrip():
     assert_array_almost_equal(x.data, y.data, decimal=15)
 
 
-
 def test_l2t_scaled_t2l_roundtrip():
     lie_basis = rpc.LieBasis(4, 4)
     tensor_basis = rpc.TensorBasis(lie_basis.width, lie_basis.depth)
@@ -40,7 +36,7 @@ def test_l2t_scaled_t2l_roundtrip():
 
     y = rpc.tensor_to_lie(tensor_x, lie_basis)
 
-    assert_array_almost_equal(0.5*x.data, y.data, decimal=15)
+    assert_array_almost_equal(0.5 * x.data, y.data, decimal=15)
 
 
 def test_l2t_t2l_scaled_roundtrip():
@@ -57,5 +53,23 @@ def test_l2t_t2l_scaled_roundtrip():
 
     y = rpc.tensor_to_lie(tensor_x, lie_basis, scale_factor=0.5)
 
-    assert_array_almost_equal(0.5*x.data, y.data, decimal=15)
+    assert_array_almost_equal(0.5 * x.data, y.data, decimal=15)
 
+
+def test_l2t_t2l_caching_consistency():
+    """
+    Bug reported in #314
+
+    t2l was cached in l2t cache dict
+    """
+
+    lie_basis = rpc.LieBasis(4, 4)
+
+    l2t_1 = lie_basis.get_l2t_matrix(np.dtype("float64"))
+    t2l_1 = lie_basis.get_t2l_matrix(np.dtype("float64"))
+
+    l2t_2 = lie_basis.get_l2t_matrix(np.dtype("float64"))
+    t2l_2 = lie_basis.get_t2l_matrix(np.dtype("float64"))
+
+    assert l2t_1 is l2t_2
+    assert t2l_1 is t2l_2


### PR DESCRIPTION
Fix saving the t2l matrix to the l2t matrix cache after constructing the matrix for the first time. Closes #314.